### PR TITLE
Fix worktree folder naming for agent names with slashes

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -504,8 +504,10 @@ export async function spawnAgent(
       });
 
       // Append agent name to branch name to make it unique
-      worktreeInfo.branchName = `${worktreeInfo.branchName}-${agent.name}`;
-      worktreeInfo.worktreePath = `${worktreeInfo.worktreePath}-${agent.name}`;
+      // Replace forward slashes in agent name with hyphens for filesystem compatibility
+      const sanitizedAgentName = agent.name.replace(/\//g, '-');
+      worktreeInfo.branchName = `${worktreeInfo.branchName}-${sanitizedAgentName}`;
+      worktreeInfo.worktreePath = `${worktreeInfo.worktreePath}-${sanitizedAgentName}`;
 
       // Setup workspace
       const workspaceResult = await setupProjectWorkspace({


### PR DESCRIPTION
Replace forward slashes in agent names (e.g., "claude/opus-4") with hyphens when creating worktree paths to ensure filesystem compatibility.

This changes the folder naming pattern from:
~/cmux/cmux/worktrees/cmux-1754371107566-claude/opus-4

To:
~/cmux/cmux/worktrees/cmux-1754371107566-claude-opus-4

🤖 Generated with [Claude Code](https://claude.ai/code)