### PR TITLE
test(archive-task): add tests for stopping Docker containers + fix impl

### DIFF
--- a/apps/server/src/archiveTask.morph.test.ts
+++ b/apps/server/src/archiveTask.morph.test.ts
@@ -1,0 +1,89 @@
+import { api } from "@cmux/convex/api";
+import { typedZid } from "@cmux/shared/utils/typed-zid";
+import type { FunctionReturnType } from "convex/server";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock morphcloud before importing the module under test
+vi.mock("morphcloud", () => {
+  const pauseMock = vi.fn(async () => {});
+  const getMock = vi.fn(async (_args: { instanceId: string }) => ({
+    pause: pauseMock,
+  }));
+  class MorphCloudClient {
+    instances = { get: getMock };
+  }
+  return { MorphCloudClient, testing: { pauseMock, getMock } };
+});
+
+// Silence file logging
+vi.mock("./utils/fileLogger.js", () => ({
+  serverLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    close: vi.fn(),
+  },
+  dockerLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    close: vi.fn(),
+  },
+}));
+
+import * as morphMod from "morphcloud";
+import { stopContainersForRunsFromTree } from "./archiveTask.js";
+
+describe("stopContainersForRunsFromTree - morph path", () => {
+  it("pauses morph instance for morph provider runs", async () => {
+    const zidRun = typedZid("taskRuns");
+    const zidTask = typedZid("tasks");
+    const now = Date.now();
+    const instanceId = "morphvm_test_instance";
+
+    const tree = [
+      {
+        _id: zidRun.parse("rm1"),
+        _creationTime: now,
+        taskId: zidTask.parse("tm1"),
+        prompt: "p",
+        status: "running",
+        log: "",
+        createdAt: now,
+        updatedAt: now,
+        vscode: {
+          provider: "morph",
+          status: "running",
+          containerName: instanceId,
+        },
+        children: [],
+      },
+    ] satisfies FunctionReturnType<typeof api.taskRuns.getByTask>;
+
+    const results = await stopContainersForRunsFromTree(tree, "tm1");
+    expect(results).toHaveLength(1);
+    expect(results[0]?.success).toBe(true);
+
+    const testing = Reflect.get(morphMod as object, "testing");
+    if (
+      typeof testing === "object" &&
+      testing !== null &&
+      typeof Reflect.get(testing as object, "pauseMock") === "function" &&
+      typeof Reflect.get(testing as object, "getMock") === "function"
+    ) {
+      const pauseMock = Reflect.get(testing as object, "pauseMock");
+      const getMock = Reflect.get(testing as object, "getMock");
+      expect(getMock as (...args: unknown[]) => unknown).toHaveBeenCalledTimes(
+        1
+      );
+      const firstCallArgs = (getMock as { mock: { calls: unknown[][] } }).mock
+        .calls[0] as [{ instanceId: string }];
+      expect(firstCallArgs[0]?.instanceId).toBe(instanceId);
+      expect(
+        pauseMock as (...args: unknown[]) => unknown
+      ).toHaveBeenCalledTimes(1);
+    } else {
+      throw new Error("Morph mock not found");
+    }
+  });
+});

