### PR TITLE
Adjust landing page navigation bar padding for wider layout

### DIFF
--- a/apps/landing/app/page.tsx
+++ b/apps/landing/app/page.tsx
@@ -54,7 +54,7 @@ export default function LandingPage() {
 
       {/* Header */}
       <header className="mb-6 bg-neutral-950/80 backdrop-blur top-0 z-40 border-b border-neutral-900">
-        <div className="container max-w-5xl mx-auto px-3 sm:px-5 py-2.5">
+        <div className="container max-w-5xl mx-auto px-2 sm:px-3 py-2.5">
           <div className="grid w-full grid-cols-[auto_1fr] grid-rows-1 items-center gap-2">
             <a
               aria-label="Go to homepage"


### PR DESCRIPTION
make the nav bar of the landing page have less padding, it should look a tad bit wider than the rest of the content below in the body