### PR TITLE
Align landing page hero image with navbar width

### DIFF
--- a/apps/landing/app/page.tsx
+++ b/apps/landing/app/page.tsx
@@ -217,7 +217,7 @@ export default function LandingPage() {
             </div>
           </div>
           {/* First demo image combined with hero */}
-          <div className="mt-16 mb-8 relative overflow-hidden rounded-lg max-w-4xl mx-auto">
+          <div className="mt-16 mb-8 relative overflow-hidden rounded-lg">
             <Image
               src="/cmux-demo-2.png"
               alt="cmux dashboard showing parallel AI agent execution"


### PR DESCRIPTION
in the landing page we actually want to make sure that the first section with the orchestrate AI coding agents... the image needs to be the same width as the nav bar top with the cmux (like they should be aligned) it shouldn't protrude over like in the rest of the page as well as like everyhting else as well...