--- a/apps/server/src/archiveTask.test.ts
+++ b/apps/server/src/archiveTask.test.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
-
-// Mock Convex client used by the server
-vi.mock("./utils/convexClient.js", () => {
-  return {
-    convex: {
-      // Will be customized per-test
-      query: vi.fn(),
-      mutation: vi.fn(),
-    },
-  };
-});
+import { api } from "@cmux/convex/api";
+import { typedZid } from "@cmux/shared/utils/typed-zid";
+import type { FunctionReturnType } from "convex/server";
+import { exec as _exec } from "node:child_process";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { stopContainersForRunsFromTree } from "./archiveTask.js";
 
 // Quiet logger output during tests
 vi.mock("./utils/fileLogger.js", () => ({
@@ -27,155 +22,131 @@ vi.mock("./utils/fileLogger.js", () => ({
   },
 }));
 
-// Avoid waiting for external services on startup
-vi.mock("./utils/waitForConvex.js", () => ({
-  waitForConvex: vi.fn(async () => {}),
-}));
+const execAsync = promisify(_exec);
 
-// No-op container state sync during tests
-vi.mock("./vscode/DockerVSCodeInstance.js", () => ({
-  DockerVSCodeInstance: {
-    startContainerStateSync: vi.fn(),
-    stopContainerStateSync: vi.fn(),
-  },
-}));
+async function docker(
+  cmd: string
+): Promise<{ stdout: string; stderr: string }> {
+  return execAsync(cmd, { timeout: 30_000 });
+}
 
-// No-op GitHub refresh on server start
-vi.mock("./utils/refreshGitHubData.js", () => ({
-  refreshGitHubData: vi.fn(async () => {}),
-  refreshBranchesForRepo: vi.fn(async () => {}),
-}));
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
 
-// Stub child_process.exec that server.ts promisifies to execAsync
-// We capture docker commands to assert behavior.
-const execCalls: string[] = [];
-vi.mock("node:child_process", async () => {
-  return {
-    exec: (
-      command: string,
-      optionsOrCb?: any,
-      maybeCb?: (error: any, stdout: string, stderr: string) => void
-    ) => {
-      const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
-      // Record every command for later assertions
-      execCalls.push(command);
-
-      // Short-circuit a few commands used by the server
-      if (command.startsWith("ulimit -n")) {
-        cb?.(null, "10240\n", "");
-        return {} as any;
-      }
-
-      if (command.startsWith("docker stop")) {
-        // Simulate an error for a specific container to test the fallback path
-        if (command.includes("cmux-exited")) {
-          const err = new Error("No such container");
-          // execAsync would reject; emulate callback error
-          cb?.(err as any, "", "Error response from daemon: No such container\n");
-        } else {
-          cb?.(null, "stopped\n", "");
-        }
-        return {} as any;
-      }
-
-      if (command.startsWith("docker ps -a")) {
-        // Return an exited status so the server treats it as already stopped
-        cb?.(null, "Exited (0) 2 hours ago\n", "");
-        return {} as any;
-      }
-
-      // Default noop
-      cb?.(null, "", "");
-      return {} as any;
-    },
-    spawn: vi.fn(),
-  };
-});
-
-// After mocks: import server and socket client
-import { startServer } from "./server.js";
-import { io as ioc } from "socket.io-client";
-import { convex } from "./utils/convexClient.js";
-
-describe.sequential("archive-task stops Docker containers", () => {
-  const PORT = 4091;
-  let cleanup: (() => Promise<void>) | undefined;
+describe.sequential("stopContainersForRuns (docker E2E)", () => {
+  const containers: string[] = [];
+  const zidRun = typedZid("taskRuns");
+  const zidTask = typedZid("tasks");
+  const now = Date.now();
 
   beforeAll(async () => {
-    const srv = await startServer({
-      port: PORT,
-      publicPath: "/",
-      defaultRepo: null,
-    });
-    cleanup = srv.cleanup;
-  }, 20_000);
+    // Ensure image exists; pull is idempotent
+    await docker("docker pull alpine:3");
+  }, 120_000);
 
   afterAll(async () => {
-    if (cleanup) await cleanup();
-  }, 20_000);
+    // Cleanup any leftover containers
+    for (const name of containers) {
+      try {
+        await docker(`docker rm -f ${name}`);
+      } catch {
+        // ignore
+      }
+    }
+  }, 60_000);
 
-  it("emits archive-task and calls docker stop for each run", async () => {
-    // Arrange Convex to return test task runs
-    const taskId = "t-1" as any;
-    const runs = [
+  it("stops running containers and treats exited as success", async () => {
+    const runA = `cmux-test-a-${randomSuffix()}`;
+    const runB = `cmux-test-b-${randomSuffix()}`;
+    const alreadyExited = `cmux-test-exited-${randomSuffix()}`;
+    containers.push(runA, runB, alreadyExited);
+
+    // Start two long-running containers
+    await docker(`docker run -d --name ${runA} alpine:3 sh -c 'sleep 300'`);
+    await docker(`docker run -d --name ${runB} alpine:3 sh -c 'sleep 300'`);
+    // Create an exited container
+    await docker(`docker run --name ${alreadyExited} alpine:3 sh -c 'true'`);
+
+    const tree = [
       {
-        _id: "run1",
-        vscode: { provider: "docker", containerName: "cmux-a" },
+        _id: zidRun.parse("r1"),
+        _creationTime: now,
+        taskId: zidTask.parse("t-e2e"),
+        prompt: "p",
+        status: "running",
+        log: "",
+        createdAt: now,
+        updatedAt: now,
+        vscode: { provider: "docker", status: "running", containerName: runA },
+        children: [
+          {
+            _id: zidRun.parse("r2"),
+            _creationTime: now,
+            taskId: zidTask.parse("t-e2e"),
+            prompt: "p",
+            status: "running",
+            log: "",
+            createdAt: now,
+            updatedAt: now,
+            vscode: {
+              provider: "docker",
+              status: "stopped",
+              containerName: alreadyExited,
+            },
+            children: [],
+          },
+        ],
       },
       {
-        _id: "run2",
-        vscode: { provider: "docker", containerName: "cmux-exited" }, // will exercise fallback path
+        _id: zidRun.parse("r3"),
+        _creationTime: now,
+        taskId: zidTask.parse("t-e2e"),
+        prompt: "p",
+        status: "running",
+        log: "",
+        createdAt: now,
+        updatedAt: now,
+        vscode: { provider: "docker", status: "running", containerName: runB },
+        children: [],
       },
+    ] satisfies FunctionReturnType<typeof api.taskRuns.getByTask>;
+
+    const results = await stopContainersForRunsFromTree(tree, "t-e2e");
+
+    // All three should be reported success
+    expect(results.every((r) => r.success)).toBe(true);
+
+    // Verify stopped state for runA and runB
+    const { stdout: aState } = await docker(
+      `docker inspect -f '{{.State.Running}} {{.State.Status}}' ${runA}`
+    );
+    const { stdout: bState } = await docker(
+      `docker inspect -f '{{.State.Running}} {{.State.Status}}' ${runB}`
+    );
+    expect(aState.trim()).toMatch(/false\s+(exited|created)/);
+    expect(bState.trim()).toMatch(/false\s+(exited|created)/);
+  }, 120_000);
+
+  it("returns failure for non-existent containers", async () => {
+    const missing = `cmux-test-missing-${randomSuffix()}`;
+
+    const treeMissing = [
       {
-        _id: "run3",
-        vscode: { provider: "docker", containerName: "cmux-b" },
+        _id: zidRun.parse("r4"),
+        _creationTime: now,
+        taskId: zidTask.parse("t-missing"),
+        prompt: "p",
+        status: "running",
+        log: "",
+        createdAt: now,
+        updatedAt: now,
+        vscode: { provider: "docker", status: "running", containerName: missing },
+        children: [],
       },
-    ];
+    ] satisfies FunctionReturnType<typeof api.taskRuns.getByTask>;
 
-    (convex.query as any).mockImplementation(async (_fn: unknown, args: any) => {
-      if (args && args.taskId === taskId) return runs;
-      return [];
-    });
-
-    // Connect a socket client and emit the event
-    const socket = ioc(`http://localhost:${PORT}`, {
-      transports: ["websocket"],
-      extraHeaders: { Origin: "http://localhost:5173" },
-      forceNew: true,
-      reconnectionAttempts: 3,
-      reconnectionDelay: 50,
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("socket connect timeout")), 5000);
-      socket.on("connect", () => {
-        clearTimeout(timer);
-        resolve();
-      });
-      socket.on("connect_error", reject);
-    });
-
-    const response = await new Promise<{ success: boolean; error?: string }>((resolve) => {
-      socket.emit("archive-task", { taskId }, (res: { success: boolean; error?: string }) => {
-        resolve(res);
-      });
-    });
-
-    socket.close();
-
-    expect(response.success).toBe(true);
-
-    // Assert that docker stop was called for each docker run
-    const stopCalls = execCalls.filter((c) => c.startsWith("docker stop"));
-    expect(stopCalls).toEqual([
-      "docker stop cmux-a",
-      "docker stop cmux-exited",
-      "docker stop cmux-b",
-    ]);
-
-    // Also ensure we checked status for the exited one
-    const psChecks = execCalls.filter((c) => c.startsWith("docker ps -a"));
-    expect(psChecks.some((c) => c.includes("cmux-exited"))).toBe(true);
-  }, 20_000);
+    const results = await stopContainersForRunsFromTree(treeMissing, "t-missing");
+    expect(results[0]?.success).toBe(false);
+  }, 60_000);
 });
