### PR TITLE
Compress multiline content to one line

### DIFF
--- a/apps/client/src/routes/_layout.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.task.$taskId.index.tsx
@@ -334,9 +334,9 @@ function TaskDetailPage() {
       </div>
 
       {task?.text && (
-        <div className="text-xs text-neutral-300 mb-2">
+        <div className="text-xs text-neutral-300 mb-2 overflow-hidden">
           <span className="text-neutral-400">Prompt:</span>{" "}
-          <span className="font-medium">{task.text}</span>
+          <span className="font-medium whitespace-nowrap overflow-hidden text-ellipsis inline-block max-w-full">{task.text}</span>
         </div>
       )}
 


### PR DESCRIPTION
Prevent prompt text from wrapping by adding CSS classes to ensure it stays on a single line and truncates with an ellipsis.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a03f580-a597-43db-99fa-af1ebec3e632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a03f580-a597-43db-99fa-af1ebec3e632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

