### PR TITLE
Integrate qwen code cli with credential handling

### DIFF
--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -16,6 +16,7 @@ import {
   GEMINI_FLASH_CONFIG,
   GEMINI_PRO_CONFIG,
 } from "./providers/gemini/configs.js";
+import { QWEN_CODE_CONFIG } from "./providers/qwen-code/configs.js";
 import {
   CODEX_GPT_4_1_CONFIG,
   CODEX_GPT_5_CONFIG,
@@ -68,6 +69,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
   CODEX_GPT_4_1_CONFIG,
   GEMINI_FLASH_CONFIG,
   GEMINI_PRO_CONFIG,
+  QWEN_CODE_CONFIG,
   AMP_CONFIG,
   OPENCODE_SONNET_CONFIG,
   OPENCODE_OPUS_CONFIG,

--- a/packages/shared/src/providers/qwen-code/check-requirements.ts
+++ b/packages/shared/src/providers/qwen-code/check-requirements.ts
@@ -1,0 +1,33 @@
+export async function checkQwenCodeRequirements(): Promise<string[]> {
+  const { access } = await import("node:fs/promises");
+  const { homedir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const missing: string[] = [];
+
+  const home = homedir();
+  const geminiOauth = join(home, ".gemini", "oauth_creds.json");
+  const geminiMcpTokens = join(home, ".gemini", "mcp-oauth-tokens.json");
+  const qwenOauth = join(home, ".qwen", "oauth_creds.json");
+
+  const exists = async (p: string) => access(p).then(() => true).catch(() => false);
+
+  const hasGeminiOauth = await exists(geminiOauth);
+  const hasGeminiMcp = await exists(geminiMcpTokens);
+  const hasQwenOauth = await exists(qwenOauth);
+
+  let hasGoogleAppCreds = false;
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    hasGoogleAppCreds = await exists(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+  }
+
+  const hasOpenAIKey = Boolean(process.env.OPENAI_API_KEY);
+
+  if (!(hasGeminiOauth || hasGeminiMcp || hasQwenOauth || hasGoogleAppCreds || hasOpenAIKey)) {
+    missing.push(
+      "Qwen Code auth (no ~/.gemini/oauth_creds.json, ~/.gemini/mcp-oauth-tokens.json, ~/.qwen/oauth_creds.json, GOOGLE_APPLICATION_CREDENTIALS file, or OPENAI_API_KEY)"
+    );
+  }
+
+  return missing;
+}

--- a/packages/shared/src/providers/qwen-code/configs.ts
+++ b/packages/shared/src/providers/qwen-code/configs.ts
@@ -1,0 +1,13 @@
+import type { AgentConfig } from "../../agentConfig.js";
+import { OPENAI_API_KEY } from "../../apiKeys.js";
+import { checkQwenCodeRequirements } from "./check-requirements.js";
+import { getQwenCodeEnvironment } from "./environment.js";
+
+export const QWEN_CODE_CONFIG: AgentConfig = {
+  name: "qwen-code",
+  command: "bunx",
+  args: ["@qwen-code/qwen-code@latest", "$PROMPT"],
+  environment: getQwenCodeEnvironment,
+  checkRequirements: checkQwenCodeRequirements,
+  apiKeys: [OPENAI_API_KEY],
+};

--- a/packages/shared/src/providers/qwen-code/environment.ts
+++ b/packages/shared/src/providers/qwen-code/environment.ts
@@ -1,0 +1,56 @@
+import type { EnvironmentResult } from "../common/environment-result.js";
+
+export async function getQwenCodeEnvironment(): Promise<EnvironmentResult> {
+  const { readFile, access } = await import("node:fs/promises");
+  const { homedir } = await import("node:os");
+  const { join, basename } = await import("node:path");
+  const { Buffer } = await import("node:buffer");
+
+  const files: EnvironmentResult["files"] = [];
+  const env: Record<string, string> = {};
+  const startupCommands: string[] = [];
+
+  // Ensure config directories exist in container
+  startupCommands.push("mkdir -p ~/.gemini");
+  startupCommands.push("mkdir -p ~/.qwen");
+
+  const home = homedir();
+
+  async function tryCopy(srcPath: string, destPath: string, mode = "600") {
+    try {
+      await access(srcPath);
+      const content = await readFile(srcPath, "utf-8");
+      files.push({ destinationPath: destPath, contentBase64: Buffer.from(content).toString("base64"), mode });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Copy OAuth creds if present
+  await tryCopy(join(home, ".gemini", "oauth_creds.json"), "$HOME/.gemini/oauth_creds.json", "600");
+  await tryCopy(join(home, ".gemini", "mcp-oauth-tokens.json"), "$HOME/.gemini/mcp-oauth-tokens.json", "600");
+  await tryCopy(join(home, ".qwen", "oauth_creds.json"), "$HOME/.qwen/oauth_creds.json", "600");
+
+  // If GOOGLE_APPLICATION_CREDENTIALS points to a file, copy it and set env var to container path
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    const localPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    try {
+      await access(localPath!);
+      const fileName = basename(localPath!);
+      const dest = `$HOME/.gemini/${fileName}`;
+      const content = await readFile(localPath!, "utf-8");
+      files.push({ destinationPath: dest, contentBase64: Buffer.from(content).toString("base64"), mode: "600" });
+      env.GOOGLE_APPLICATION_CREDENTIALS = dest;
+    } catch {
+      // ignore if not found
+    }
+  }
+
+  // Pass through OPENAI_API_KEY if available (also provided from Convex keys)
+  if (process.env.OPENAI_API_KEY) {
+    env.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+  }
+
+  return { files, env, startupCommands };
+}


### PR DESCRIPTION
Add `qwen-code` CLI agent with support for its specific OAuth and API key credential requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-34397828-48f0-45e9-b43e-64ffb6a0291a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34397828-48f0-45e9-b43e-64ffb6a0291a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

