### PR TITLE
Implement deterministic task completion for opencode models

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -33,6 +33,7 @@ import { checkDockerReadiness } from "./checkDockerReadiness.js";
 import { detectTerminalIdle } from "./detectTerminalIdle.js";
 import { FileWatcher, computeGitDiff, getFileWithDiff } from "./fileWatcher.js";
 import { startAmpProxy } from "@cmux/shared/src/providers/amp/proxy";
+import { startOpencodeProxy } from "@cmux/shared/src/providers/opencode/proxy";
 import { log } from "./logger.js";
 
 const execAsync = promisify(exec);
@@ -1432,6 +1433,13 @@ httpServer.listen(WORKER_PORT, () => {
 // Start AMP proxy via shared provider module
 startAmpProxy({
   ampUrl: process.env.AMP_URL,
+  workerId: WORKER_ID,
+  emitToMainServer: emitToMainServer,
+});
+
+// Start OpenCode proxy (detect completion by inspecting responses)
+startOpencodeProxy({
+  upstreamUrl: process.env.OPENCODE_UPSTREAM_URL || "http://127.0.0.1:4096",
   workerId: WORKER_ID,
   emitToMainServer: emitToMainServer,
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -83,6 +83,15 @@
       "import": "./src/providers/opencode/completion-detector.ts",
       "types": "./src/providers/opencode/completion-detector.ts"
     }
+    ,
+    "./src/providers/opencode/event-detector": {
+      "import": "./src/providers/opencode/event-detector.ts",
+      "types": "./src/providers/opencode/event-detector.ts"
+    },
+    "./src/providers/opencode/event-detector.ts": {
+      "import": "./src/providers/opencode/event-detector.ts",
+      "types": "./src/providers/opencode/event-detector.ts"
+    }
   },
   "dependencies": {
     "@cmux/convex": "workspace:*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,14 @@
       "import": "./src/index.ts",
       "types": "./src/index.ts"
     },
+    "./src/providers/opencode/proxy": {
+      "import": "./src/providers/opencode/proxy.ts",
+      "types": "./src/providers/opencode/proxy.ts"
+    },
+    "./src/providers/opencode/proxy.ts": {
+      "import": "./src/providers/opencode/proxy.ts",
+      "types": "./src/providers/opencode/proxy.ts"
+    },
     "./src/providers/amp/proxy": {
       "import": "./src/providers/amp/proxy.ts",
       "types": "./src/providers/amp/proxy.ts"

--- a/packages/shared/src/providers/opencode/environment.ts
+++ b/packages/shared/src/providers/opencode/environment.ts
@@ -1,6 +1,6 @@
 import type { EnvironmentContext, EnvironmentResult } from "../common/environment-result.js";
 
-export async function getOpencodeEnvironment(_ctx: EnvironmentContext): Promise<EnvironmentResult> {
+export async function getOpencodeEnvironment(ctx: EnvironmentContext): Promise<EnvironmentResult> {
   const { readFile } = await import("node:fs/promises");
   const { homedir } = await import("node:os");
   const { Buffer } = await import("node:buffer");
@@ -24,6 +24,11 @@ export async function getOpencodeEnvironment(_ctx: EnvironmentContext): Promise<
   } catch (error) {
     console.warn("Failed to read opencode auth.json:", error);
   }
+
+  // Route OpenCode SDK/CLI through our local proxy with a per-task prefix.
+  // The proxy listens on http://localhost:39380 and expects /task/<taskRunId>/... paths
+  // so it can attribute completion events to the correct task.
+  env.OPENCODE_URL = `http://localhost:39380/task/${ctx.taskRunId}`;
 
   return { files, env, startupCommands };
 }

--- a/packages/shared/src/providers/opencode/event-detector.ts
+++ b/packages/shared/src/providers/opencode/event-detector.ts
@@ -1,0 +1,183 @@
+import { promises as fsp } from "node:fs";
+import { watch, createReadStream, type FSWatcher } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+type StopFn = () => void;
+
+function getOpencodeLogDirs(): string[] {
+  const home = os.homedir();
+  return [
+    path.join(home, ".local", "share", "opencode", "log"),
+    path.join(home, ".config", "opencode", "log"),
+    path.join(home, ".opencode", "log"),
+  ];
+}
+
+function isIdleEvent(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  // Fast substring check first
+  if (/session\.idle/i.test(trimmed)) return true;
+  // Try parse JSON if it looks like JSON
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const obj = JSON.parse(trimmed) as any;
+      const event = obj.event || obj.payload || obj;
+      const type = String(event?.type || event?.Type || "").toLowerCase();
+      if (type === "session.idle" || type.endsWith("session.idle")) return true;
+    } catch {
+      // ignore
+    }
+  }
+  // Also match common key=value formats
+  if (/type\s*=\s*session\.idle/i.test(trimmed)) return true;
+  return false;
+}
+
+/**
+ * Watch OpenCode log files for a session.idle event and invoke onComplete immediately.
+ * - Watches known log directories under the user home directory
+ * - Attaches file watchers to existing .log files and streams appended bytes
+ * - Also watches the directory to attach to newly created log files
+ */
+export function watchOpencodeLogsForCompletion(options: {
+  sinceMs?: number; // optional lower bound on event time (best-effort)
+  onComplete: () => void | Promise<void>;
+  onError?: (error: Error) => void;
+}): StopFn {
+  const { sinceMs = 0, onComplete, onError } = options;
+  let stopped = false;
+  const dirWatchers: FSWatcher[] = [];
+  const fileWatchers: Map<string, FSWatcher> = new Map();
+  const lastSizes: Map<string, number> = new Map();
+
+  // Simple line splitter for appended text chunks
+  const buffers: Map<string, string> = new Map();
+  const feed = (file: string, chunk: string) => {
+    const prev = buffers.get(file) || "";
+    const data = prev + chunk;
+    const lines = data.split(/\r?\n/);
+    buffers.set(file, lines.pop() || "");
+    for (const line of lines) {
+      try {
+        if (isIdleEvent(line)) {
+          // Optional crude timestamp gate: if the line contains ISO-like ts and is older than sinceMs, ignore
+          const match = line.match(/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})/);
+          if (match && match[1]) {
+            const ts = Date.parse(match[1]);
+            if (!Number.isNaN(ts) && ts < sinceMs) continue;
+          }
+          if (!stopped) {
+            stopped = true;
+            stop();
+            Promise.resolve(onComplete()).catch((e) =>
+              onError?.(e instanceof Error ? e : new Error(String(e)))
+            );
+            return;
+          }
+        }
+      } catch (e) {
+        onError?.(e instanceof Error ? e : new Error(String(e)));
+      }
+    }
+  };
+
+  const attachFileWatcher = async (filePath: string) => {
+    if (stopped || fileWatchers.has(filePath)) return;
+    try {
+      const st = await fsp.stat(filePath);
+      lastSizes.set(filePath, st.size);
+    } catch {
+      lastSizes.set(filePath, 0);
+    }
+
+    const readNew = async (initial = false) => {
+      try {
+        const st = await fsp.stat(filePath);
+        const start = initial ? 0 : lastSizes.get(filePath) || 0;
+        if (st.size <= start) {
+          lastSizes.set(filePath, st.size);
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          const rs = createReadStream(filePath, {
+            start,
+            end: st.size - 1,
+            encoding: "utf-8",
+          });
+          rs.on("data", (chunk: string | Buffer) => {
+            const text = typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+            feed(filePath, text);
+          });
+          rs.on("end", resolve);
+          rs.on("error", resolve);
+        });
+        lastSizes.set(filePath, st.size);
+      } catch (e) {
+        // ignore transient errors
+      }
+    };
+
+    // Initial read of existing content (helpful if the event already happened)
+    await readNew(true);
+
+    const fw = watch(filePath, { persistent: false }, async (evt) => {
+      if (stopped) return;
+      if (evt === "change") await readNew(false);
+    });
+    fileWatchers.set(filePath, fw);
+  };
+
+  const attachDirWatcher = async (dir: string) => {
+    try {
+      await fsp.mkdir(dir, { recursive: true });
+    } catch {}
+    try {
+      const files = await fsp.readdir(dir);
+      for (const f of files) {
+        if (f.endsWith(".log")) await attachFileWatcher(path.join(dir, f));
+      }
+    } catch {}
+
+    const dw = watch(
+      dir,
+      { persistent: false },
+      async (_evt, filename) => {
+        if (stopped) return;
+        const name = filename?.toString();
+        if (!name) return;
+        if (name.endsWith(".log")) {
+          await attachFileWatcher(path.join(dir, name));
+        }
+      }
+    );
+    dirWatchers.push(dw);
+  };
+
+  for (const dir of getOpencodeLogDirs()) {
+    void attachDirWatcher(dir);
+  }
+
+  const stop = () => {
+    for (const w of dirWatchers) {
+      try {
+        w.close();
+      } catch {}
+    }
+    dirWatchers.splice(0, dirWatchers.length);
+    for (const [, w] of fileWatchers) {
+      try {
+        w.close();
+      } catch {}
+    }
+    fileWatchers.clear();
+  };
+
+  return stop;
+}
+
+export default {
+  watchOpencodeLogsForCompletion,
+};
+

