### PR TITLE
Integrate qwen-code cli with credential handling

### DIFF
--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -34,6 +34,7 @@ import {
   OPENCODE_QWEN3_CODER_CONFIG,
   OPENCODE_SONNET_CONFIG,
 } from "./providers/opencode/configs.js";
+import { QWEN_CODE_CONFIG } from "./providers/qwen/configs.js";
 
 export { checkDockerStatus } from "./providers/common/check-docker.js";
 export { checkGitStatus } from "./providers/common/check-git.js";
@@ -83,4 +84,5 @@ export const AGENT_CONFIGS: AgentConfig[] = [
   CURSOR_GPT_5_CONFIG,
   CURSOR_SONNET_4_CONFIG,
   CURSOR_SONNET_4_THINKING_CONFIG,
+  QWEN_CODE_CONFIG,
 ];

--- a/packages/shared/src/apiKeys.ts
+++ b/packages/shared/src/apiKeys.ts
@@ -35,3 +35,9 @@ export const CURSOR_API_KEY: AgentConfigApiKey = {
   displayName: "Cursor API Key",
   description: "API key for Cursor agent",
 };
+
+export const QWEN_API_KEY: AgentConfigApiKey = {
+  envVar: "QWEN_API_KEY",
+  displayName: "Qwen API Key",
+  description: "API key for Qwen code models",
+};

