### PR TITLE
Remove GitHub token from settings and Convex

### DIFF
--- a/apps/client/src/components/provider-status-pills.tsx
+++ b/apps/client/src/components/provider-status-pills.tsx
@@ -46,14 +46,14 @@ export function ProviderStatusPills() {
   const gitNotReady = !status.gitStatus?.isAvailable;
   const dockerImageNotReady = status.dockerStatus?.workerImage && !status.dockerStatus.workerImage.isAvailable;
   const dockerImagePulling = status.dockerStatus?.workerImage?.isPulling;
-  const githubNotConfigured = !status.githubStatus?.hasToken;
+  // GitHub token configuration is no longer surfaced in UI
 
   // Count total available and unavailable providers
   const totalProviders = status.providers?.length ?? 0;
   const availableProviders = totalProviders - unavailableProviders.length;
 
   // If everything is ready, don't show anything
-  if (unavailableProviders.length === 0 && !dockerNotReady && !gitNotReady && !dockerImageNotReady && !githubNotConfigured) {
+  if (unavailableProviders.length === 0 && !dockerNotReady && !gitNotReady && !dockerImageNotReady) {
     return null;
   }
 
@@ -106,7 +106,6 @@ export function ProviderStatusPills() {
                   <p>• Docker image {status.dockerStatus?.workerImage?.name} is pulling...</p>
                 )}
                 {gitNotReady && <p>• Git installation required</p>}
-                {githubNotConfigured && <p>• GitHub PAT token configuration needed</p>}
                 {unavailableProviders.length > 0 && (
                   <p>
                     • {unavailableProviders.length} AI provider
@@ -202,30 +201,7 @@ export function ProviderStatusPills() {
             </Tooltip>
           )}
 
-          {githubNotConfigured && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={() => navigate({ to: "/settings" })}
-                  className={clsx(
-                    "flex items-center gap-1.5 px-2.5 py-1 rounded-lg",
-                    "bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-600",
-                    "text-neutral-800 dark:text-neutral-200",
-                    "text-xs font-medium cursor-default select-none"
-                  )}
-                >
-                  <div className="w-1.5 h-1.5 rounded-full bg-amber-500"></div>
-                  Add GitHub token
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="font-medium">Optional: Configure GitHub Personal Access Token</p>
-                <p className="text-xs opacity-90">
-                  Configure your GitHub Personal Access Token to enable automatic PR creation and repository management
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          )}
+          {/* GitHub token pill removed */}
         </div>
       </TooltipProvider>
     </div>

--- a/apps/client/src/routes/_layout.settings.tsx
+++ b/apps/client/src/routes/_layout.settings.tsx
@@ -209,11 +209,6 @@ function SettingsComponent() {
     // Check worktree path changes
     const worktreePathChanged = worktreePath !== originalWorktreePath;
 
-    // Check GitHub token changes
-    const githubTokenChanged =
-      (apiKeyValues["GITHUB_TOKEN"] || "") !==
-      (originalApiKeyValues["GITHUB_TOKEN"] || "");
-
     // Check all required API keys for changes
     const apiKeysChanged = apiKeys.some((keyConfig) => {
       const currentValue = apiKeyValues[keyConfig.envVar] || "";
@@ -234,7 +229,6 @@ function SettingsComponent() {
     return (
       worktreePathChanged ||
       autoPrChanged ||
-      githubTokenChanged ||
       apiKeysChanged ||
       containerSettingsChanged
     );
@@ -274,27 +268,7 @@ function SettingsComponent() {
         setOriginalContainerSettingsData(containerSettingsData);
       }
 
-      // Save GitHub token if changed
-      const githubTokenValue = apiKeyValues["GITHUB_TOKEN"] || "";
-      const originalGithubTokenValue =
-        originalApiKeyValues["GITHUB_TOKEN"] || "";
-
-      if (githubTokenValue !== originalGithubTokenValue) {
-        if (githubTokenValue.trim()) {
-          await saveApiKeyMutation.mutateAsync({
-            envVar: "GITHUB_TOKEN",
-            value: githubTokenValue.trim(),
-            displayName: "GitHub Personal Access Token",
-            description: "Used for creating pull requests via GitHub CLI",
-          });
-          savedCount++;
-        } else if (originalGithubTokenValue) {
-          await convex.mutation(api.apiKeys.remove, {
-            envVar: "GITHUB_TOKEN",
-          });
-          deletedCount++;
-        }
-      }
+      // Note: GitHub token is no longer managed via settings/Convex
 
       for (const key of apiKeys) {
         const value = apiKeyValues[key.envVar] || "";
@@ -468,89 +442,7 @@ function SettingsComponent() {
               </div>
             </div>
 
-            {/* GitHub Authentication */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  GitHub Authentication
-                </h2>
-              </div>
-              <div className="p-4">
-                <div className="space-y-1">
-                  <label
-                    htmlFor="GITHUB_TOKEN"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
-                  >
-                    GitHub Personal Access Token
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                    Required for creating pull requests. Create a token at{" "}
-                    <a
-                      href="https://github.com/settings/tokens/new"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-500 hover:text-blue-600"
-                    >
-                      github.com/settings/tokens
-                    </a>{" "}
-                    with 'repo' and 'pull_request' scopes.
-                  </p>
-                  <div className="relative mt-2">
-                    <input
-                      type={showKeys["GITHUB_TOKEN"] ? "text" : "password"}
-                      id="GITHUB_TOKEN"
-                      value={apiKeyValues["GITHUB_TOKEN"] || ""}
-                      onChange={(e) =>
-                        handleApiKeyChange("GITHUB_TOKEN", e.target.value)
-                      }
-                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100"
-                      placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => toggleShowKey("GITHUB_TOKEN")}
-                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-neutral-500"
-                    >
-                      {showKeys["GITHUB_TOKEN"] ? (
-                        <svg
-                          className="h-5 w-5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                          />
-                        </svg>
-                      ) : (
-                        <svg
-                          className="h-5 w-5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                          />
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                          />
-                        </svg>
-                      )}
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
+            {/* GitHub Authentication removed: GitHub token is no longer managed here */}
 
             {/* AI Provider Authentication */}
             <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">

--- a/apps/server/src/utils/providerStatus.ts
+++ b/apps/server/src/utils/providerStatus.ts
@@ -16,7 +16,7 @@ const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null;
 
 async function checkGitHubStatus(): Promise<GitHubStatus> {
   try {
-    const token = await getGitHubTokenFromKeychain(convex || undefined);
+    const token = await getGitHubTokenFromKeychain();
     return {
       isConfigured: !!token,
       hasToken: !!token,

--- a/apps/server/src/vscode/DockerVSCodeInstance.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.ts
@@ -749,7 +749,7 @@ export class DockerVSCodeInstance extends VSCodeInstance {
       const githubToken = await getGitHubTokenFromKeychain(convex);
       if (!githubToken) {
         dockerLogger.info(
-          "No GitHub token found on host (Convex, gh, or keychain) - skipping gh auth setup"
+          "No GitHub token found via gh CLI or env - skipping gh auth setup"
         );
         return;
       }


### PR DESCRIPTION
Get rid of GitHub token in the settings as well as storing it in Convex entirely. In the getGitCredentials function, we also don't want to retrieve it from Convex either.