### PR TITLE
Add test for uppercase acronyms in pr titles

### DIFF
--- a/apps/server/src/utils/branchNameGenerator.ts
+++ b/apps/server/src/utils/branchNameGenerator.ts
@@ -9,10 +9,13 @@ import { serverLogger } from "./fileLogger.js";
  */
 export function toKebabCase(input: string): string {
   return input
+    // Normalize possessive apostrophes for acronyms: "CPU's" -> "CPUs"
+    .replace(/\b([A-Z]{2,})'s\b/g, "$1s")
     // First, handle camelCase by inserting hyphens before capital letters
     .replace(/([a-z])([A-Z])/g, "$1-$2")
     // Also handle sequences like "HTTPServer" -> "HTTP-Server"
-    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+    // Split between an uppercase acronym run and a following Capitalized word, but avoid splitting acronym+plural like "PRs" or "APIs"
+    .replace(/([A-Z]+)([A-Z][a-z]{2,})/g, "$1-$2")
     .toLowerCase()
     // Replace any sequence of non-alphanumeric characters with a single hyphen
     .replace(/[^a-z0-9]+/g, "-")


### PR DESCRIPTION
Improve kebab-case conversion to correctly handle pluralized and possessive acronyms.

This prevents incorrect splitting of terms like "PRs" into "p-rs" and normalizes "CPU's" to "cpus" for better branch name and PR title generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-28e33e9a-3a39-4c76-bea3-c0eabe34d731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28e33e9a-3a39-4c76-bea3-c0eabe34d731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

