### PR TITLE
Set Up @cmux/preview-comments React Package with Tailwind (opus 4.1

### DIFF
--- a/apps/www/app/api/[[...route]]/route.ts
+++ b/apps/www/app/api/[[...route]]/route.ts
@@ -1,4 +1,4 @@
-import { booksRouter, healthRouter, usersRouter } from "@/lib/routes/index";
+import { booksRouter, commentsRouter, healthRouter, usersRouter } from "@/lib/routes/index";
 import { stackServerApp } from "@/lib/utils/stack";
 import { swaggerUI } from "@hono/swagger-ui";
 import { OpenAPIHono } from "@hono/zod-openapi";
@@ -59,6 +59,7 @@ app.get("/user", async (c) => {
 app.route("/", healthRouter);
 app.route("/", usersRouter);
 app.route("/", booksRouter);
+app.route("/", commentsRouter);
 
 // OpenAPI documentation
 app.doc("/doc", {

--- a/apps/www/lib/routes/comments.route.ts
+++ b/apps/www/lib/routes/comments.route.ts
@@ -1,0 +1,230 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+
+// In-memory storage for comments
+const commentsStore = new Map<string, Comment>();
+
+// Comment schema
+const CommentSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  nodeId: z.string(),
+  x: z.number(),
+  y: z.number(),
+  page: z.string(),
+  pageTitle: z.string(),
+  userAgent: z.string(),
+  screenWidth: z.number(),
+  screenHeight: z.number(),
+  devicePixelRatio: z.number(),
+  userId: z.string(),
+  userName: z.string(),
+  timestamp: z.string(),
+  resolved: z.boolean().optional(),
+});
+
+const CommentInputSchema = CommentSchema.omit({ id: true });
+
+type Comment = z.infer<typeof CommentSchema>;
+type CommentInput = z.infer<typeof CommentInputSchema>;
+
+// Routes
+const getCommentsRoute = createRoute({
+  method: "get",
+  path: "/comments",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            comments: z.array(CommentSchema),
+          }),
+        },
+      },
+      description: "List of comments",
+    },
+  },
+  tags: ["Comments"],
+  summary: "Get all comments",
+});
+
+const createCommentRoute = createRoute({
+  method: "post",
+  path: "/comments",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: CommentInputSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+      description: "Created comment",
+    },
+  },
+  tags: ["Comments"],
+  summary: "Create a new comment",
+});
+
+const getCommentRoute = createRoute({
+  method: "get",
+  path: "/comments/{id}",
+  request: {
+    params: z.object({
+      id: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+      description: "Comment details",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string(),
+          }),
+        },
+      },
+      description: "Comment not found",
+    },
+  },
+  tags: ["Comments"],
+  summary: "Get a comment by ID",
+});
+
+const updateCommentRoute = createRoute({
+  method: "patch",
+  path: "/comments/{id}",
+  request: {
+    params: z.object({
+      id: z.string(),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            text: z.string().optional(),
+            resolved: z.boolean().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: CommentSchema,
+        },
+      },
+      description: "Updated comment",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string(),
+          }),
+        },
+      },
+      description: "Comment not found",
+    },
+  },
+  tags: ["Comments"],
+  summary: "Update a comment",
+});
+
+const deleteCommentRoute = createRoute({
+  method: "delete",
+  path: "/comments/{id}",
+  request: {
+    params: z.object({
+      id: z.string(),
+    }),
+  },
+  responses: {
+    204: {
+      description: "Comment deleted",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string(),
+          }),
+        },
+      },
+      description: "Comment not found",
+    },
+  },
+  tags: ["Comments"],
+  summary: "Delete a comment",
+});
+
+// Router
+export const commentsRouter = new OpenAPIHono()
+  .openapi(getCommentsRoute, (c) => {
+    const comments = Array.from(commentsStore.values());
+    return c.json({ comments });
+  })
+  .openapi(createCommentRoute, (c) => {
+    const input = c.req.valid("json");
+    const id = generateId();
+    const comment: Comment = {
+      ...input,
+      id,
+      resolved: false,
+    };
+    commentsStore.set(id, comment);
+    return c.json(comment, 201);
+  })
+  .openapi(getCommentRoute, (c) => {
+    const { id } = c.req.valid("param");
+    const comment = commentsStore.get(id);
+    if (!comment) {
+      return c.json({ message: "Comment not found" }, 404);
+    }
+    return c.json(comment);
+  })
+  .openapi(updateCommentRoute, (c) => {
+    const { id } = c.req.valid("param");
+    const updates = c.req.valid("json");
+    const comment = commentsStore.get(id);
+    if (!comment) {
+      return c.json({ message: "Comment not found" }, 404);
+    }
+    const updatedComment = { ...comment, ...updates };
+    commentsStore.set(id, updatedComment);
+    return c.json(updatedComment);
+  })
+  .openapi(deleteCommentRoute, (c) => {
+    const { id } = c.req.valid("param");
+    if (!commentsStore.has(id)) {
+      return c.json({ message: "Comment not found" }, 404);
+    }
+    commentsStore.delete(id);
+    return c.body(null, 204);
+  });
+
+// Utility function to generate random ID
+function generateId(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  for (let i = 0; i < 5; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}

--- a/apps/www/lib/routes/index.ts
+++ b/apps/www/lib/routes/index.ts
@@ -1,3 +1,4 @@
 export { booksRouter } from "./books.route";
+export { commentsRouter } from "./comments.route";
 export { healthRouter } from "./health.route";
 export { usersRouter } from "./users.route";

--- a/packages/preview-comments/build-styles.js
+++ b/packages/preview-comments/build-styles.js
@@ -1,0 +1,33 @@
+import postcss from 'postcss';
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function buildStyles() {
+  const css = await fs.readFile(path.join(__dirname, 'src/styles.css'), 'utf8');
+  
+  const result = await postcss([
+    tailwindcss(path.join(__dirname, 'tailwind.config.js')),
+    autoprefixer,
+  ]).process(css, {
+    from: path.join(__dirname, 'src/styles.css'),
+    to: path.join(__dirname, 'dist/styles.css'),
+  });
+
+  // Write the CSS file
+  await fs.writeFile(path.join(__dirname, 'dist/styles.css'), result.css);
+  
+  // Create a JS module that exports the CSS as a string
+  const jsContent = `export const styles = ${JSON.stringify(result.css)};\n`;
+  await fs.writeFile(path.join(__dirname, 'dist/styles.js'), jsContent);
+  
+  // Create TypeScript definition
+  const dtsContent = `export declare const styles: string;\n`;
+  await fs.writeFile(path.join(__dirname, 'dist/styles.d.ts'), dtsContent);
+}
+
+buildStyles().catch(console.error);

--- a/packages/preview-comments/package.json
+++ b/packages/preview-comments/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@cmux/preview-comments",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles": {
+      "import": "./dist/styles.js",
+      "types": "./dist/styles.d.ts"
+    }
+  },
+  "scripts": {
+    "dev": "tsc --watch",
+    "build": "tsc && node build-styles.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.5.7",
+    "typescript": "^5"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  }
+}

