### PR TITLE
Dockerfile: Add & Test lsof with docker exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     nano \
     net-tools \
+    lsof \
     sudo \
     supervisor \
     iptables \


### PR DESCRIPTION
add lsof to preinstalled stuff in @Dockerfile and test it to make sure it works with docker exec