--- a/packages/shared/src/providers/qwen/check-requirements.ts
+++ b/packages/shared/src/providers/qwen/check-requirements.ts
@@ -1,0 +1,81 @@
+export async function checkQwenRequirements(): Promise<string[]> {
+  const { access, readFile } = await import("node:fs/promises");
+  const { homedir } = await import("node:os");
+  const { join } = await import("node:path");
+  
+  const missing: string[] = [];
+  const qwenDir = join(homedir(), ".qwen");
+  const geminiDir = join(homedir(), ".gemini");
+
+  // Check for authentication files in multiple locations
+  const authFiles = [
+    { path: join(qwenDir, "oauth_creds.json"), name: "~/.qwen/oauth_creds.json" },
+    { path: join(geminiDir, "oauth_creds.json"), name: "~/.gemini/oauth_creds.json" },
+    { path: join(geminiDir, "mcp-oauth-tokens.json"), name: "~/.gemini/mcp-oauth-tokens.json" },
+  ];
+
+  let hasAuth = false;
+  for (const { path } of authFiles) {
+    try {
+      await access(path);
+      hasAuth = true;
+      break; // Found at least one auth file
+    } catch {
+      // Continue checking
+    }
+  }
+
+  // Also check for API keys in environment variables
+  const apiKeyEnvVars = [
+    "QWEN_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+  ];
+
+  let hasApiKey = false;
+  for (const envVar of apiKeyEnvVars) {
+    if (process.env[envVar]) {
+      hasApiKey = true;
+      break;
+    }
+  }
+
+  // Check for API keys in .env files
+  if (!hasApiKey) {
+    const envPaths = [
+      join(qwenDir, ".env"),
+      join(geminiDir, ".env"),
+      join(homedir(), ".env"),
+    ];
+
+    for (const envPath of envPaths) {
+      try {
+        const content = await readFile(envPath, "utf-8");
+        // Check for any of the API key environment variables in the file
+        for (const envVar of apiKeyEnvVars) {
+          if (content.includes(`${envVar}=`)) {
+            hasApiKey = true;
+            break;
+          }
+        }
+        if (hasApiKey) break;
+      } catch {
+        // Continue checking
+      }
+    }
+  }
+
+  if (!hasAuth && !hasApiKey) {
+    missing.push("Qwen authentication (no OAuth credentials or API key found)");
+  }
+
+  // Check for settings file (optional but recommended)
+  try {
+    await access(join(qwenDir, "settings.json"));
+  } catch {
+    // Settings file is optional, so we don't add it to missing
+    // But we could add a warning if desired
+  }
+
+  return missing;
+}

--- a/packages/shared/src/providers/qwen/configs.ts
+++ b/packages/shared/src/providers/qwen/configs.ts
@@ -1,0 +1,16 @@
+import type { AgentConfig } from "../../agentConfig.js";
+import { QWEN_API_KEY } from "../../apiKeys.js";
+import { checkQwenRequirements } from "./check-requirements.js";
+import { getQwenEnvironment } from "./environment.js";
+
+export const QWEN_CODE_CONFIG: AgentConfig = {
+  name: "qwen/code",
+  command: "bunx",
+  args: [
+    "@qwen-code/qwen-code@latest",
+    "$PROMPT",
+  ],
+  environment: getQwenEnvironment,
+  apiKeys: [QWEN_API_KEY],
+  checkRequirements: checkQwenRequirements,
+};

--- a/packages/shared/src/providers/qwen/environment.ts
+++ b/packages/shared/src/providers/qwen/environment.ts
@@ -1,0 +1,109 @@
+import type { EnvironmentResult } from "../common/environment-result.js";
+
+export async function getQwenEnvironment(): Promise<EnvironmentResult> {
+  // These must be lazy since configs are imported into the browser
+  const { readFile, stat } = await import("node:fs/promises");
+  const { homedir } = await import("node:os");
+  const { Buffer } = await import("node:buffer");
+  const { join } = await import("node:path");
+
+  const files: EnvironmentResult["files"] = [];
+  const env: Record<string, string> = {};
+  const startupCommands: string[] = [];
+
+  // Ensure .qwen directory exists
+  startupCommands.push("mkdir -p ~/.qwen");
+
+  const qwenDir = join(homedir(), ".qwen");
+  const geminiDir = join(homedir(), ".gemini");
+
+  // Helper function to safely copy file
+  async function copyFile(
+    sourcePath: string,
+    destinationPath: string,
+    mode: string = "644"
+  ) {
+    try {
+      const content = await readFile(sourcePath, "utf-8");
+      files.push({
+        destinationPath,
+        contentBase64: Buffer.from(content).toString("base64"),
+        mode,
+      });
+      return true;
+    } catch (error) {
+      // Only log if it's not a "file not found" error
+      if (error instanceof Error && 'code' in error && error.code !== "ENOENT") {
+        console.warn(`Failed to read ${sourcePath}:`, error);
+      }
+      return false;
+    }
+  }
+
+  // 1. Check for OAuth credentials in ~/.qwen/oauth_creds.json
+  await copyFile(
+    join(qwenDir, "oauth_creds.json"),
+    "$HOME/.qwen/oauth_creds.json",
+    "600"
+  );
+
+  // 2. Check for OAuth credentials in ~/.gemini/oauth_creds.json (Google)
+  await copyFile(
+    join(geminiDir, "oauth_creds.json"),
+    "$HOME/.gemini/oauth_creds.json",
+    "600"
+  );
+
+  // 3. Check for MCP OAuth tokens in ~/.gemini/mcp-oauth-tokens.json
+  await copyFile(
+    join(geminiDir, "mcp-oauth-tokens.json"),
+    "$HOME/.gemini/mcp-oauth-tokens.json",
+    "600"
+  );
+
+  // 4. Check for settings file in .qwen directory
+  await copyFile(join(qwenDir, "settings.json"), "$HOME/.qwen/settings.json");
+
+  // 5. Check for .env files in multiple locations
+  const envPaths = [
+    join(qwenDir, ".env"),
+    join(geminiDir, ".env"),
+    join(homedir(), ".env"),
+  ];
+
+  for (const envPath of envPaths) {
+    try {
+      const content = await readFile(envPath, "utf-8");
+      let filename = ".env";
+      if (envPath.includes(".qwen")) {
+        filename = ".qwen/.env";
+      } else if (envPath.includes(".gemini")) {
+        filename = ".gemini/.env";
+      }
+      files.push({
+        destinationPath: `$HOME/${filename}`,
+        contentBase64: Buffer.from(content).toString("base64"),
+        mode: "600",
+      });
+    } catch {
+      // Continue to next path
+    }
+  }
+
+  // 6. Pass through relevant environment variables
+  const relevantEnvVars = [
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "OPENAI_API_KEY",
+    "QWEN_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+  ];
+
+  for (const envVar of relevantEnvVars) {
+    if (process.env[envVar]) {
+      env[envVar] = process.env[envVar];
+    }
+  }
+
+  return { files, env, startupCommands };
+}

--- a/packages/shared/src/providers/qwen/index.ts
+++ b/packages/shared/src/providers/qwen/index.ts
@@ -1,0 +1,3 @@
+export * from "./configs.js";
+export * from "./check-requirements.js";
+export * from "./environment.js";


### PR DESCRIPTION
Adds `qwen-code` CLI tool integration to enable its use as an agent.

---
<a href="https://cursor.com/background-agent?bcId=bc-907ef6fb-a85b-4de6-96b0-43ccd4489090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-907ef6fb-a85b-4de6-96b0-43ccd4489090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

