### PR TITLE
Automate task naming and branching strategy

### DIFF
--- a/apps/server/src/utils/llmNamer.ts
+++ b/apps/server/src/utils/llmNamer.ts
@@ -1,0 +1,146 @@
+import { api } from "@cmux/convex/api";
+import { convex } from "./convexClient.js";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+// Providers and cheap models
+// - OpenAI: gpt-5-nano via @openai/codex
+// - Anthropic: claude-3-5-haiku-20241022 via @anthropic-ai/claude-code
+// - Gemini: gemini-2.5-flash-lite via @google/gemini-cli
+
+type Provider = "openai" | "anthropic" | "gemini";
+
+interface NameSuggestOptions {
+  taskDescription: string;
+  repoName: string;
+  worktreesPath: string;
+  branchPrefix?: string | null;
+  originPath?: string;
+}
+
+function sanitizeSlug(input: string, maxLen = 40): string {
+  const base = input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+  return base.substring(0, maxLen);
+}
+
+async function detectAvailableProvider(): Promise<{ provider: Provider | null; apiKeyEnv: string | null }>
+{
+  try {
+    const keyMap = await convex.query(api.apiKeys.getAllForAgents);
+    if (keyMap["OPENAI_API_KEY"] || process.env.OPENAI_API_KEY) {
+      return { provider: "openai", apiKeyEnv: "OPENAI_API_KEY" };
+    }
+    if (keyMap["ANTHROPIC_API_KEY"] || process.env.ANTHROPIC_API_KEY) {
+      return { provider: "anthropic", apiKeyEnv: "ANTHROPIC_API_KEY" };
+    }
+    if (keyMap["GEMINI_API_KEY"] || process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) {
+      // Prefer GEMINI_API_KEY if present; fall back to GOOGLE_API_KEY
+      return { provider: "gemini", apiKeyEnv: keyMap["GEMINI_API_KEY"] ? "GEMINI_API_KEY" : (process.env.GEMINI_API_KEY ? "GEMINI_API_KEY" : "GOOGLE_API_KEY") };
+    }
+  } catch {}
+  return { provider: null, apiKeyEnv: null };
+}
+
+async function callLLMForName(provider: Provider, prompt: string): Promise<string | null> {
+  // Run through underlying CLIs with cheap models. Use --yes/--force and no interactive behavior.
+  // Return a single-line suggestion.
+  const { exec } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execAsync = promisify(exec);
+
+  try {
+    if (provider === "openai") {
+      const cmd = `bunx --yes @openai/codex --model gpt-5-nano --sandbox never "${prompt.replace(/"/g, '\\"')}" | head -n 1`;
+      const { stdout } = await execAsync(cmd, { env: process.env });
+      return stdout.trim();
+    }
+    if (provider === "anthropic") {
+      const cmd = `bunx --yes @anthropic-ai/claude-code --model claude-3-5-haiku-20241022 --dangerously-skip-permissions "${prompt.replace(/"/g, '\\"')}" | head -n 1`;
+      const { stdout } = await execAsync(cmd, { env: process.env });
+      return stdout.trim();
+    }
+    if (provider === "gemini") {
+      const cmd = `bunx --yes @google/gemini-cli --model gemini-2.5-flash-lite --prompt "${prompt.replace(/"/g, '\\"')}" | head -n 1`;
+      const { stdout } = await execAsync(cmd, { env: process.env });
+      return stdout.trim();
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export async function ensureUniqueName(
+  baseName: string,
+  worktreesPath: string,
+  originPath?: string
+): Promise<{ branchName: string; worktreePath: string }>
+{
+  let attempt = 0;
+  let current = baseName;
+  while (true) {
+    const candidatePath = path.join(worktreesPath, current);
+    try {
+      await fs.access(candidatePath);
+      // Exists, try suffix
+      attempt += 1;
+      current = `${baseName}-${attempt}`;
+      continue;
+    } catch {
+      // Directory does not exist; optionally check for existing branch in origin
+      if (originPath) {
+        try {
+          const { exec } = await import("node:child_process");
+          const { promisify } = await import("node:util");
+          const execAsync = promisify(exec);
+          // Check local refs (if repo initialized) and remote heads
+          const checkLocal = `git -C "${originPath}" show-ref --verify --quiet refs/heads/${current}`;
+          const checkRemote = `git -C "${originPath}" ls-remote --exit-code --heads origin ${current}`;
+          try {
+            await execAsync(checkLocal);
+            // Local branch exists
+            attempt += 1;
+            current = `${baseName}-${attempt}`;
+            continue;
+          } catch {}
+          try {
+            await execAsync(checkRemote);
+            // Remote branch exists
+            attempt += 1;
+            current = `${baseName}-${attempt}`;
+            continue;
+          } catch {}
+        } catch {}
+      }
+      return { branchName: current, worktreePath: candidatePath };
+    }
+  }
+}
+
+export async function suggestBranchAndWorktree(options: NameSuggestOptions): Promise<{ branchName: string; worktreePath: string }>
+{
+  const { provider } = await detectAvailableProvider();
+
+  const fallback = sanitizeSlug(options.taskDescription || options.repoName || "task");
+
+  let suggested = fallback;
+  if (provider) {
+    const prompt = `Given this task: "${options.taskDescription}" for repo "${options.repoName}", propose a short, kebab-case branch name (no spaces, only [a-z0-9-]), 3-6 words, no prefix or ticket numbers.`;
+    const llm = await callLLMForName(provider, prompt);
+    if (llm) {
+      const cleaned = sanitizeSlug(llm);
+      if (cleaned.length >= 3) suggested = cleaned;
+    }
+  }
+
+  // Apply optional prefix if provided and non-empty, but default to none
+  const prefix = options.branchPrefix?.trim();
+  const baseName = prefix ? `${sanitizeSlug(prefix, 20)}-${suggested}` : suggested;
+
+  return await ensureUniqueName(baseName, options.worktreesPath, options.originPath);
+}

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -137,6 +137,7 @@ export default defineSchema({
   }).index("by_envVar", ["envVar"]),
   workspaceSettings: defineTable({
     worktreePath: v.optional(v.string()), // Custom path for git worktrees
+    branchPrefix: v.optional(v.string()), // Optional branch name prefix (no default)
     createdAt: v.number(),
     updatedAt: v.number(),
   }),

--- a/packages/convex/convex/workspaceSettings.ts
+++ b/packages/convex/convex/workspaceSettings.ts
@@ -12,6 +12,7 @@ export const get = query({
 export const update = mutation({
   args: {
     worktreePath: v.optional(v.string()),
+    branchPrefix: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db.query("workspaceSettings").first();
@@ -20,11 +21,13 @@ export const update = mutation({
     if (existing) {
       await ctx.db.patch(existing._id, {
         worktreePath: args.worktreePath,
+        branchPrefix: args.branchPrefix,
         updatedAt: now,
       });
     } else {
       await ctx.db.insert("workspaceSettings", {
         worktreePath: args.worktreePath,
+        branchPrefix: args.branchPrefix,
         createdAt: now,
         updatedAt: now,
       });


### PR DESCRIPTION
Implement LLM-based branch and worktree naming with configurable prefixes and uniqueness checks to improve task organization.

The previous naming scheme used a generic timestamp (`cmux-timestamp`), which made it difficult to identify the purpose of a branch or worktree at a glance. This change leverages available LLMs to generate descriptive, kebab-cased names based on the task description, making them more human-readable. It also introduces a configurable prefix for better organization and robust uniqueness checks against existing folders and Git branches to prevent collisions.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4181068-e96b-4f2b-8d5c-8038cf33541c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4181068-e96b-4f2b-8d5c-8038cf33541c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

