### PR TITLE
Implement 'Open With' for terminals and Xcode, with server-side checks.

### DIFF
--- a/apps/client/src/components/OpenEditorSplitButton-Enhanced.tsx
+++ b/apps/client/src/components/OpenEditorSplitButton-Enhanced.tsx
@@ -1,0 +1,217 @@
+import { useSocket } from "@/contexts/socket/use-socket";
+import { useApplications } from "@/contexts/applications-context";
+import { getApplicationIcon } from "@/components/ui/application-icons";
+import { Menu } from "@base-ui-components/react/menu";
+import clsx from "clsx";
+import { Check, ChevronDown } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { MenuArrow } from "./ui/menu";
+import type { AvailableApplication } from "@cmux/shared";
+
+interface OpenEditorSplitButtonEnhancedProps {
+  worktreePath?: string | null;
+  classNameLeft?: string;
+  classNameRight?: string;
+}
+
+export function OpenEditorSplitButtonEnhanced({
+  worktreePath,
+  classNameLeft,
+  classNameRight,
+}: OpenEditorSplitButtonEnhancedProps) {
+  const { socket } = useSocket();
+  const { applications } = useApplications();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handleOpenInEditorError = (data: { error: string }) => {
+      console.error("Failed to open application:", data.error);
+    };
+    socket.on("open-in-editor-error", handleOpenInEditorError);
+    return () => {
+      socket.off("open-in-editor-error", handleOpenInEditorError);
+    };
+  }, [socket]);
+
+  // Filter available applications and group by type
+  const availableApps = useMemo(() => {
+    const available = applications.filter(app => app.available);
+    return {
+      editors: available.filter(app => app.type === "editor"),
+      terminals: available.filter(app => app.type === "terminal"),
+      ides: available.filter(app => app.type === "ide"),
+    };
+  }, [applications]);
+
+  const [selectedAppId, setSelectedAppId] = useState<string | null>(() => {
+    const stored = typeof window !== "undefined"
+      ? window.localStorage.getItem("cmux:lastOpenWith")
+      : null;
+    
+    // Check if stored app is still available
+    if (stored && applications.find(app => app.id === stored && app.available)) {
+      return stored;
+    }
+    
+    // Default to first available editor, terminal, or IDE
+    const firstAvailable = 
+      availableApps.editors[0] || 
+      availableApps.terminals[0] || 
+      availableApps.ides[0];
+    
+    return firstAvailable?.id || null;
+  });
+
+  useEffect(() => {
+    if (selectedAppId) {
+      window.localStorage.setItem("cmux:lastOpenWith", selectedAppId);
+    }
+  }, [selectedAppId]);
+
+  const handleOpenWithApp = useCallback(
+    (appId: string): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        if (socket && worktreePath) {
+          socket.emit(
+            "open-in-editor",
+            { editor: appId, path: worktreePath },
+            (response: { success: boolean; error?: string }) => {
+              if (response.success) resolve();
+              else reject(new Error(response.error || "Failed to open application"));
+            }
+          );
+        } else {
+          reject(new Error("Unable to open application"));
+        }
+      });
+    },
+    [socket, worktreePath]
+  );
+
+  const selectedApp = applications.find(app => app.id === selectedAppId);
+  const leftDisabled = !selectedApp || !selectedApp.available || !worktreePath;
+  const SelectedIcon = selectedApp ? getApplicationIcon(selectedApp.id) : null;
+
+  const openSelected = useCallback(() => {
+    if (!selectedApp) return;
+    const name = selectedApp.name;
+    const loadingToast = toast.loading(`Opening ${name}...`);
+    handleOpenWithApp(selectedApp.id)
+      .then(() => {
+        toast.success(`Opened ${name}`, { id: loadingToast });
+      })
+      .catch((error: Error) => {
+        let errorMessage = "Failed to open application";
+        if (
+          error.message?.includes("ENOENT") ||
+          error.message?.includes("not found") ||
+          error.message?.includes("command not found")
+        ) {
+          errorMessage = `${selectedApp.name} is not installed or not found in PATH`;
+        } else if (error.message) {
+          errorMessage = error.message;
+        }
+        toast.error(errorMessage, { id: loadingToast });
+      });
+  }, [handleOpenWithApp, selectedApp]);
+
+  const renderApplicationGroup = (
+    title: string,
+    apps: AvailableApplication[]
+  ) => {
+    if (apps.length === 0) return null;
+    
+    return (
+      <>
+        <div className="px-2 py-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+          {title}
+        </div>
+        {apps.map((app) => {
+          const Icon = getApplicationIcon(app.id);
+          return (
+            <Menu.RadioItem
+              key={app.id}
+              value={app.id}
+              disabled={!worktreePath}
+              className={clsx(
+                "grid cursor-default grid-cols-[0.75rem_1rem_1fr] items-center gap-2 py-2 pr-8 pl-2.5 text-sm leading-4 outline-none select-none",
+                "data-[highlighted]:relative data-[highlighted]:z-0",
+                "data-[highlighted]:text-neutral-50 dark:data-[highlighted]:text-neutral-900",
+                "data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0",
+                "data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm",
+                "data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-100",
+                "data-[disabled]:text-neutral-400 dark:data-[disabled]:text-neutral-600 data-[disabled]:cursor-not-allowed"
+              )}
+              onClick={() => setMenuOpen(false)}
+            >
+              <Menu.RadioItemIndicator className="col-start-1">
+                <Check className="w-3 h-3" />
+              </Menu.RadioItemIndicator>
+              {Icon && <Icon className="w-3.5 h-3.5 col-start-2" />}
+              <span className="col-start-3">{app.name}</span>
+            </Menu.RadioItem>
+          );
+        })}
+      </>
+    );
+  };
+
+  return (
+    <div className="flex items-stretch">
+      <button
+        onClick={openSelected}
+        disabled={leftDisabled}
+        className={clsx(
+          "flex items-center gap-1.5 px-3 py-1 bg-neutral-800 text-white rounded-l hover:bg-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-xs select-none whitespace-nowrap",
+          "border border-neutral-700 border-r",
+          classNameLeft
+        )}
+      >
+        {SelectedIcon && <SelectedIcon className="w-3.5 h-3.5" />}
+        {selectedApp ? selectedApp.name : "Open with"}
+      </button>
+      <Menu.Root open={menuOpen} onOpenChange={setMenuOpen}>
+        <Menu.Trigger
+          className={clsx(
+            "flex items-center px-2 py-1 bg-neutral-800 text-white rounded-r hover:bg-neutral-700 select-none border border-neutral-700 border-l-0",
+            classNameRight
+          )}
+          title="Choose application"
+        >
+          <ChevronDown className="w-3.5 h-3.5" />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner sideOffset={5} className="outline-none z-[10001]">
+            <Menu.Popup
+              className={clsx(
+                "origin-[var(--transform-origin)] rounded-md bg-white dark:bg-black py-1",
+                "text-neutral-900 dark:text-neutral-100",
+                "shadow-lg shadow-neutral-200 dark:shadow-neutral-950",
+                "outline outline-neutral-200 dark:outline-neutral-800",
+                "transition-[transform,scale,opacity]",
+                "data-[ending-style]:scale-90 data-[ending-style]:opacity-0",
+                "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",
+                "min-w-[200px] max-h-[400px] overflow-y-auto"
+              )}
+            >
+              <MenuArrow />
+              <Menu.RadioGroup
+                value={selectedAppId || undefined}
+                onValueChange={(val) => {
+                  setSelectedAppId(val);
+                  setMenuOpen(false);
+                }}
+              >
+                {renderApplicationGroup("Editors", availableApps.editors)}
+                {renderApplicationGroup("Terminals", availableApps.terminals)}
+                {renderApplicationGroup("IDEs", availableApps.ides)}
+              </Menu.RadioGroup>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+    </div>
+  );
+}

