### PR TITLE
Create and navigate to draft PR

### DIFF
--- a/apps/client/src/routes/_layout.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.task.$taskId.index.tsx
@@ -181,9 +181,24 @@ function TaskDetailPage() {
   const handleViewPR = () => {
     if (crownedRun?.pullRequestUrl && crownedRun.pullRequestUrl !== "pending") {
       window.open(crownedRun.pullRequestUrl, "_blank");
-    } else {
-      // TODO: Create draft PR if it doesn't exist
+    } else if (crownedRun && socket) {
+      // Create draft PR
       console.log("Creating draft PR...");
+      socket.emit("create-draft-pr", 
+        { 
+          taskRunId: crownedRun._id, 
+          taskId: task._id 
+        }, 
+        (response: { success: boolean; error?: string; prUrl?: string }) => {
+          if (response.success && response.prUrl) {
+            // Open the PR in a new tab
+            window.open(response.prUrl, "_blank");
+          } else {
+            console.error("Failed to create draft PR:", response.error);
+            // TODO: Show error toast to user
+          }
+        }
+      );
     }
   };
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -18,6 +18,7 @@ export default defineSchema({
     isCompleted: v.boolean(),
     isArchived: v.optional(v.boolean()),
     description: v.optional(v.string()),
+    prTitle: v.optional(v.string()), // Generated PR title for the task
     projectFullName: v.optional(v.string()),
     baseBranch: v.optional(v.string()),
     worktreePath: v.optional(v.string()),


### PR DESCRIPTION
Implements the "View PR" button to create and navigate to a draft GitHub PR, enhancing user workflow.

The "View PR" button now allows users to quickly generate a draft PR with an AI-generated title and task description as the body, streamlining the process of reviewing and publishing changes made by agents. The PR title is generated and persisted when agents are spawned.

---
<a href="https://cursor.com/background-agent?bcId=bc-380e6275-94b0-4db6-9e65-f04ea655565b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-380e6275-94b0-4db6-9e65-f04ea655565b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

