### PR TITLE
Autofocus describe task input

### DIFF
--- a/apps/client/src/components/dashboard/DashboardInput.tsx
+++ b/apps/client/src/components/dashboard/DashboardInput.tsx
@@ -38,6 +38,7 @@ export const DashboardInput = memo(
     ref
   ) {
     const internalApiRef = useRef<EditorApi | null>(null);
+    const hasFocusedRef = useRef(false);
 
     useImperativeHandle(ref, () => ({
       getContent: () => internalApiRef.current?.getContent() || { text: "", images: [] },
@@ -68,6 +69,15 @@ export const DashboardInput = memo(
 
     const handleEditorReady = (api: EditorApi) => {
       internalApiRef.current = api;
+      
+      // Autofocus the editor when it's ready (only once)
+      if (!hasFocusedRef.current) {
+        // Small delay to ensure the editor is fully rendered
+        setTimeout(() => {
+          api.focus?.();
+          hasFocusedRef.current = true;
+        }, 100);
+      }
     };
 
     return (


### PR DESCRIPTION
Autofocus the "describe a task" input for immediate typing.

The existing `AutoFocusPlugin` in Lexical was not reliably focusing the input on initial load. This change ensures the editor is focused once it's fully ready by manually calling `focus()` with a slight delay, preventing the need for a manual click.

---
<a href="https://cursor.com/background-agent?bcId=bc-16b75445-43c0-49dd-98c4-7dbb5b036e81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16b75445-43c0-49dd-98c4-7dbb5b036e81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