--- a/apps/client/src/components/OpenInEditorButton-Enhanced.tsx
+++ b/apps/client/src/components/OpenInEditorButton-Enhanced.tsx
@@ -1,0 +1,188 @@
+import { useSocket } from "@/contexts/socket/use-socket";
+import { useApplications } from "@/contexts/applications-context";
+import { getApplicationIcon } from "@/components/ui/application-icons";
+import { ChevronDown, ExternalLink } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { toast } from "sonner";
+import type { AvailableApplication } from "@cmux/shared";
+
+interface OpenInEditorButtonEnhancedProps {
+  workspacePath: string;
+}
+
+export function OpenInEditorButtonEnhanced({ workspacePath }: OpenInEditorButtonEnhancedProps) {
+  const { socket } = useSocket();
+  const { applications } = useApplications();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Filter available applications and group by type
+  const availableApps = useMemo(() => {
+    const available = applications.filter(app => app.available);
+    return {
+      editors: available.filter(app => app.type === "editor"),
+      terminals: available.filter(app => app.type === "terminal"),
+      ides: available.filter(app => app.type === "ide"),
+    };
+  }, [applications]);
+
+  const [selectedAppId, setSelectedAppId] = useState<string>(() => {
+    const stored = typeof window !== "undefined"
+      ? window.localStorage.getItem("cmux:lastOpenWith")
+      : null;
+    
+    // Check if stored app is still available
+    if (stored && applications.find(app => app.id === stored && app.available)) {
+      return stored;
+    }
+    
+    // Default to first available app
+    const firstAvailable = 
+      availableApps.editors[0] || 
+      availableApps.terminals[0] || 
+      availableApps.ides[0];
+    
+    return firstAvailable?.id || "cursor";
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem("cmux:lastOpenWith", selectedAppId);
+  }, [selectedAppId]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleOpenInEditorError = (data: { error: string }) => {
+      console.error("Failed to open application:", data.error);
+      toast.error(`Failed to open: ${data.error}`);
+    };
+
+    socket.on("open-in-editor-error", handleOpenInEditorError);
+
+    return () => {
+      socket.off("open-in-editor-error", handleOpenInEditorError);
+    };
+  }, [socket]);
+
+  const handleOpenWithApp = useCallback((appId: string) => {
+    if (workspacePath && socket) {
+      const app = applications.find(a => a.id === appId);
+      const appName = app?.name || appId;
+      
+      const loadingToast = toast.loading(`Opening ${appName}...`);
+      
+      socket.emit(
+        "open-in-editor",
+        {
+          editor: appId,
+          path: workspacePath,
+        },
+        (response) => {
+          if (response.success) {
+            toast.success(`Opened ${appName}`, { id: loadingToast });
+          } else {
+            let errorMessage = "Failed to open application";
+            if (response.error?.includes("not found") || response.error?.includes("ENOENT")) {
+              errorMessage = `${appName} is not installed or not found in PATH`;
+            } else if (response.error) {
+              errorMessage = response.error;
+            }
+            toast.error(errorMessage, { id: loadingToast });
+          }
+        }
+      );
+    }
+  }, [workspacePath, socket, applications]);
+
+  const renderApplicationGroup = (
+    title: string,
+    apps: AvailableApplication[]
+  ) => {
+    if (apps.length === 0) return null;
+
+    return (
+      <>
+        <div className="px-3 py-1 text-xs font-semibold text-neutral-500 dark:text-neutral-400 border-b border-neutral-700">
+          {title}
+        </div>
+        {apps.map((app) => {
+          const Icon = getApplicationIcon(app.id);
+          return (
+            <button
+              key={app.id}
+              onClick={() => {
+                setSelectedAppId(app.id);
+                setIsDropdownOpen(false);
+                handleOpenWithApp(app.id);
+              }}
+              className={`w-full px-3 py-2 text-sm text-left hover:bg-neutral-700 transition-colors flex items-center gap-2 ${
+                selectedAppId === app.id
+                  ? "text-blue-400 bg-neutral-700/50"
+                  : "text-neutral-200"
+              }`}
+            >
+              {Icon && <Icon className="w-4 h-4" />}
+              {app.name}
+            </button>
+          );
+        })}
+      </>
+    );
+  };
+
+  const selectedApp = applications.find(app => app.id === selectedAppId);
+  const SelectedIcon = selectedApp ? getApplicationIcon(selectedApp.id) : ExternalLink;
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <div className="flex items-center h-8 bg-neutral-800 rounded-md overflow-hidden border border-neutral-700 shadow-sm">
+        <button
+          onClick={() => handleOpenWithApp(selectedAppId)}
+          className="flex items-center gap-2 px-3 py-0 h-full text-sm bg-transparent hover:bg-neutral-700 text-neutral-200 transition-colors flex-1 select-none"
+        >
+          <SelectedIcon className="w-4 h-4" />
+          Open with {selectedApp?.name || "Editor"}
+        </button>
+        <div className="w-px h-4 bg-neutral-600" />
+        <button
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          className="flex items-center justify-center w-8 h-full bg-transparent hover:bg-neutral-700 text-neutral-200 transition-colors"
+        >
+          <ChevronDown
+            className={`w-4 h-4 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
+          />
+        </button>
+      </div>
+      {isDropdownOpen && (
+        <div className="absolute right-0 mt-1 w-48 bg-neutral-800 border border-neutral-700 rounded-md shadow-lg z-20 select-none overflow-hidden">
+          {renderApplicationGroup("Editors", availableApps.editors)}
+          {renderApplicationGroup("Terminals", availableApps.terminals)}
+          {renderApplicationGroup("IDEs", availableApps.ides)}
+          {availableApps.editors.length === 0 && 
+           availableApps.terminals.length === 0 && 
+           availableApps.ides.length === 0 && (
+            <div className="px-3 py-2 text-sm text-neutral-400">
+              No applications detected
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/task-detail-header.tsx
+++ b/apps/client/src/components/task-detail-header.tsx
@@ -1,4 +1,4 @@
-import { OpenEditorSplitButton } from "@/components/OpenEditorSplitButton";
+import { OpenEditorSplitButtonEnhanced } from "@/components/OpenEditorSplitButton-Enhanced";
 import { Dropdown } from "@/components/ui/dropdown";
 import { MergeButton, type MergeMethod } from "@/components/ui/merge-button";
 import { useSocket } from "@/contexts/socket/use-socket";
@@ -220,7 +220,7 @@ export function TaskDetailHeader({
             </button>
           )}
 
-          <OpenEditorSplitButton worktreePath={worktreePath} />
+          <OpenEditorSplitButtonEnhanced worktreePath={worktreePath} />
 
           <button className="p-1 text-neutral-400 hover:text-neutral-700 dark:hover:text-white select-none hidden">
             <ExternalLink className="w-3.5 h-3.5" />

--- a/apps/client/src/components/ui/application-icons.tsx
+++ b/apps/client/src/components/ui/application-icons.tsx
@@ -1,0 +1,29 @@
+import { Code2, Code, Folder, Terminal, FileCode2, SquareTerminal, Box } from "lucide-react";
+import type { ComponentType } from "react";
+
+export const applicationIcons: Record<string, ComponentType<{ className?: string }>> = {
+  // Editors
+  "vscode": Code2,
+  "cursor": Code,
+  "windsurf": Code,
+  "finder": Folder,
+  
+  // Terminals
+  "terminal": Terminal,
+  "iterm": Terminal,
+  "ghostty": SquareTerminal,
+  "alacritty": Terminal,
+  "gnome-terminal": Terminal,
+  "konsole": Terminal,
+  "xterm": Terminal,
+  "cmd": Terminal,
+  "powershell": Terminal,
+  "wt": Terminal,
+  
+  // IDEs
+  "xcode": FileCode2,
+};
+
+export function getApplicationIcon(appId: string): ComponentType<{ className?: string }> {
+  return applicationIcons[appId] || Box;
+}

--- a/apps/client/src/contexts/applications-context.tsx
+++ b/apps/client/src/contexts/applications-context.tsx
@@ -1,0 +1,56 @@
+import type { AvailableApplication, DetectApplicationsResponse } from "@cmux/shared";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { useSocket } from "./socket/use-socket";
+
+interface ApplicationsContextType {
+  applications: AvailableApplication[];
+  isLoading: boolean;
+  refreshApplications: () => void;
+}
+
+const ApplicationsContext = createContext<ApplicationsContextType | undefined>(undefined);
+
+export function ApplicationsProvider({ children }: { children: ReactNode }) {
+  const { socket } = useSocket();
+  const [applications, setApplications] = useState<AvailableApplication[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refreshApplications = () => {
+    if (!socket) return;
+    
+    setIsLoading(true);
+    socket.emit("detect-applications", (response: DetectApplicationsResponse) => {
+      setApplications(response.applications);
+      setIsLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleDetectedApplications = (data: DetectApplicationsResponse) => {
+      setApplications(data.applications);
+      setIsLoading(false);
+    };
+
+    socket.on("detected-applications", handleDetectedApplications);
+
+    return () => {
+      socket.off("detected-applications", handleDetectedApplications);
+    };
+  }, [socket]);
+
+  return (
+    <ApplicationsContext.Provider value={{ applications, isLoading, refreshApplications }}>
+      {children}
+    </ApplicationsContext.Provider>
+  );
+}
+
+export function useApplications() {
+  const context = useContext(ApplicationsContext);
+  if (!context) {
+    throw new Error("useApplications must be used within ApplicationsProvider");
+  }
+  return context;
+}

--- a/apps/client/src/providers.tsx
+++ b/apps/client/src/providers.tsx
@@ -1,5 +1,6 @@
 import { ThemeProvider } from "@/components/theme/theme-provider";
 import { SocketProvider } from "@/contexts/socket/socket-provider";
+import { ApplicationsProvider } from "@/contexts/applications-context";
 import { HeroUIProvider } from "@heroui/react";
 import { StackProvider, StackTheme } from "@stackframe/react";
 import {
@@ -72,7 +73,11 @@ export function Providers({ children }: ProvidersProps) {
         <StackTheme>
           <StackProvider app={stackClientApp}>
             <AntdConfigProvider theme={antdTheme}>
-              <SocketProvider>{children}</SocketProvider>
+              <SocketProvider>
+                <ApplicationsProvider>
+                  {children}
+                </ApplicationsProvider>
+              </SocketProvider>
             </AntdConfigProvider>
           </StackProvider>
         </StackTheme>

--- a/apps/server/src/utils/detectApplications.ts
+++ b/apps/server/src/utils/detectApplications.ts
@@ -1,0 +1,279 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+
+const execAsync = promisify(exec);
+
+export interface AvailableApplication {
+  id: string;
+  name: string;
+  type: "editor" | "terminal" | "ide";
+  available: boolean;
+  path?: string;
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  try {
+    const checkCommand = os.platform() === "win32" ? `where ${command}` : `which ${command}`;
+    await execAsync(checkCommand);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function macAppExists(appName: string): Promise<string | null> {
+  if (os.platform() !== "darwin") return null;
+  
+  const appPaths = [
+    `/Applications/${appName}.app`,
+    `${os.homedir()}/Applications/${appName}.app`,
+    `/System/Applications/${appName}.app`,
+  ];
+  
+  for (const appPath of appPaths) {
+    try {
+      await fs.access(appPath);
+      return appPath;
+    } catch {
+      continue;
+    }
+  }
+  
+  return null;
+}
+
+export async function detectAvailableApplications(): Promise<AvailableApplication[]> {
+  const applications: AvailableApplication[] = [];
+  const platform = os.platform();
+  
+  // Existing editors (keep these for compatibility)
+  applications.push({
+    id: "vscode",
+    name: "VS Code", 
+    type: "editor",
+    available: await commandExists("code"),
+  });
+  
+  applications.push({
+    id: "cursor",
+    name: "Cursor",
+    type: "editor",
+    available: await commandExists("cursor"),
+  });
+  
+  applications.push({
+    id: "windsurf",
+    name: "Windsurf",
+    type: "editor",
+    available: await commandExists("windsurf"),
+  });
+  
+  // Terminal applications
+  if (platform === "darwin") {
+    // macOS terminals
+    const terminalPath = await macAppExists("Terminal");
+    applications.push({
+      id: "terminal",
+      name: "Terminal",
+      type: "terminal",
+      available: terminalPath !== null,
+      path: terminalPath || undefined,
+    });
+    
+    const itermPath = await macAppExists("iTerm");
+    applications.push({
+      id: "iterm",
+      name: "iTerm",
+      type: "terminal",
+      available: itermPath !== null,
+      path: itermPath || undefined,
+    });
+    
+    const ghosttyPath = await macAppExists("Ghostty");
+    applications.push({
+      id: "ghostty",
+      name: "Ghostty",
+      type: "terminal",
+      available: ghosttyPath !== null,
+      path: ghosttyPath || undefined,
+    });
+    
+    const alacrittyPath = await macAppExists("Alacritty");
+    applications.push({
+      id: "alacritty",
+      name: "Alacritty",
+      type: "terminal",
+      available: alacrittyPath !== null,
+      path: alacrittyPath || undefined,
+    });
+    
+    // Xcode
+    const xcodePath = await macAppExists("Xcode");
+    applications.push({
+      id: "xcode",
+      name: "Xcode",
+      type: "ide",
+      available: xcodePath !== null,
+      path: xcodePath || undefined,
+    });
+    
+    // Finder (always available on macOS)
+    applications.push({
+      id: "finder",
+      name: "Finder",
+      type: "editor",
+      available: true,
+    });
+  } else if (platform === "linux") {
+    // Linux terminals
+    applications.push({
+      id: "gnome-terminal",
+      name: "GNOME Terminal",
+      type: "terminal",
+      available: await commandExists("gnome-terminal"),
+    });
+    
+    applications.push({
+      id: "konsole",
+      name: "Konsole",
+      type: "terminal",
+      available: await commandExists("konsole"),
+    });
+    
+    applications.push({
+      id: "xterm",
+      name: "XTerm",
+      type: "terminal",
+      available: await commandExists("xterm"),
+    });
+    
+    applications.push({
+      id: "alacritty",
+      name: "Alacritty",
+      type: "terminal",
+      available: await commandExists("alacritty"),
+    });
+  } else if (platform === "win32") {
+    // Windows terminals
+    applications.push({
+      id: "cmd",
+      name: "Command Prompt",
+      type: "terminal",
+      available: true,
+    });
+    
+    applications.push({
+      id: "powershell",
+      name: "PowerShell",
+      type: "terminal",
+      available: await commandExists("powershell"),
+    });
+    
+    applications.push({
+      id: "wt",
+      name: "Windows Terminal",
+      type: "terminal",
+      available: await commandExists("wt"),
+    });
+  }
+  
+  return applications;
+}
+
+export async function openWithApplication(
+  appId: string,
+  targetPath: string
+): Promise<void> {
+  const platform = os.platform();
+  let command: string;
+  
+  if (platform === "darwin") {
+    switch (appId) {
+      case "vscode":
+        command = `code "${targetPath}"`;
+        break;
+      case "cursor":
+        command = `cursor "${targetPath}"`;
+        break;
+      case "windsurf":
+        command = `windsurf "${targetPath}"`;
+        break;
+      case "finder":
+        command = `open "${targetPath}"`;
+        break;
+      case "terminal":
+        command = `open -a Terminal "${targetPath}"`;
+        break;
+      case "iterm":
+        command = `open -a iTerm "${targetPath}"`;
+        break;
+      case "ghostty":
+        command = `open -a Ghostty "${targetPath}"`;
+        break;
+      case "alacritty":
+        command = `open -a Alacritty --args --working-directory "${targetPath}"`;
+        break;
+      case "xcode":
+        command = `open -a Xcode "${targetPath}"`;
+        break;
+      default:
+        throw new Error(`Unknown application: ${appId}`);
+    }
+  } else if (platform === "linux") {
+    switch (appId) {
+      case "vscode":
+        command = `code "${targetPath}"`;
+        break;
+      case "cursor":
+        command = `cursor "${targetPath}"`;
+        break;
+      case "windsurf":
+        command = `windsurf "${targetPath}"`;
+        break;
+      case "gnome-terminal":
+        command = `gnome-terminal --working-directory="${targetPath}"`;
+        break;
+      case "konsole":
+        command = `konsole --workdir "${targetPath}"`;
+        break;
+      case "xterm":
+        command = `xterm -e "cd '${targetPath}' && bash"`;
+        break;
+      case "alacritty":
+        command = `alacritty --working-directory "${targetPath}"`;
+        break;
+      default:
+        throw new Error(`Unknown application: ${appId}`);
+    }
+  } else if (platform === "win32") {
+    switch (appId) {
+      case "vscode":
+        command = `code "${targetPath}"`;
+        break;
+      case "cursor":
+        command = `cursor "${targetPath}"`;
+        break;
+      case "windsurf":
+        command = `windsurf "${targetPath}"`;
+        break;
+      case "cmd":
+        command = `start cmd /K "cd /d ${targetPath}"`;
+        break;
+      case "powershell":
+        command = `start powershell -NoExit -Command "cd '${targetPath}'"`;
+        break;
+      case "wt":
+        command = `wt -d "${targetPath}"`;
+        break;
+      default:
+        throw new Error(`Unknown application: ${appId}`);
+    }
+  } else {
+    throw new Error(`Unsupported platform: ${platform}`);
+  }
+  
+  await execAsync(command);
+}

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -138,7 +138,7 @@ export const GitFullDiffResponseSchema = z.object({
 });
 
 export const OpenInEditorSchema = z.object({
-  editor: z.enum(["vscode", "cursor", "windsurf", "finder"]),
+  editor: z.string(), // Changed to string to support dynamic app list
   path: z.string(),
 });
 
@@ -149,6 +149,19 @@ export const OpenInEditorErrorSchema = z.object({
 export const OpenInEditorResponseSchema = z.object({
   success: z.boolean(),
   error: z.string().optional(),
+});
+
+// Application detection events
+export const AvailableApplicationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["editor", "terminal", "ide"]),
+  available: z.boolean(),
+  path: z.string().optional(),
+});
+
+export const DetectApplicationsResponseSchema = z.object({
+  applications: z.array(AvailableApplicationSchema),
 });
 
 // File listing events
@@ -344,6 +357,8 @@ export type GitFullDiffResponse = z.infer<typeof GitFullDiffResponseSchema>;
 export type OpenInEditor = z.infer<typeof OpenInEditorSchema>;
 export type OpenInEditorError = z.infer<typeof OpenInEditorErrorSchema>;
 export type OpenInEditorResponse = z.infer<typeof OpenInEditorResponseSchema>;
+export type AvailableApplication = z.infer<typeof AvailableApplicationSchema>;
+export type DetectApplicationsResponse = z.infer<typeof DetectApplicationsResponseSchema>;
 export type ListFilesRequest = z.infer<typeof ListFilesRequestSchema>;
 export type FileInfo = z.infer<typeof FileInfoSchema>;
 export type ListFilesResponse = z.infer<typeof ListFilesResponseSchema>;
@@ -372,6 +387,10 @@ export type DefaultRepo = z.infer<typeof DefaultRepoSchema>;
 
 // Socket.io event map types
 export interface ClientToServerEvents {
+  // Application detection
+  "detect-applications": (
+    callback: (response: DetectApplicationsResponse) => void
+  ) => void;
   // Terminal operations
   "start-task": (
     data: StartTask,
@@ -482,6 +501,8 @@ export interface ClientToServerEvents {
 }
 
 export interface ServerToClientEvents {
+  // Application detection
+  "detected-applications": (data: DetectApplicationsResponse) => void;
   "task-started": (data: TaskStarted) => void;
   "task-error": (data: TaskError) => void;
   "git-status-response": (data: GitStatusResponse) => void;


### PR DESCRIPTION
I want the open with functionality to have common terminals such as iTerm, Terminal, Ghostie, or Alacritty. This needs to be implemented for both the div page, like the split button, as well as the sidebar button on the left-hand side.  Then, we need to do a server-side check to make sure if one of those exists or not before we actually render it on the front end. I also want the open with functionality to include Xcode as well, and it should spawn Xcode in the right directory. We should do a check pretty early on, like when a client connects to the backend through Socket.io. The backend needs to immediately do the checks to see if this stuff exists and send data back to the frontend. The frontend then needs to persist it in some state variable, and that state variable needs to be reused so we don't query the backend too often. Too often. So the backend is only queried once, and then it's stored in the frontend cache, so it's like fast. So it's like pretty fast to use for a user and doesn't feel laggy.