### PR TITLE
Add error handling and reporting for terminal failures

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -1,4 +1,9 @@
 import { OpenWithDropdown } from "@/components/OpenWithDropdown";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { type Doc } from "@cmux/convex/dataModel";
 import { Link, useLocation } from "@tanstack/react-router";
 import clsx from "clsx";
@@ -181,7 +186,21 @@ function TaskRunTree({ run, level, taskId }: TaskRunTreeProps) {
           />
         </button>
 
-        <div className="mr-2 flex-shrink-0">{statusIcon}</div>
+        {run.status === "failed" && run.errorMessage ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="mr-2 flex-shrink-0">{statusIcon}</div>
+            </TooltipTrigger>
+            <TooltipContent
+              side="right"
+              className="max-w-xs whitespace-pre-wrap break-words"
+            >
+              {run.errorMessage}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <div className="mr-2 flex-shrink-0">{statusIcon}</div>
+        )}
 
         <div className="flex-1 min-w-0 flex items-center gap-1">
           <span className="truncate text-neutral-700 dark:text-neutral-300">

--- a/apps/server/src/vscode/VSCodeInstance.ts
+++ b/apps/server/src/vscode/VSCodeInstance.ts
@@ -135,6 +135,14 @@ export abstract class VSCodeInstance extends EventEmitter {
         this.emit("terminal-idle", data);
       });
 
+      this.workerSocket.on("worker:terminal-failed", (data) => {
+        dockerLogger.error(
+          `[VSCodeInstance ${this.instanceId}] Terminal failed:`,
+          data
+        );
+        this.emit("terminal-failed", data);
+      });
+
       this.workerSocket.on("worker:error", (data) => {
         dockerLogger.error(
           `[VSCodeInstance ${this.instanceId}] Worker error:`,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -54,6 +54,7 @@ export default defineSchema({
     updatedAt: v.number(),
     completedAt: v.optional(v.number()),
     exitCode: v.optional(v.number()),
+    errorMessage: v.optional(v.string()), // Error message when run fails early
     userId: v.optional(v.string()), // Link to user who created the run
     isCrowned: v.optional(v.boolean()), // Whether this run won the crown evaluation
     crownReason: v.optional(v.string()), // LLM's reasoning for why this run was crowned

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -387,6 +387,25 @@ export const complete = mutation({
   },
 });
 
+// Mark a task run as failed with an error message
+export const fail = mutation({
+  args: {
+    id: v.id("taskRuns"),
+    errorMessage: v.string(),
+    exitCode: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.patch(args.id, {
+      status: "failed",
+      errorMessage: args.errorMessage,
+      exitCode: args.exitCode ?? 1,
+      completedAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
 // Get all active VSCode instances
 export const getActiveVSCodeInstances = query({
   handler: async (ctx) => {

--- a/packages/shared/src/providers/openai/configs.ts
+++ b/packages/shared/src/providers/openai/configs.ts
@@ -14,6 +14,7 @@ export const CODEX_GPT_5_CONFIG: AgentConfig = {
     "danger-full-access",
     "--ask-for-approval",
     "never",
+    "--prompt",
     "$PROMPT",
   ],
   environment: getOpenAIEnvironment,

--- a/packages/shared/src/worker-schemas.ts
+++ b/packages/shared/src/worker-schemas.ts
@@ -109,6 +109,15 @@ export const WorkerTerminalIdleSchema = z.object({
   elapsedMs: z.number(),
 });
 
+// Terminal failure event (e.g., tmux spawn/agent command failed)
+export const WorkerTerminalFailedSchema = z.object({
+  workerId: z.string(),
+  terminalId: z.string(),
+  taskId: z.string().optional(),
+  errorMessage: z.string(),
+  elapsedMs: z.number().optional(),
+});
+
 // File upload schema for authentication files
 export const WorkerUploadFilesSchema = z.object({
   files: z.array(
@@ -174,6 +183,7 @@ export type WorkerTerminalExit = z.infer<typeof WorkerTerminalExitSchema>;
 export type WorkerTerminalCreated = z.infer<typeof WorkerTerminalCreatedSchema>;
 export type WorkerTerminalClosed = z.infer<typeof WorkerTerminalClosedSchema>;
 export type WorkerTerminalIdle = z.infer<typeof WorkerTerminalIdleSchema>;
+export type WorkerTerminalFailed = z.infer<typeof WorkerTerminalFailedSchema>;
 export type WorkerUploadFiles = z.infer<typeof WorkerUploadFilesSchema>;
 export type WorkerConfigureGit = z.infer<typeof WorkerConfigureGitSchema>;
 export type WorkerExec = z.infer<typeof WorkerExecSchema>;
@@ -232,6 +242,7 @@ export interface WorkerToServerEvents {
   "worker:terminal-exit": (data: WorkerTerminalExit) => void;
   "worker:terminal-closed": (data: WorkerTerminalClosed) => void;
   "worker:terminal-idle": (data: WorkerTerminalIdle) => void;
+  "worker:terminal-failed": (data: WorkerTerminalFailed) => void;
 
   // Error reporting
   "worker:error": (data: { workerId: string; error: string }) => void;


### PR DESCRIPTION
- Implemented a new `terminal-failed` event in the VSCode instance to capture and log terminal failures.
- Enhanced the `spawnAgent` function to track terminal failure states and log error messages.
- Updated the task run schema to include an optional `errorMessage` field for failed runs.
- Added a new mutation to mark task runs as failed with an error message.
- Improved the error reporting mechanism in the worker to capture initial stderr output during terminal startup.
- Integrated tooltips in the TaskTree component to display error messages for failed tasks.