### PR TITLE
rearrange the order of models, make opus 4.1 first one on the list in the ui

### DIFF
--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -47,8 +47,8 @@ export interface AgentConfig {
 }
 
 export const AGENT_CONFIGS: AgentConfig[] = [
-  CLAUDE_SONNET_CONFIG,
   CLAUDE_OPUS_4_1_CONFIG,
+  CLAUDE_SONNET_CONFIG,
   CLAUDE_OPUS_4_CONFIG,
   CODEX_O3_CONFIG,
   CODEX_O4_MINI_CONFIG,


### PR DESCRIPTION
## Summary
- Task completed by claude/sonnet-4 agent 🏆
- Model claude/sonnet-4 made actual changes by reordering CLAUDE_OPUS_4_1_CONFIG to be first in the agent configs list, while claude/opus-4.1 made no changes at all.

## Details
- Task ID: jx7fq1qabf7yngwyzxbbg962ph7n438s
- Agent: claude/sonnet-4
- Completed: 2025-08-06T12:45:31.540Z

---
🤖 Generated with [cmux](https://github.com/lawrencecchen/cmux)