--- a/packages/shared/src/providers/opencode/proxy.ts
+++ b/packages/shared/src/providers/opencode/proxy.ts
@@ -1,0 +1,252 @@
+import { createServer as createHttpServer } from "node:http";
+
+export type OpencodeProxyOptions = {
+  // URL of the upstream OpenCode server (the real server the CLI talks to)
+  upstreamUrl?: string; // defaults to http://127.0.0.1:4096
+  workerId?: string;
+  emitToMainServer?: (event: string, payload: unknown) => void;
+};
+
+// Local proxy port (separate from AMP's proxy)
+const OPENCODE_PROXY_PORT = 39380;
+
+function extractTaskRunIdFromPath(urlPath: string | undefined | null): string | null {
+  if (!urlPath) return null;
+  // We expect URLs like: /task/<taskRunId>/session/messages ...
+  const m = urlPath.match(/^\/?task\/([a-zA-Z0-9_-]{8,64})(?:\/|$)/);
+  return m?.[1] || null;
+}
+
+function stripTaskPrefix(urlPath: string | undefined | null): string {
+  if (!urlPath) return "/";
+  return urlPath.replace(/^\/?task\/([a-zA-Z0-9_-]{8,64})(?=\/|$)/, "");
+}
+
+// Heuristic: determine completion from OpenCode JSON response bodies
+// We look for assistant messages with a completed time or finish markers.
+function opencodeResponseIndicatesCompletion(json: unknown): boolean {
+  if (json == null) return false;
+
+  // Single object payload
+  if (typeof json === "object" && !Array.isArray(json)) {
+    // Shape may be { info, parts } or a single Message
+    const obj = json as Record<string, unknown>;
+
+    // Try { info, parts }
+    if (obj.info && typeof obj.info === "object") {
+      const info = obj.info as Record<string, unknown>;
+      if (String(info["role"]) === "assistant") {
+        const time = info["time"] as Record<string, unknown> | undefined;
+        const completed = Number((time as any)?.completed || 0);
+        if (completed > 0) return true;
+      }
+    }
+
+    // Try raw Message with role/time
+    const role = String((obj as any)?.role || "");
+    if (role === "assistant") {
+      const time = (obj as any)?.time as { completed?: number } | undefined;
+      if (time && typeof time.completed === "number" && time.completed > 0) {
+        return true;
+      }
+    }
+
+    // Check for generic finish markers
+    const finish = (obj as any)?.finish || (obj as any)?.response?.finish;
+    const finishReason = String((finish?.reason ?? "").toString().toLowerCase());
+    if (finishReason && finishReason !== "tool_use") return true;
+
+    // Some payloads may be nested arrays of { info, parts }
+  }
+
+  // Array of items (possibly { info, parts }[] or Message[])
+  if (Array.isArray(json)) {
+    // Iterate most recent items first
+    for (let i = json.length - 1; i >= 0; i--) {
+      const item = json[i] as any;
+      if (!item || typeof item !== "object") continue;
+
+      // { info, parts }
+      const info = item.info as any;
+      if (info && typeof info === "object") {
+        if (String(info.role) === "assistant") {
+          const completed = Number(info?.time?.completed || 0);
+          if (completed > 0) return true;
+        }
+        continue;
+      }
+
+      // Raw Message
+      if (String(item.role) === "assistant") {
+        const completed = Number(item?.time?.completed || 0);
+        if (completed > 0) return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function startOpencodeProxy(options: OpencodeProxyOptions = {}) {
+  const OPENCODE_TARGET_HOST = options.upstreamUrl || process.env.OPENCODE_UPSTREAM_URL || "http://127.0.0.1:4096";
+  const emit = options.emitToMainServer || (() => {});
+  const workerId = options.workerId;
+
+  // Prevent duplicate emits per taskRunId
+  const completedTasks = new Set<string>();
+
+  (async () => {
+    const server = createHttpServer(async (req, res) => {
+      const start = Date.now();
+      const origUrl = req.url || "/";
+      const taskRunId = extractTaskRunIdFromPath(origUrl);
+      const forwardPath = stripTaskPrefix(origUrl) || "/";
+      const targetUrl = `${OPENCODE_TARGET_HOST}${forwardPath.startsWith("/") ? "" : "/"}${forwardPath}`;
+
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+
+      req.on("end", async () => {
+        const reqBuffer = Buffer.concat(chunks);
+        const contentType = (req.headers["content-type"] || "") as string;
+
+        // Clone headers for upstream, removing hop-by-hop headers
+        const upstreamHeaders = new Headers();
+        for (const [key, value] of Object.entries(req.headers)) {
+          if (value == null) continue;
+          const lower = key.toLowerCase();
+          if (lower === "host" || lower === "content-length") continue;
+          if (Array.isArray(value)) upstreamHeaders.set(key, value.join(", "));
+          else upstreamHeaders.set(key, String(value));
+        }
+
+        let bodyForFetch: string | Buffer | undefined;
+        let loggedRequestBody: unknown = undefined;
+        if (req.method && req.method !== "GET" && req.method !== "HEAD") {
+          if (contentType.includes("application/json")) {
+            const text = reqBuffer.toString("utf8");
+            bodyForFetch = text;
+            try {
+              loggedRequestBody = JSON.parse(text);
+            } catch {
+              loggedRequestBody = text;
+            }
+          } else {
+            bodyForFetch = reqBuffer;
+          }
+        }
+
+        try {
+          const proxyResponse = await fetch(targetUrl, {
+            method: req.method,
+            headers: upstreamHeaders,
+            body: bodyForFetch as any,
+            redirect: "manual",
+          });
+
+          // Copy response headers
+          const responseHeaders = new Headers(proxyResponse.headers);
+          responseHeaders.delete("content-encoding");
+          responseHeaders.delete("content-length");
+
+          res.statusCode = proxyResponse.status;
+          res.statusMessage = proxyResponse.statusText;
+          responseHeaders.forEach((v, k) => res.setHeader(k, v));
+
+          // Detect completion from JSON responses where possible
+          const responseContentType = proxyResponse.headers.get("content-type") || "";
+
+          // Special case: SSE should be proxied as a stream without buffering
+          if (responseContentType.includes("text/event-stream")) {
+            // Pipe through raw without inspection
+            const reader = proxyResponse.body?.getReader();
+            if (reader) {
+              const pump = async () => {
+                try {
+                  while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    if (value) res.write(Buffer.from(value));
+                  }
+                } catch {
+                  // ignore
+                } finally {
+                  res.end();
+                }
+              };
+              void pump();
+              return;
+            } else {
+              // Fallback if body is not readable (unlikely)
+              res.end();
+              return;
+            }
+          }
+
+          let responseBodyForClient: string | Uint8Array | null = null;
+          let parsedJson: unknown = undefined;
+          try {
+            if (
+              typeof responseContentType === "string" &&
+              (responseContentType.includes("application/json") ||
+                responseContentType.startsWith("text/"))
+            ) {
+              const text = await proxyResponse.text();
+              responseBodyForClient = text;
+              try {
+                parsedJson = JSON.parse(text);
+              } catch {
+                // non-JSON text
+              }
+            } else {
+              const ab = await proxyResponse.arrayBuffer();
+              responseBodyForClient = new Uint8Array(ab);
+            }
+          } catch {
+            responseBodyForClient = null;
+          }
+
+          // If we got JSON and we have a taskRunId, try to detect completion
+          if (taskRunId && parsedJson && !completedTasks.has(taskRunId)) {
+            try {
+              const completed = opencodeResponseIndicatesCompletion(parsedJson);
+              if (completed) {
+                completedTasks.add(taskRunId);
+                const elapsedMs = Date.now() - start;
+                emit("worker:task-complete", {
+                  workerId,
+                  taskRunId,
+                  agentModel: "opencode",
+                  elapsedMs,
+                  detectionMethod: "opencode-proxy",
+                });
+              }
+            } catch {
+              // ignore detection error
+            }
+          }
+
+          if (typeof responseBodyForClient === "string") {
+            res.end(responseBodyForClient);
+          } else if (responseBodyForClient) {
+            res.end(Buffer.from(responseBodyForClient));
+          } else {
+            res.end();
+          }
+        } catch (e) {
+          // Upstream failed; return 502
+          res.statusCode = 502;
+          res.setHeader("content-type", "application/json");
+          res.end(
+            JSON.stringify({ error: "Bad Gateway to OpenCode upstream", details: String((e as Error)?.message || e) })
+          );
+        }
+      });
+    });
+
+    server.listen(OPENCODE_PROXY_PORT);
+  })().catch(() => {});
+
+  return;
+}
+


### PR DESCRIPTION
implement task completion detection for opencode models without using terminal idle. you should see how we do it deterministically for other models ( without any unnecessary setTimeouts or setIntervals)... there should a function in opencode where you can check sessionIdle (or basically complete in this instance) export const NotificationPlugin = async ({ client, $ }) => {
  return {    event: async ({ event }) => {      // Send notification on session completion      if (event.type === "session.idle") {        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`      }    },  }}i want you to keep the code as provider agnositc as possible, so do not put provider speicifc code in @apps/server/src/agentSpawner.ts ... add a folder and put your task completion code there, similar to the other models. you can pattern match. the goal is to make it more consistent. do not fallback to terminal idle or any set timeout of that sort.