### PR TITLE
Implement 'Open With' for terminals and Xcode, with server-side checks.

### DIFF
--- a/apps/client/src/components/OpenWithDropdown.tsx
+++ b/apps/client/src/components/OpenWithDropdown.tsx
@@ -30,7 +30,7 @@ export function OpenWithDropdown({
   className,
   iconClassName = "w-3.5 h-3.5",
 }: OpenWithDropdownProps) {
-  const { socket } = useSocket();
+  const { socket, openWithCapabilities } = useSocket();
 
   useEffect(() => {
     if (!socket) return;
@@ -46,6 +46,18 @@ export function OpenWithDropdown({
     };
   }, [socket]);
 
+  const serverEditors = [
+    "cursor",
+    "vscode",
+    "windsurf",
+    "finder",
+    "terminal",
+    "iterm",
+    "ghostty",
+    "alacritty",
+    "xcode",
+  ] as const;
+
   const handleOpenInEditor = useCallback(
     (editor: EditorType): Promise<void> => {
       return new Promise((resolve, reject) => {
@@ -55,13 +67,13 @@ export function OpenWithDropdown({
           resolve();
         } else if (
           socket &&
-          ["cursor", "vscode", "windsurf", "finder"].includes(editor) &&
+          (serverEditors as readonly string[]).includes(editor) &&
           worktreePath
         ) {
           socket.emit(
             "open-in-editor",
             {
-              editor: editor as "cursor" | "vscode" | "windsurf" | "finder",
+              editor: editor as (typeof serverEditors)[number],
               path: worktreePath,
             },
             (response) => {
@@ -93,6 +105,8 @@ export function OpenWithDropdown({
     }
   }, [branch]);
 
+  const caps = openWithCapabilities;
+
   const menuItems: MenuItem[] = [
     {
       id: "vscode-remote" as const,
@@ -102,11 +116,16 @@ export function OpenWithDropdown({
     {
       id: "vscode" as const,
       name: "VS Code (local)",
-      enabled: !!worktreePath,
+      enabled: !!worktreePath && !!caps?.vscode,
     },
-    { id: "cursor" as const, name: "Cursor", enabled: !!worktreePath },
-    { id: "windsurf" as const, name: "Windsurf", enabled: !!worktreePath },
-    { id: "finder" as const, name: "Finder", enabled: !!worktreePath },
+    { id: "cursor" as const, name: "Cursor", enabled: !!worktreePath && !!caps?.cursor },
+    { id: "windsurf" as const, name: "Windsurf", enabled: !!worktreePath && !!caps?.windsurf },
+    { id: "finder" as const, name: "Finder", enabled: !!worktreePath && !!caps?.finder },
+    { id: "terminal" as const, name: "Terminal", enabled: !!worktreePath && !!caps?.terminal },
+    { id: "iterm" as const, name: "iTerm", enabled: !!worktreePath && !!caps?.iterm },
+    { id: "ghostty" as const, name: "Ghostty", enabled: !!worktreePath && !!caps?.ghostty },
+    { id: "alacritty" as const, name: "Alacritty", enabled: !!worktreePath && !!caps?.alacritty },
+    { id: "xcode" as const, name: "Xcode", enabled: !!worktreePath && !!caps?.xcode },
   ];
 
   return (

--- a/apps/client/src/components/ui/dropdown-types.ts
+++ b/apps/client/src/components/ui/dropdown-types.ts
@@ -1,4 +1,4 @@
-import { Code2, Code, Folder } from "lucide-react";
+import { Code2, Code, Folder, TerminalSquare, Hammer } from "lucide-react";
 
 export const editorIcons = {
   "vscode-remote": Code2,
@@ -6,6 +6,11 @@ export const editorIcons = {
   "cursor": Code,
   "windsurf": Code,
   "finder": Folder,
+  "terminal": TerminalSquare,
+  "iterm": TerminalSquare,
+  "ghostty": TerminalSquare,
+  "alacritty": TerminalSquare,
+  "xcode": Hammer,
 } as const;
 
 export type EditorType = keyof typeof editorIcons;

--- a/apps/server/src/utils/detectOpenWith.ts
+++ b/apps/server/src/utils/detectOpenWith.ts
@@ -1,0 +1,70 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+async function commandExists(cmd: string): Promise<boolean> {
+  try {
+    await execAsync(`command -v ${cmd}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function macAppExists(appName: string): Promise<boolean> {
+  try {
+    // -R: required app; -a: specific application by name
+    await execAsync(`open -Ra "${appName}"`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectOpenWithCapabilities() {
+  const isMac = process.platform === "darwin";
+
+  // Common editors already supported via PATH checks
+  const [hasVSCode, hasCursor, hasWindsurf] = await Promise.all([
+    commandExists("code"),
+    commandExists("cursor"),
+    commandExists("windsurf"),
+  ]);
+
+  // Finder only on macOS
+  const hasFinder = isMac;
+
+  // Terminals
+  const [hasTerminal, hasITerm, hasGhosttyCli, hasGhosttyApp, hasAlacrittyCli, hasAlacrittyApp] = await Promise.all([
+    isMac ? macAppExists("Terminal") : Promise.resolve(false),
+    isMac ? macAppExists("iTerm") : Promise.resolve(false),
+    commandExists("ghostty"),
+    isMac ? macAppExists("Ghostty") : Promise.resolve(false),
+    commandExists("alacritty"),
+    isMac ? macAppExists("Alacritty") : Promise.resolve(false),
+  ]);
+
+  const hasGhostty = hasGhosttyCli || hasGhosttyApp;
+  const hasAlacritty = hasAlacrittyCli || hasAlacrittyApp;
+
+  // Xcode
+  const [hasXed, hasXcodeApp] = await Promise.all([
+    isMac ? commandExists("xed") : Promise.resolve(false),
+    isMac ? macAppExists("Xcode") : Promise.resolve(false),
+  ]);
+  const hasXcode = hasXed || hasXcodeApp;
+
+  return {
+    vscode: hasVSCode,
+    cursor: hasCursor,
+    windsurf: hasWindsurf,
+    finder: hasFinder,
+    terminal: hasTerminal,
+    iterm: hasITerm,
+    ghostty: hasGhostty,
+    alacritty: hasAlacritty,
+    xcode: hasXcode,
+  } as const;
+}
+

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -138,7 +138,17 @@ export const GitFullDiffResponseSchema = z.object({
 });
 
 export const OpenInEditorSchema = z.object({
-  editor: z.enum(["vscode", "cursor", "windsurf", "finder"]),
+  editor: z.enum([
+    "vscode",
+    "cursor",
+    "windsurf",
+    "finder",
+    "terminal",
+    "iterm",
+    "ghostty",
+    "alacritty",
+    "xcode",
+  ]),
   path: z.string(),
 });
 
@@ -149,6 +159,19 @@ export const OpenInEditorErrorSchema = z.object({
 export const OpenInEditorResponseSchema = z.object({
   success: z.boolean(),
   error: z.string().optional(),
+});
+
+// Open-with capabilities
+export const OpenWithCapabilitiesSchema = z.object({
+  vscode: z.boolean().optional(),
+  cursor: z.boolean().optional(),
+  windsurf: z.boolean().optional(),
+  finder: z.boolean().optional(),
+  terminal: z.boolean().optional(),
+  iterm: z.boolean().optional(),
+  ghostty: z.boolean().optional(),
+  alacritty: z.boolean().optional(),
+  xcode: z.boolean().optional(),
 });
 
 // File listing events
@@ -344,6 +367,7 @@ export type GitFullDiffResponse = z.infer<typeof GitFullDiffResponseSchema>;
 export type OpenInEditor = z.infer<typeof OpenInEditorSchema>;
 export type OpenInEditorError = z.infer<typeof OpenInEditorErrorSchema>;
 export type OpenInEditorResponse = z.infer<typeof OpenInEditorResponseSchema>;
+export type OpenWithCapabilities = z.infer<typeof OpenWithCapabilitiesSchema>;
 export type ListFilesRequest = z.infer<typeof ListFilesRequestSchema>;
 export type FileInfo = z.infer<typeof FileInfoSchema>;
 export type ListFilesResponse = z.infer<typeof ListFilesResponseSchema>;
@@ -493,6 +517,7 @@ export interface ServerToClientEvents {
   "vscode-spawned": (data: VSCodeSpawned) => void;
   "vscode-error": (data: VSCodeError) => void;
   "default-repo": (data: DefaultRepo) => void;
+  "open-with-capabilities": (data: OpenWithCapabilities) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
I want the open with functionality to have common terminals such as iTerm, Terminal, Ghostie, or Alacritty. This needs to be implemented for both the div page, like the split button, as well as the sidebar button on the left-hand side.  Then, we need to do a server-side check to make sure if one of those exists or not before we actually render it on the front end. I also want the open with functionality to include Xcode as well, and it should spawn Xcode in the right directory. We should do a check pretty early on, like when a client connects to the backend through Socket.io. The backend needs to immediately do the checks to see if this stuff exists and send data back to the frontend. The frontend then needs to persist it in some state variable, and that state variable needs to be reused so we don't query the backend too often. Too often. So the backend is only queried once, and then it's stored in the frontend cache, so it's like fast. So it's like pretty fast to use for a user and doesn't feel laggy.