-

--- a/apps/server/src/archiveTask.test.ts
+++ b/apps/server/src/archiveTask.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+
+// Mock Convex client used by the server
+vi.mock("./utils/convexClient.js", () => {
+  return {
+    convex: {
+      // Will be customized per-test
+      query: vi.fn(),
+      mutation: vi.fn(),
+    },
+  };
+});
+
+// Quiet logger output during tests
+vi.mock("./utils/fileLogger.js", () => ({
+  serverLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    close: vi.fn(),
+  },
+  dockerLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    close: vi.fn(),
+  },
+}));
+
+// Avoid waiting for external services on startup
+vi.mock("./utils/waitForConvex.js", () => ({
+  waitForConvex: vi.fn(async () => {}),
+}));
+
+// No-op container state sync during tests
+vi.mock("./vscode/DockerVSCodeInstance.js", () => ({
+  DockerVSCodeInstance: {
+    startContainerStateSync: vi.fn(),
+    stopContainerStateSync: vi.fn(),
+  },
+}));
+
+// No-op GitHub refresh on server start
+vi.mock("./utils/refreshGitHubData.js", () => ({
+  refreshGitHubData: vi.fn(async () => {}),
+  refreshBranchesForRepo: vi.fn(async () => {}),
+}));
+
+// Stub child_process.exec that server.ts promisifies to execAsync
+// We capture docker commands to assert behavior.
+const execCalls: string[] = [];
+vi.mock("node:child_process", async () => {
+  return {
+    exec: (
+      command: string,
+      optionsOrCb?: any,
+      maybeCb?: (error: any, stdout: string, stderr: string) => void
+    ) => {
+      const cb = typeof optionsOrCb === "function" ? optionsOrCb : maybeCb;
+      // Record every command for later assertions
+      execCalls.push(command);
+
+      // Short-circuit a few commands used by the server
+      if (command.startsWith("ulimit -n")) {
+        cb?.(null, "10240\n", "");
+        return {} as any;
+      }
+
+      if (command.startsWith("docker stop")) {
+        // Simulate an error for a specific container to test the fallback path
+        if (command.includes("cmux-exited")) {
+          const err = new Error("No such container");
+          // execAsync would reject; emulate callback error
+          cb?.(err as any, "", "Error response from daemon: No such container\n");
+        } else {
+          cb?.(null, "stopped\n", "");
+        }
+        return {} as any;
+      }
+
+      if (command.startsWith("docker ps -a")) {
+        // Return an exited status so the server treats it as already stopped
+        cb?.(null, "Exited (0) 2 hours ago\n", "");
+        return {} as any;
+      }
+
+      // Default noop
+      cb?.(null, "", "");
+      return {} as any;
+    },
+    spawn: vi.fn(),
+  };
+});
+
+// After mocks: import server and socket client
+import { startServer } from "./server.js";
+import { io as ioc } from "socket.io-client";
+import { convex } from "./utils/convexClient.js";
+
+describe.sequential("archive-task stops Docker containers", () => {
+  const PORT = 4091;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(async () => {
+    const srv = await startServer({
+      port: PORT,
+      publicPath: "/",
+      defaultRepo: null,
+    });
+    cleanup = srv.cleanup;
+  }, 20_000);
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  }, 20_000);
+
+  it("emits archive-task and calls docker stop for each run", async () => {
+    // Arrange Convex to return test task runs
+    const taskId = "t-1" as any;
+    const runs = [
+      {
+        _id: "run1",
+        vscode: { provider: "docker", containerName: "cmux-a" },
+      },
+      {
+        _id: "run2",
+        vscode: { provider: "docker", containerName: "cmux-exited" }, // will exercise fallback path
+      },
+      {
+        _id: "run3",
+        vscode: { provider: "docker", containerName: "cmux-b" },
+      },
+    ];
+
+    (convex.query as any).mockImplementation(async (_fn: unknown, args: any) => {
+      if (args && args.taskId === taskId) return runs;
+      return [];
+    });
+
+    // Connect a socket client and emit the event
+    const socket = ioc(`http://localhost:${PORT}`, {
+      transports: ["websocket"],
+      extraHeaders: { Origin: "http://localhost:5173" },
+      forceNew: true,
+      reconnectionAttempts: 3,
+      reconnectionDelay: 50,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("socket connect timeout")), 5000);
+      socket.on("connect", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      socket.on("connect_error", reject);
+    });
+
+    const response = await new Promise<{ success: boolean; error?: string }>((resolve) => {
+      socket.emit("archive-task", { taskId }, (res: { success: boolean; error?: string }) => {
+        resolve(res);
+      });
+    });
+
+    socket.close();
+
+    expect(response.success).toBe(true);
+
+    // Assert that docker stop was called for each docker run
+    const stopCalls = execCalls.filter((c) => c.startsWith("docker stop"));
+    expect(stopCalls).toEqual([
+      "docker stop cmux-a",
+      "docker stop cmux-exited",
+      "docker stop cmux-b",
+    ]);
+
+    // Also ensure we checked status for the exited one
+    const psChecks = execCalls.filter((c) => c.startsWith("docker ps -a"));
+    expect(psChecks.some((c) => c.includes("cmux-exited"))).toBe(true);
+  }, 20_000);
+});
+