--- a/packages/preview-comments/postcss.config.js
+++ b/packages/preview-comments/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/packages/preview-comments/src/CommentForm.tsx
+++ b/packages/preview-comments/src/CommentForm.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+interface CommentFormProps {
+  onSubmit: (text: string) => void;
+  onCancel: () => void;
+}
+
+export function CommentForm({ onSubmit, onCancel }: CommentFormProps) {
+  const [text, setText] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (text.trim()) {
+      onSubmit(text.trim());
+      setText('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="cmux-space-y-3">
+      <div>
+        <label className="cmux-block cmux-text-sm cmux-font-medium cmux-text-neutral-700 cmux-mb-1">
+          Add a comment
+        </label>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="cmux-w-full cmux-px-3 cmux-py-2 cmux-border cmux-border-neutral-300 cmux-rounded-md cmux-text-sm focus:cmux-outline-none focus:cmux-ring-2 focus:cmux-ring-blue-500 focus:cmux-border-transparent"
+          rows={4}
+          placeholder="Type your comment..."
+          autoFocus
+        />
+      </div>
+      <div className="cmux-flex cmux-gap-2 cmux-justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="cmux-px-3 cmux-py-1.5 cmux-text-sm cmux-text-neutral-600 hover:cmux-text-neutral-900 cmux-transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={!text.trim()}
+          className="cmux-px-3 cmux-py-1.5 cmux-bg-blue-500 cmux-text-white cmux-text-sm cmux-rounded-md hover:cmux-bg-blue-600 disabled:cmux-opacity-50 disabled:cmux-cursor-not-allowed cmux-transition-colors"
+        >
+          Submit
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/preview-comments/src/CommentMarker.tsx
+++ b/packages/preview-comments/src/CommentMarker.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { Comment } from './types';
+
+interface CommentMarkerProps {
+  comment: Comment;
+}
+
+export function CommentMarker({ comment }: CommentMarkerProps) {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    // Try to find the element using the nodeId selector
+    try {
+      const selectors = comment.nodeId.split(',');
+      let targetElement: Element | null = null;
+      
+      for (const selector of selectors) {
+        targetElement = document.querySelector(selector.trim());
+        if (targetElement) break;
+      }
+      
+      if (targetElement && targetElement instanceof HTMLElement) {
+        setElement(targetElement);
+        updatePosition(targetElement);
+      }
+    } catch (error) {
+      console.error('Failed to find element for comment:', error);
+    }
+  }, [comment.nodeId]);
+
+  useEffect(() => {
+    if (!element) return;
+
+    const updatePos = () => updatePosition(element);
+    
+    // Update position on scroll/resize
+    window.addEventListener('scroll', updatePos, true);
+    window.addEventListener('resize', updatePos);
+    
+    return () => {
+      window.removeEventListener('scroll', updatePos, true);
+      window.removeEventListener('resize', updatePos);
+    };
+  }, [element]);
+
+  const updatePosition = (el: HTMLElement) => {
+    const rect = el.getBoundingClientRect();
+    setPosition({
+      x: rect.left + rect.width * comment.x,
+      y: rect.top + rect.height * comment.y
+    });
+  };
+
+  if (!position) return null;
+
+  return (
+    <div
+      className="cmux-fixed cmux-w-6 cmux-h-6 cmux-bg-blue-500 cmux-rounded-full cmux-border-2 cmux-border-white cmux-shadow-lg cmux-z-[9997] cmux-cursor-pointer hover:cmux-scale-110 cmux-transition-transform"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+        transform: 'translate(-50%, -50%)'
+      }}
+      title={comment.text}
+    >
+      <span className="cmux-flex cmux-items-center cmux-justify-center cmux-h-full cmux-text-white cmux-text-xs cmux-font-bold">
+        {comment.id.slice(0, 2)}
+      </span>
+    </div>
+  );
+}

