### PR TITLE
Enable tmux clipboard sharing in conf

### DIFF
--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -7,6 +7,9 @@ set -g escape-time 0
 # Enable mouse support
 set -g mouse on
 
+# Sync tmux copy to system clipboard
+set -g set-clipboard on
+
 # Scroll wheel enters copy-mode and scrolls tmux history
 # This avoids forwarding wheel events to TUI apps that move the cursor
 bind -n WheelUpPane if-shell -F -t = "#{pane_in_mode}" \


### PR DESCRIPTION
Add `set -g set-clipboard on` to `configs/tmux.conf` to sync tmux copy actions with the system clipboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-36bdba44-4c55-41f8-a74f-e85948c91371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36bdba44-4c55-41f8-a74f-e85948c91371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

