### PR TITLE
Remove crown icon from task list

### DIFF
--- a/apps/client/src/components/dashboard/TaskItem.tsx
+++ b/apps/client/src/components/dashboard/TaskItem.tsx
@@ -16,7 +16,6 @@ import {
   Archive,
   Check,
   Copy,
-  Crown,
   Pin,
 } from "lucide-react";
 import { memo, useCallback, useMemo } from "react";
@@ -38,12 +37,6 @@ export const TaskItem = memo(function TaskItem({ task }: TaskItemProps) {
 
   // Mutation for toggling keep-alive status
   const toggleKeepAlive = useMutation(api.taskRuns.toggleKeepAlive);
-  
-  // Query for crown evaluation
-  const crownedRun = useConvexQuery(
-    api.crown.getCrownedRun, 
-    isFakeConvexId(task._id) ? "skip" : { taskId: task._id }
-  );
 
   // Find the latest task run with a VSCode instance
   const getLatestVSCodeInstance = useCallback(() => {
@@ -144,9 +137,6 @@ export const TaskItem = memo(function TaskItem({ task }: TaskItemProps) {
         <span className="text-[14px] truncate">
           {task.text}
         </span>
-        {crownedRun && (
-          <Crown className="w-3.5 h-3.5 text-yellow-500 flex-shrink-0" />
-        )}
         {(task.projectFullName || (task.branch && task.branch !== "main")) && (
           <span className="text-[11px] text-neutral-400 dark:text-neutral-500 flex-shrink-0 ml-auto mr-0">
             {task.projectFullName && (


### PR DESCRIPTION
Removed the crown icon display from TaskItem component in the dashboard/home page.
- Removed Crown import from lucide-react
- Removed crownedRun query for crown evaluation
- Removed crown icon rendering logic

🤖 Generated with [Claude Code](https://claude.ai/code)