### PR TITLE
rearrange the order of models, make opus 4.1 first one on the list in the ui

### DIFF
--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -47,8 +47,8 @@ export interface AgentConfig {
 }
 
 export const AGENT_CONFIGS: AgentConfig[] = [
-  CLAUDE_SONNET_CONFIG,
   CLAUDE_OPUS_4_1_CONFIG,
+  CLAUDE_SONNET_CONFIG,
   CLAUDE_OPUS_4_CONFIG,
   CODEX_O3_CONFIG,
   CODEX_O4_MINI_CONFIG,


### PR DESCRIPTION
## Summary
- Task completed by claude/sonnet-4 agent 🏆
- Both implementations are identical - they both move CLAUDE_OPUS_4_1_CONFIG to the top of the AGENT_CONFIGS array and reorder CLAUDE_SONNET_CONFIG to second position. Since the changes are exactly the same, selecting the first implementation.

## Details
- Task ID: jx7e20arzser7qkqstf7tnzk957n4vvk
- Agent: claude/sonnet-4
- Completed: 2025-08-06T22:46:10.361Z

---
🤖 Generated with [cmux](https://github.com/lawrencecchen/cmux)