### PR TITLE
when scrolling in a vscode terminal in openvscode in the web on a TUI terminal program, it moves the cursor around instead of scrolling the full thing, how to fix? i think it's an issue of using tmux, is there a workaround? fix the worker @Dockerfile to set up tmux conf to support scrolling.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,6 +201,9 @@ COPY --from=builder /usr/local/bin/wait-for-docker.sh /usr/local/bin/wait-for-do
 RUN SHELL=/bin/bash pnpm setup && \
     . /root/.bashrc
 
+# Install tmux configuration for better mouse scrolling behavior
+COPY configs/tmux.conf /etc/tmux.conf
+
 
 # Find and install claude-code.vsix from Bun cache using ripgrep
 RUN claude_vsix=$(rg --files /root/.bun/install/cache/@anthropic-ai 2>/dev/null | rg "claude-code\.vsix$" | head -1) && \

--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -1,0 +1,30 @@
+# Enable 256-color and sane defaults
+set -g default-terminal "tmux-256color"
+set -g history-limit 100000
+setw -g mode-keys vi
+set -g escape-time 0
+
+# Enable mouse support
+set -g mouse on
+
+# Scroll wheel enters copy-mode and scrolls tmux history
+# This avoids forwarding wheel events to TUI apps that move the cursor
+bind -n WheelUpPane if-shell -F -t = "#{pane_in_mode}" \
+  "send-keys -M" \
+  "copy-mode -e; send-keys -M"
+
+# While in copy-mode, keep scrolling with the wheel
+bind -T copy-mode-vi WheelUpPane send-keys -X scroll-up
+bind -T copy-mode-vi WheelDownPane send-keys -X scroll-down
+
+# For symmetry: when already in copy-mode, pass wheel down to copy-mode;
+# otherwise pass through (lets you exit copy-mode by scrolling to bottom)
+bind -n WheelDownPane if-shell -F -t = "#{pane_in_mode}" \
+  "send-keys -M" \
+  "send-keys -M"
+
+# Optional: PageUp enters copy-mode and pages up
+bind -n PageUp if-shell -F "#{pane_in_mode}" \
+  "send-keys -X page-up" \
+  "copy-mode -e; send-keys -X page-up"
+


### PR DESCRIPTION
## Summary
- Task completed by codex/gpt-5 agent 🏆
- The codex/gpt-5 implementation is superior because it creates a dedicated configuration file with comprehensive tmux settings, proper wheel scrolling bindings for copy-mode, and includes additional useful tmux defaults like vi mode keys and history settings, providing a more maintainable and complete solution.

## Details
- Task ID: jx752bqhdz57fcyr6y9x7gtcas7n8d9c
- Agent: codex/gpt-5
- Completed: 2025-08-08T09:20:51.342Z

---
🤖 Generated with [cmux](https://github.com/lawrencecchen/cmux)