--- a/apps/server/src/archiveTask.ts
+++ b/apps/server/src/archiveTask.ts
@@ -1,0 +1,144 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { serverLogger } from "./utils/fileLogger.js";
+import { convex } from "./utils/convexClient.js";
+import { api } from "@cmux/convex/api";
+import type { FunctionReturnType } from "convex/server";
+import type { Id } from "@cmux/convex/dataModel";
+import { MorphCloudClient } from "morphcloud";
+
+const execAsync = promisify(exec);
+
+export type VSCodeProvider = "docker" | "morph" | "daytona" | "other";
+
+export interface StopResult {
+  success: boolean;
+  containerName: string;
+  provider: VSCodeProvider;
+  error?: unknown;
+}
+
+async function stopDockerContainer(containerName: string): Promise<void> {
+  try {
+    await execAsync(`docker stop ${containerName}`, { timeout: 15_000 });
+    return;
+  } catch (err) {
+    // If docker stop failed, check if it's already exited/stopped
+    try {
+      const { stdout } = await execAsync(
+        `docker ps -a --filter "name=${containerName}" --format "{{.Status}}"`
+      );
+      if (stdout.toLowerCase().includes("exited")) {
+        // Consider success if the container is already stopped
+        return;
+      }
+    } catch {
+      // ignore check errors and rethrow original
+    }
+    throw err;
+  }
+}
+
+async function pauseMorphInstance(instanceId: string): Promise<void> {
+  const client = new MorphCloudClient();
+  const instance = await client.instances.get({ instanceId });
+  await instance.pause();
+}
+
+export async function stopContainersForRuns(
+  taskId: Id<"tasks">,
+  query: (
+    ref: typeof api.taskRuns.getByTask,
+    args: { taskId: Id<"tasks"> }
+  ) => Promise<FunctionReturnType<typeof api.taskRuns.getByTask>> = (ref, args) =>
+    convex.query(ref, args)
+): Promise<StopResult[]> {
+  const tree = await query(api.taskRuns.getByTask, { taskId });
+  return stopContainersForRunsFromTree(tree, String(taskId));
+}
+
+export function stopContainersForRunsFromTree(
+  tree: FunctionReturnType<typeof api.taskRuns.getByTask>,
+  taskIdLabel?: string
+): Promise<StopResult[]> {
+  // Flatten tree without casts
+  const flat: unknown[] = [];
+  const walk = (nodes: unknown): void => {
+    if (!Array.isArray(nodes)) return;
+    for (const n of nodes) {
+      flat.push(n);
+      if (typeof n === "object" && n !== null) {
+        const children = Reflect.get(Object(n), "children");
+        walk(children);
+      }
+    }
+  };
+  walk(tree);
+
+  if (typeof taskIdLabel === "string") {
+    serverLogger.info(
+      `Archiving task ${taskIdLabel} with ${flat.length} runs`
+    );
+  }
+
+  // Collect valid docker/morph targets
+  const targets: { provider: VSCodeProvider; containerName: string; runId: string }[] = [];
+  for (const r of flat) {
+    if (typeof r !== "object" || r === null) continue;
+    const vscode = Reflect.get(Object(r), "vscode");
+    const runId = Reflect.get(Object(r), "_id");
+    const provider =
+      typeof vscode === "object" && vscode !== null
+        ? Reflect.get(Object(vscode), "provider")
+        : undefined;
+    const name =
+      typeof vscode === "object" && vscode !== null
+        ? Reflect.get(Object(vscode), "containerName")
+        : undefined;
+
+    if (provider === "docker" && typeof name === "string" && typeof runId === "string") {
+      targets.push({ provider: "docker", containerName: name, runId });
+    } else if (provider === "morph" && typeof name === "string" && typeof runId === "string") {
+      targets.push({ provider: "morph", containerName: name, runId });
+    }
+  }
+
+  return Promise.all(
+    targets.map(async (t): Promise<StopResult> => {
+      try {
+        serverLogger.info(
+          `Stopping ${t.provider} container for run ${t.runId}: ${t.containerName}`
+        );
+        if (t.provider === "docker") {
+          await stopDockerContainer(t.containerName);
+          serverLogger.info(
+            `Successfully stopped Docker container: ${t.containerName}`
+          );
+          return { success: true, containerName: t.containerName, provider: t.provider };
+        }
+        if (t.provider === "morph") {
+          await pauseMorphInstance(t.containerName);
+          serverLogger.info(
+            `Successfully paused Morph instance: ${t.containerName}`
+          );
+          return { success: true, containerName: t.containerName, provider: t.provider };
+        }
+        serverLogger.warn(
+          `Unsupported provider '${t.provider}' for container ${t.containerName}`
+        );
+        return {
+          success: false,
+          containerName: t.containerName,
+          provider: t.provider,
+          error: new Error("Unsupported provider"),
+        };
+      } catch (error) {
+        serverLogger.error(
+          `Failed to stop ${t.provider} container ${t.containerName}:`,
+          error
+        );
+        return { success: false, containerName: t.containerName, provider: t.provider, error };
+      }
+    })
+  );
+}


### PR DESCRIPTION
- Verify `archive-task` socket event stops associated Docker containers
- Mock `child_process.exec` to capture and assert `docker stop` calls
- Include a test case for containers that are already exited
- Use `socket.io-client` to simulate client interaction