--- a/packages/preview-comments/src/CommentsFloatingWidget.tsx
+++ b/packages/preview-comments/src/CommentsFloatingWidget.tsx
@@ -1,0 +1,281 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import clsx from 'clsx';
+import { Comment, CommentInput } from './types';
+import { CommentsList } from './CommentsList';
+import { CommentForm } from './CommentForm';
+import { CommentMarker } from './CommentMarker';
+
+interface CommentsFloatingWidgetProps {
+  apiUrl: string;
+  userId: string;
+  userName: string;
+}
+
+export function CommentsFloatingWidget({
+  apiUrl,
+  userId,
+  userName
+}: CommentsFloatingWidgetProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [position, setPosition] = useState({ x: 20, y: 20 });
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [isAddingComment, setIsAddingComment] = useState(false);
+  const [selectedElement, setSelectedElement] = useState<HTMLElement | null>(null);
+  const dragRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+
+  // Fetch comments on mount
+  useEffect(() => {
+    fetchComments();
+  }, []);
+
+  const fetchComments = async () => {
+    try {
+      const response = await fetch(`${apiUrl}/api/comments`);
+      if (response.ok) {
+        const data = await response.json();
+        setComments(data.comments || []);
+      }
+    } catch (error) {
+      console.error('Failed to fetch comments:', error);
+    }
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('[data-no-drag]')) return;
+    
+    setIsDragging(true);
+    dragStartRef.current = {
+      x: e.clientX - position.x,
+      y: e.clientY - position.y
+    };
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging) return;
+      
+      setPosition({
+        x: e.clientX - dragStartRef.current.x,
+        y: e.clientY - dragStartRef.current.y
+      });
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging]);
+
+  const handleAddComment = () => {
+    setIsAddingComment(true);
+    setSelectedElement(null);
+    
+    // Add click listener to parent document
+    const handleClick = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      
+      const target = e.target as HTMLElement;
+      
+      // Ignore clicks on the widget itself
+      if (dragRef.current?.contains(target)) {
+        return;
+      }
+      
+      setSelectedElement(target);
+      setIsAddingComment(false);
+      
+      // Remove the listener
+      document.removeEventListener('click', handleClick, true);
+    };
+    
+    // Use capture phase to intercept before other handlers
+    setTimeout(() => {
+      document.addEventListener('click', handleClick, true);
+    }, 100);
+  };
+
+  const handleSubmitComment = async (text: string) => {
+    if (!selectedElement) return;
+    
+    const rect = selectedElement.getBoundingClientRect();
+    const nodeId = getNodeSelector(selectedElement);
+    
+    const commentData: CommentInput = {
+      text,
+      nodeId,
+      x: rect.x / rect.width,
+      y: rect.y / rect.height,
+      page: window.location.pathname,
+      pageTitle: document.title,
+      userAgent: navigator.userAgent,
+      screenWidth: window.innerWidth,
+      screenHeight: window.innerHeight,
+      devicePixelRatio: window.devicePixelRatio,
+      userId,
+      userName,
+      timestamp: new Date().toISOString()
+    };
+    
+    try {
+      const response = await fetch(`${apiUrl}/api/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(commentData)
+      });
+      
+      if (response.ok) {
+        const newComment = await response.json();
+        setComments([...comments, newComment]);
+        setSelectedElement(null);
+      }
+    } catch (error) {
+      console.error('Failed to add comment:', error);
+    }
+  };
+
+  const getNodeSelector = (element: HTMLElement): string => {
+    const path: string[] = [];
+    let current: HTMLElement | null = element;
+    
+    while (current && current !== document.body) {
+      let selector = current.tagName.toLowerCase();
+      
+      if (current.id) {
+        selector += `#${current.id}`;
+      } else {
+        const parent = current.parentElement;
+        if (parent) {
+          const siblings = Array.from(parent.children).filter(
+            child => child.tagName === current!.tagName
+          );
+          if (siblings.length > 1) {
+            const index = siblings.indexOf(current) + 1;
+            selector += `:nth-of-type(${index})`;
+          }
+        }
+      }
+      
+      if (current.className) {
+        selector += `.${current.className.split(' ').filter(Boolean).join('.')}`;
+      }
+      
+      path.unshift(selector);
+      current = current.parentElement;
+    }
+    
+    const cssSelector = 'body>' + path.join('>');
+    const computedSelector = path.length > 0 ? cssSelector + ',' + 'body.' + element.className.split(' ').filter(Boolean).join('.') + '>' + path.join('>') : '';
+    
+    return computedSelector || cssSelector;
+  };
+
+  return (
+    <>
+      {/* Comment markers */}
+      {comments.map(comment => (
+        <CommentMarker key={comment.id} comment={comment} />
+      ))}
+      
+      {/* Main widget */}
+      <div
+        ref={dragRef}
+        className={clsx(
+          'cmux-fixed cmux-bg-white cmux-rounded-lg cmux-shadow-2xl cmux-border cmux-border-neutral-200',
+          isDragging && 'cmux-cursor-grabbing',
+          'cmux-transition-transform'
+        )}
+        style={{
+          transform: `translate(${position.x}px, ${position.y}px)`,
+          width: isOpen ? '360px' : 'auto',
+          height: isOpen ? '480px' : 'auto',
+          maxHeight: '80vh'
+        }}
+        onMouseDown={handleMouseDown}
+      >
+        {!isOpen ? (
+          <button
+            onClick={() => setIsOpen(true)}
+            className="cmux-p-3 cmux-cursor-pointer hover:cmux-bg-neutral-50 cmux-rounded-lg cmux-transition-colors"
+            data-no-drag
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C13.19 22 14.34 21.78 15.41 21.39L21 23L19.39 17.41C20.78 15.34 22 13.19 22 12C22 6.48 17.52 2 12 2ZM7 11H17V13H7V11ZM7 7H17V9H7V7ZM7 15H13V17H7V15Z" fill="currentColor"/>
+            </svg>
+          </button>
+        ) : (
+          <div className="cmux-flex cmux-flex-col cmux-h-full">
+            {/* Header */}
+            <div className="cmux-flex cmux-items-center cmux-justify-between cmux-p-4 cmux-border-b cmux-border-neutral-200 cmux-cursor-grab">
+              <h3 className="cmux-text-lg cmux-font-semibold cmux-text-neutral-900">Comments</h3>
+              <div className="cmux-flex cmux-gap-2" data-no-drag>
+                <button
+                  onClick={handleAddComment}
+                  className={clsx(
+                    'cmux-p-2 cmux-rounded-md cmux-transition-colors',
+                    isAddingComment 
+                      ? 'cmux-bg-blue-500 cmux-text-white' 
+                      : 'hover:cmux-bg-neutral-100'
+                  )}
+                  title="Add comment"
+                >
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M10 4V16M4 10H16" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                  </svg>
+                </button>
+                <button
+                  onClick={() => setIsOpen(false)}
+                  className="cmux-p-2 hover:cmux-bg-neutral-100 cmux-rounded-md cmux-transition-colors"
+                >
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M6 6L14 14M6 14L14 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            
+            {/* Content */}
+            <div className="cmux-flex-1 cmux-overflow-y-auto cmux-p-4" data-no-drag>
+              {selectedElement ? (
+                <CommentForm
+                  onSubmit={handleSubmitComment}
+                  onCancel={() => setSelectedElement(null)}
+                />
+              ) : isAddingComment ? (
+                <div className="cmux-text-center cmux-py-8 cmux-text-neutral-500">
+                  Click on an element to add a comment
+                </div>
+              ) : (
+                <CommentsList comments={comments} />
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+      
+      {/* Visual feedback for selected element */}
+      {selectedElement && (
+        <div
+          className="cmux-fixed cmux-border-2 cmux-border-blue-500 cmux-pointer-events-none cmux-z-[9998]"
+          style={{
+            left: selectedElement.getBoundingClientRect().left + 'px',
+            top: selectedElement.getBoundingClientRect().top + 'px',
+            width: selectedElement.getBoundingClientRect().width + 'px',
+            height: selectedElement.getBoundingClientRect().height + 'px',
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/preview-comments/src/CommentsList.tsx
+++ b/packages/preview-comments/src/CommentsList.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Comment } from './types';
+import clsx from 'clsx';
+
+interface CommentsListProps {
+  comments: Comment[];
+}
+
+export function CommentsList({ comments }: CommentsListProps) {
+  if (comments.length === 0) {
+    return (
+      <div className="cmux-text-center cmux-py-8 cmux-text-neutral-500">
+        No comments yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="cmux-space-y-3">
+      {comments.map(comment => (
+        <div
+          key={comment.id}
+          className={clsx(
+            'cmux-p-3 cmux-rounded-lg cmux-border cmux-border-neutral-200',
+            comment.resolved && 'cmux-opacity-60'
+          )}
+        >
+          <div className="cmux-flex cmux-items-start cmux-justify-between cmux-mb-2">
+            <span className="cmux-text-sm cmux-font-medium cmux-text-neutral-900">
+              {comment.userName}
+            </span>
+            <span className="cmux-text-xs cmux-text-neutral-500">
+              {new Date(comment.timestamp).toLocaleString()}
+            </span>
+          </div>
+          <p className="cmux-text-sm cmux-text-neutral-700">{comment.text}</p>
+          <div className="cmux-mt-2 cmux-text-xs cmux-text-neutral-500">
+            {comment.page}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/preview-comments/src/PreviewCommentsWidget.tsx
+++ b/packages/preview-comments/src/PreviewCommentsWidget.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { CommentsFloatingWidget } from './CommentsFloatingWidget';
+import { styles } from '../dist/styles';
+
+export interface PreviewCommentsWidgetProps {
+  apiUrl?: string;
+  userId?: string;
+  userName?: string;
+}
+
+export function PreviewCommentsWidget({
+  apiUrl = 'http://localhost:9779',
+  userId = 'anonymous',
+  userName = 'Anonymous User'
+}: PreviewCommentsWidgetProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const shadowRootRef = useRef<ShadowRoot | null>(null);
+  const reactRootRef = useRef<Root | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Create shadow root
+    if (!shadowRootRef.current) {
+      shadowRootRef.current = containerRef.current.attachShadow({ mode: 'open' });
+      
+      // Add styles to shadow DOM
+      const styleElement = document.createElement('style');
+      styleElement.textContent = styles;
+      shadowRootRef.current.appendChild(styleElement);
+      
+      // Create container for React
+      const rootDiv = document.createElement('div');
+      rootDiv.id = 'cmux-preview-comments-root';
+      shadowRootRef.current.appendChild(rootDiv);
+      
+      // Create React root in shadow DOM
+      reactRootRef.current = createRoot(rootDiv);
+    }
+
+    // Render the widget
+    if (reactRootRef.current) {
+      reactRootRef.current.render(
+        <CommentsFloatingWidget
+          apiUrl={apiUrl}
+          userId={userId}
+          userName={userName}
+        />
+      );
+    }
+
+    return () => {
+      if (reactRootRef.current) {
+        reactRootRef.current.unmount();
+        reactRootRef.current = null;
+      }
+      shadowRootRef.current = null;
+    };
+  }, [apiUrl, userId, userName]);
+
+  return <div ref={containerRef} style={{ position: 'fixed', zIndex: 9999 }} />;
+}

--- a/packages/preview-comments/src/index.tsx
+++ b/packages/preview-comments/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PreviewCommentsWidget } from './PreviewCommentsWidget';
+
+export interface PreviewCommentsConfig {
+  apiUrl?: string;
+  userId?: string;
+  userName?: string;
+}
+
+export function PreviewComments(config?: PreviewCommentsConfig) {
+  return <PreviewCommentsWidget {...config} />;
+}
+
+export default PreviewComments;

--- a/packages/preview-comments/src/styles.css
+++ b/packages/preview-comments/src/styles.css
@@ -1,0 +1,10 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :host {
+    all: initial;
+    font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  }
+}

--- a/packages/preview-comments/src/types.ts
+++ b/packages/preview-comments/src/types.ts
@@ -1,0 +1,19 @@
+export interface Comment {
+  id: string;
+  text: string;
+  nodeId: string;
+  x: number;
+  y: number;
+  page: string;
+  pageTitle: string;
+  userAgent: string;
+  screenWidth: number;
+  screenHeight: number;
+  devicePixelRatio: number;
+  userId: string;
+  userName: string;
+  timestamp: string;
+  resolved?: boolean;
+}
+
+export interface CommentInput extends Omit<Comment, 'id'> {}

--- a/packages/preview-comments/tailwind.config.js
+++ b/packages/preview-comments/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  prefix: "cmux-",
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+  corePlugins: {
+    preflight: false,
+  },
+};

--- a/packages/preview-comments/tsconfig.json
+++ b/packages/preview-comments/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
help me set up a new package called @cmux/preview-comments it should be a react app. then i want to import it in the @cmux/www package to render it in the main layout page; it should be a floating widget that can be dragged around, similar to the vercel comments widget. make sure to use tailwind, and ensure that just importing the component works without having to set up tailwind stuff to point towards our internal node modules stuff or having to import another css file. we need to set up the comments stuff with shadow realm + tailwind reset + ensure tailwind styles work properly and don't conflict with the parent app, even if parent app uses tailwind. the comments widget should talk to port 9779 by default, with the hono openapi thing. for now, just store comments in memory of the hono server. the create/mutation endpoint for each comment needs to include stuff like: { "id": "77HUQ", "nodeId": "body>div>section>div>div:nth-of-type(2)>a:nth-of-type(2),body.__className_e8ce0c>div.min-h-screen>section.pt-24>div.max-w-4xl>div.flex:nth-of-type(2)>a.inline-flex:nth-of-type(2)", "x": 0.7234354628422425, "y": 0.483695652173913, "page": "/", "pageTitle": "cmux - Orchestrate AI coding agents in parallel", "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36", "screenWidth": 1763, "screenHeight": 1328, "devicePixelRatio": 2}Also each comment needs to be relative to certain elements; the x and y are kinda like ratios inside the nodeId itself. This way we can support different screen sizes well.