### PR TITLE
when generating branch names, we should handle camelcase by adding hyphens between each of the words

### DIFF
--- a/apps/server/src/utils/branchNameGenerator.test.ts
+++ b/apps/server/src/utils/branchNameGenerator.test.ts
@@ -55,6 +55,22 @@ describe("toKebabCase", () => {
     expect(toKebabCase("café")).toBe("caf");
     expect(toKebabCase("naïve")).toBe("na-ve");
   });
+
+  it("should handle camelCase by adding hyphens", () => {
+    expect(toKebabCase("camelCase")).toBe("camel-case");
+    expect(toKebabCase("handleCamelCaseWithHyphens")).toBe("handle-camel-case-with-hyphens");
+    expect(toKebabCase("myVariableName")).toBe("my-variable-name");
+    expect(toKebabCase("APIResponse")).toBe("api-response");
+    expect(toKebabCase("HTTPSConnection")).toBe("https-connection");
+    expect(toKebabCase("XMLHttpRequest")).toBe("xml-http-request");
+    expect(toKebabCase("IOError")).toBe("io-error");
+  });
+
+  it("should handle mixed camelCase and spaces", () => {
+    expect(toKebabCase("Add myNewFeature")).toBe("add-my-new-feature");
+    expect(toKebabCase("Fix getUserById bug")).toBe("fix-get-user-by-id-bug");
+    expect(toKebabCase("Update APIEndpoint")).toBe("update-api-endpoint");
+  });
 });
 
 describe("generateRandomId", () => {

--- a/apps/server/src/utils/branchNameGenerator.ts
+++ b/apps/server/src/utils/branchNameGenerator.ts
@@ -9,6 +9,10 @@ import { serverLogger } from "./fileLogger.js";
  */
 export function toKebabCase(input: string): string {
   return input
+    // First, handle camelCase by inserting hyphens before capital letters
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    // Also handle sequences like "HTTPServer" -> "HTTP-Server"
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
     .toLowerCase()
     // Replace any sequence of non-alphanumeric characters with a single hyphen
     .replace(/[^a-z0-9]+/g, "-")


### PR DESCRIPTION
## Summary\n- Task completed by claude/opus-4.1 agent 🏆\n- The claude/opus-4.1 implementation provides more comprehensive test coverage with additional edge cases for camelCase handling, mixed scenarios, and acronym sequences. It also includes clearer comments explaining the regex transformations and handles more complex cases like 'Add myNewFeature' and 'Fix getUserById bug'.\n\n## Details\n- Task ID: jx72ng2f437p30p66717217s8s7ng163\n- Agent: claude/opus-4.1\n- Completed: 2025-08-12T06:39:48.679Z\n\n---\n🤖 Generated with [cmux](https://github.com/lawrencecchen/cmux)