### PR TITLE
rearrange the order of models, make opus 4.1 first one on the list in the ui

### DIFF
--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -47,8 +47,8 @@ export interface AgentConfig {
 }
 
 export const AGENT_CONFIGS: AgentConfig[] = [
-  CLAUDE_SONNET_CONFIG,
   CLAUDE_OPUS_4_1_CONFIG,
+  CLAUDE_SONNET_CONFIG,
   CLAUDE_OPUS_4_CONFIG,
   CODEX_O3_CONFIG,
   CODEX_O4_MINI_CONFIG,


### PR DESCRIPTION
## Summary
- Task completed by claude/sonnet-4 agent 🏆
- Both implementations are identical - they move CLAUDE_OPUS_4_1_CONFIG to the top of the AGENT_CONFIGS array. Since both make the same changes with equal correctness and completeness, selecting the first implementation (index 0).

## Details
- Task ID: jx76z9p95a67rraxmw52jn17n57n4mh8
- Agent: claude/sonnet-4
- Completed: 2025-08-06T12:10:33.200Z

---
🤖 Generated with [cmux](https://github.com/lawrencecchen/cmux)