### PR TITLE
refactor(github): remove Convex-based token management

### DIFF
--- a/apps/client/src/routes/_layout.settings.tsx
+++ b/apps/client/src/routes/_layout.settings.tsx
@@ -209,11 +209,6 @@ function SettingsComponent() {
     // Check worktree path changes
     const worktreePathChanged = worktreePath !== originalWorktreePath;
 
-    // Check GitHub token changes
-    const githubTokenChanged =
-      (apiKeyValues["GITHUB_TOKEN"] || "") !==
-      (originalApiKeyValues["GITHUB_TOKEN"] || "");
-
     // Check all required API keys for changes
     const apiKeysChanged = apiKeys.some((keyConfig) => {
       const currentValue = apiKeyValues[keyConfig.envVar] || "";
@@ -234,7 +229,6 @@ function SettingsComponent() {
     return (
       worktreePathChanged ||
       autoPrChanged ||
-      githubTokenChanged ||
       apiKeysChanged ||
       containerSettingsChanged
     );
@@ -274,27 +268,6 @@ function SettingsComponent() {
         setOriginalContainerSettingsData(containerSettingsData);
       }
 
-      // Save GitHub token if changed
-      const githubTokenValue = apiKeyValues["GITHUB_TOKEN"] || "";
-      const originalGithubTokenValue =
-        originalApiKeyValues["GITHUB_TOKEN"] || "";
-
-      if (githubTokenValue !== originalGithubTokenValue) {
-        if (githubTokenValue.trim()) {
-          await saveApiKeyMutation.mutateAsync({
-            envVar: "GITHUB_TOKEN",
-            value: githubTokenValue.trim(),
-            displayName: "GitHub Personal Access Token",
-            description: "Used for creating pull requests via GitHub CLI",
-          });
-          savedCount++;
-        } else if (originalGithubTokenValue) {
-          await convex.mutation(api.apiKeys.remove, {
-            envVar: "GITHUB_TOKEN",
-          });
-          deletedCount++;
-        }
-      }
 
       for (const key of apiKeys) {
         const value = apiKeyValues[key.envVar] || "";
@@ -464,90 +437,6 @@ function SettingsComponent() {
                   <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-2">
                     Default location: ~/cmux
                   </p>
-                </div>
-              </div>
-            </div>
-
-            {/* GitHub Authentication */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  GitHub Authentication
-                </h2>
-              </div>
-              <div className="p-4">
-                <div className="space-y-1">
-                  <label
-                    htmlFor="GITHUB_TOKEN"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
-                  >
-                    GitHub Personal Access Token
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                    Required for creating pull requests. Create a token at{" "}
-                    <a
-                      href="https://github.com/settings/tokens/new"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-500 hover:text-blue-600"
-                    >
-                      github.com/settings/tokens
-                    </a>{" "}
-                    with 'repo' and 'pull_request' scopes.
-                  </p>
-                  <div className="relative mt-2">
-                    <input
-                      type={showKeys["GITHUB_TOKEN"] ? "text" : "password"}
-                      id="GITHUB_TOKEN"
-                      value={apiKeyValues["GITHUB_TOKEN"] || ""}
-                      onChange={(e) =>
-                        handleApiKeyChange("GITHUB_TOKEN", e.target.value)
-                      }
-                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100"
-                      placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => toggleShowKey("GITHUB_TOKEN")}
-                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-neutral-500"
-                    >
-                      {showKeys["GITHUB_TOKEN"] ? (
-                        <svg
-                          className="h-5 w-5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                          />
-                        </svg>
-                      ) : (
-                        <svg
-                          className="h-5 w-5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                          />
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                          />
-                        </svg>
-                      )}
-                    </button>
-                  </div>
                 </div>
               </div>
             </div>

--- a/apps/server/src/crownEvaluator.ts
+++ b/apps/server/src/crownEvaluator.ts
@@ -303,7 +303,7 @@ export async function evaluateCrownWithClaudeCode(
   );
 
   try {
-    const githubToken = await getGitHubTokenFromKeychain(convex);
+    const githubToken = await getGitHubTokenFromKeychain();
 
     // Get task and runs
     const task = await convex.query(api.tasks.getById, { id: taskId });

--- a/apps/server/src/handle-task-completion.ts
+++ b/apps/server/src/handle-task-completion.ts
@@ -180,7 +180,7 @@ export async function handleTaskCompletion({
               `[AgentSpawner] Triggering auto-PR for single agent completion`
             );
 
-            const githubToken = await getGitHubTokenFromKeychain(convex);
+            const githubToken = await getGitHubTokenFromKeychain();
 
             // Small delay to ensure git diff is persisted
             setTimeout(async () => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -295,7 +295,7 @@ export async function startServer({
           return;
         }
 
-        const githubToken = await getGitHubTokenFromKeychain(convex);
+        const githubToken = await getGitHubTokenFromKeychain();
         if (!githubToken) {
           callback({ success: false, error: "GitHub token is not configured" });
           return;
@@ -454,7 +454,7 @@ export async function startServer({
         const task = await convex.query(api.tasks.getById, { id: run.taskId });
         if (!task) return callback({ success: false, error: "Task not found" });
 
-        const githubToken = await getGitHubTokenFromKeychain(convex);
+        const githubToken = await getGitHubTokenFromKeychain();
         if (!githubToken)
           return callback({
             success: false,
@@ -1172,7 +1172,7 @@ Please address the issue mentioned in the comment above.`;
           await ensureRunWorktreeAndBranch(taskRunId as Id<"taskRuns">);
 
         // Get GitHub token from keychain/Convex
-        const githubToken = await getGitHubTokenFromKeychain(convex);
+        const githubToken = await getGitHubTokenFromKeychain();
         if (!githubToken) {
           callback({ success: false, error: "GitHub token is not configured" });
           return;
@@ -1397,7 +1397,7 @@ Please address the issue mentioned in the comment above.`;
         const { run, task, worktreePath, branchName, baseBranch } =
           await ensureRunWorktreeAndBranch(taskRunId);
 
-        const githubToken = await getGitHubTokenFromKeychain(convex);
+        const githubToken = await getGitHubTokenFromKeychain();
         if (!githubToken) {
           callback({ success: false, error: "GitHub token is not configured" });
           return;

--- a/apps/server/src/utils/dockerGitSetup.ts
+++ b/apps/server/src/utils/dockerGitSetup.ts
@@ -10,7 +10,7 @@ export async function setupGitCredentialsForDocker(
   convex?: ConvexHttpClient
 ): Promise<string | null> {
   try {
-    const githubToken = await getGitHubTokenFromKeychain(convex);
+    const githubToken = await getGitHubTokenFromKeychain();
     if (!githubToken) {
       return null;
     }

--- a/apps/server/src/utils/getGitHubToken.ts
+++ b/apps/server/src/utils/getGitHubToken.ts
@@ -1,30 +1,11 @@
-import { api } from "@cmux/convex/api";
 import { exec } from "child_process";
-import type { ConvexHttpClient } from "convex/browser";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
 
-export async function getGitHubTokenFromKeychain(
-  convex?: ConvexHttpClient
-): Promise<string | null> {
+export async function getGitHubTokenFromKeychain(): Promise<string | null> {
   try {
-    // Try to get GitHub token from Convex first (user-configured PAT)
-    if (convex) {
-      try {
-        const apiKeys = await convex.query(api.apiKeys.getAll);
-        const githubToken = apiKeys.find(
-          (key) => key.envVar === "GITHUB_TOKEN"
-        );
-        if (githubToken?.value) {
-          return githubToken.value;
-        }
-      } catch {
-        // Convex not available or query failed
-      }
-    }
-
-    // Try to get GitHub token from gh CLI
+    // Only try to get GitHub token from gh CLI
     try {
       const { stdout: ghToken } = await execAsync("gh auth token 2>/dev/null");
       if (ghToken.trim()) {

--- a/apps/server/src/utils/providerStatus.ts
+++ b/apps/server/src/utils/providerStatus.ts
@@ -16,7 +16,7 @@ const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null;
 
 async function checkGitHubStatus(): Promise<GitHubStatus> {
   try {
-    const token = await getGitHubTokenFromKeychain(convex || undefined);
+    const token = await getGitHubTokenFromKeychain();
     return {
       isConfigured: !!token,
       hasToken: !!token,

--- a/apps/server/src/vscode/DockerVSCodeInstance.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.ts
@@ -746,7 +746,7 @@ export class DockerVSCodeInstance extends VSCodeInstance {
       }
 
       // Get GitHub token from host
-      const githubToken = await getGitHubTokenFromKeychain(convex);
+      const githubToken = await getGitHubTokenFromKeychain();
       if (!githubToken) {
         dockerLogger.info(
           "No GitHub token found on host (Convex, gh, or keychain) - skipping gh auth setup"


### PR DESCRIPTION
- Remove client-side UI for GitHub token configuration
- Eliminate Convex storage and retrieval of GitHub Personal Access Tokens
- Centralize GitHub token sourcing to exclusively use the `gh CLI`
- Simplify `getGitHubTokenFromKeychain` by removing Convex dependency
