### PR TITLE
Add Augment Code agents for GPT-5 and Claude Sonnet-4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,6 +175,8 @@ COPY --from=builder /usr/local/bin/bunx /usr/local/bin/bunx
 # Verify bun works in runtime
 RUN bun --version && bunx --version
 RUN bun add -g @openai/codex@0.25.0 @anthropic-ai/claude-code@1.0.83 @google/gemini-cli@0.1.21 opencode-ai@0.5.28 codebuff @devcontainers/cli @sourcegraph/amp
+## Install Augment Code CLI (Auggie) globally per upstream instructions
+RUN npm install -g @augmentcode/auggie@latest && auggie --help >/dev/null 2>&1 || true
 
 # Install cursor cli
 RUN curl https://cursor.com/install -fsS | bash

--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -45,6 +45,10 @@ import {
   QWEN_MODEL_STUDIO_CODER_PLUS_CONFIG,
   QWEN_OPENROUTER_CODER_FREE_CONFIG,
 } from "./providers/qwen/configs.js";
+import {
+  AUGMENT_GPT_5_CONFIG,
+  AUGMENT_SONNET_4_CONFIG,
+} from "./providers/augment/configs.js";
 
 export { checkDockerStatus } from "./providers/common/check-docker.js";
 export { checkGitStatus } from "./providers/common/check-git.js";
@@ -105,4 +109,6 @@ export const AGENT_CONFIGS: AgentConfig[] = [
   CURSOR_GPT_5_CONFIG,
   CURSOR_SONNET_4_CONFIG,
   CURSOR_SONNET_4_THINKING_CONFIG,
+  AUGMENT_GPT_5_CONFIG,
+  AUGMENT_SONNET_4_CONFIG,
 ];

--- a/packages/shared/src/providers/augment/check-requirements.ts
+++ b/packages/shared/src/providers/augment/check-requirements.ts
@@ -1,0 +1,35 @@
+export async function checkAugmentRequirements(): Promise<string[]> {
+  const { access, stat } = await import("node:fs/promises");
+  const { homedir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const missing: string[] = [];
+
+  // Accept either local session file or env-based auth
+  const sessionPath = join(homedir(), ".augment", "session.json");
+  const hasSessionFile = await access(sessionPath)
+    .then(() => true)
+    .catch(() => false);
+
+  const hasEnvAuth = Boolean(
+    process.env.AUGMENT_API_TOKEN || process.env.AUGMENT_SESSION_AUTH
+  );
+
+  if (!hasSessionFile && !hasEnvAuth) {
+    missing.push("Augment authentication (run 'auggie login' locally)");
+  }
+
+  // Optional note: ensure the default cache dir exists if present locally
+  const augmentDir = join(homedir(), ".augment");
+  try {
+    const s = await stat(augmentDir);
+    if (!s.isDirectory()) {
+      // nothing; directory missing isn't fatal
+    }
+  } catch {
+    // missing dir isn't fatal
+  }
+
+  return missing;
+}
+

--- a/packages/shared/src/providers/augment/configs.ts
+++ b/packages/shared/src/providers/augment/configs.ts
@@ -1,0 +1,23 @@
+import type { AgentConfig } from "../../agentConfig.js";
+import { checkAugmentRequirements } from "./check-requirements.js";
+import { getAugmentEnvironment } from "./environment.js";
+
+// Augment (Auggie) agents
+// Model IDs provided by user: gpt5 and sonnet4
+
+export const AUGMENT_GPT_5_CONFIG: AgentConfig = {
+  name: "augment/gpt-5",
+  command: "auggie",
+  args: ["--model", "gpt5", "$PROMPT"],
+  environment: getAugmentEnvironment,
+  checkRequirements: checkAugmentRequirements,
+};
+
+export const AUGMENT_SONNET_4_CONFIG: AgentConfig = {
+  name: "augment/claude-sonnet-4",
+  command: "auggie",
+  args: ["--model", "sonnet4", "$PROMPT"],
+  environment: getAugmentEnvironment,
+  checkRequirements: checkAugmentRequirements,
+};
+

--- a/packages/shared/src/providers/augment/environment.ts
+++ b/packages/shared/src/providers/augment/environment.ts
@@ -1,0 +1,70 @@
+import type { EnvironmentContext, EnvironmentResult } from "../common/environment-result.js";
+
+export async function getAugmentEnvironment(_ctx: EnvironmentContext): Promise<EnvironmentResult> {
+  // Lazy imports for Node-only modules
+  const { readFile, readdir, stat } = await import("node:fs/promises");
+  const { homedir } = await import("node:os");
+  const { Buffer } = await import("node:buffer");
+  const { join } = await import("node:path");
+
+  const files: EnvironmentResult["files"] = [];
+  const env: Record<string, string> = {};
+  const startupCommands: string[] = [];
+
+  // Ensure Augment cache/auth directory exists in the container
+  startupCommands.push("mkdir -p ~/.augment");
+
+  const hostAugmentDir = join(homedir(), ".augment");
+
+  // Helper: copy one file from host .augment into container .augment
+  async function copyAugmentFile(filename: string, mode: string = "600") {
+    try {
+      const content = await readFile(join(hostAugmentDir, filename));
+      files.push({
+        destinationPath: `$HOME/.augment/${filename}`,
+        contentBase64: content.toString("base64"),
+        mode,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Primary session file produced by `auggie login`
+  await copyAugmentFile("session.json", "600");
+
+  // Opportunistically mirror other simple JSON/text files (non-recursive)
+  try {
+    const items = await readdir(hostAugmentDir, { withFileTypes: true });
+    for (const it of items) {
+      if (!it.isFile()) continue;
+      const name = it.name;
+      if (name === "session.json") continue; // already copied
+      if (!/(\.json|\.txt|\.token|_id)$/i.test(name)) continue;
+      try {
+        const content = await readFile(join(hostAugmentDir, name));
+        files.push({
+          destinationPath: `$HOME/.augment/${name}`,
+          contentBase64: content.toString("base64"),
+          mode: "600",
+        });
+      } catch {
+        // ignore individual failures
+      }
+    }
+  } catch {
+    // host .augment dir missing; rely on environment variables instead
+  }
+
+  // If the user has exported env auth, forward it
+  if (process.env.AUGMENT_API_TOKEN) {
+    env.AUGMENT_API_TOKEN = process.env.AUGMENT_API_TOKEN;
+  }
+  if (process.env.AUGMENT_SESSION_AUTH) {
+    env.AUGMENT_SESSION_AUTH = process.env.AUGMENT_SESSION_AUTH;
+  }
+
+  return { files, env, startupCommands };
+}
+


### PR DESCRIPTION
add augment code agents via augment/gpt-5 and augment/claude-sonnet-4 .. the model flags are --model and the model ids are gpt5 and sonnet4 . it is ran using auggie and you need to install via npm install -g @augmentcode/auggie... the login is done locally, you can copy the auth files like we do for the others