### PR TITLE
Set app icon from build in release and Mac scripts

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Ensure pnpm lock visible to electron-builder
         shell: bash
         run: cp pnpm-lock.yaml apps/client/pnpm-lock.yaml
+      - name: Generate app icons (build/*)
+        run: node apps/client/scripts/generate-icons.mjs
       - name: Detect mac signing secrets
         id: signing
         env:
@@ -104,6 +106,8 @@ jobs:
       - name: Ensure pnpm lock visible to electron-builder
         shell: bash
         run: cp pnpm-lock.yaml apps/client/pnpm-lock.yaml
+      - name: Generate app icons (build/*)
+        run: node apps/client/scripts/generate-icons.mjs
       - name: Detect mac signing secrets
         id: signing
         env:
@@ -169,6 +173,8 @@ jobs:
       - name: Ensure pnpm lock visible to electron-builder
         shell: bash
         run: cp pnpm-lock.yaml apps/client/pnpm-lock.yaml
+      - name: Generate app icons (build/*)
+        run: node apps/client/scripts/generate-icons.mjs
       - name: Build & publish Windows x64 to GitHub Releases
         env:
           GH_TOKEN: ${{ github.token }}
@@ -197,6 +203,8 @@ jobs:
       - name: Ensure pnpm lock visible to electron-builder
         shell: bash
         run: cp pnpm-lock.yaml apps/client/pnpm-lock.yaml
+      - name: Generate app icons (build/*)
+        run: node apps/client/scripts/generate-icons.mjs
       - name: Build & publish Linux AppImage x64 to GitHub Releases
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/client/build-mac-workaround.sh
+++ b/apps/client/build-mac-workaround.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Build the Electron app first
+# Build the Electron app and ensure icons exist
 echo "Building Electron app..."
+node ./scripts/generate-icons.mjs
 npx electron-vite build -c electron.vite.config.js
 
 # Create a temporary directory for packaging
@@ -60,23 +61,12 @@ echo "Updating app metadata..."
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion 1.0.0" "$APP_DIR/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString 1.0.0" "$APP_DIR/Contents/Info.plist"
 
-# Ensure our app icon is bundled and used by macOS
-ICONSET_SRC="$(pwd)/assets/cmux-logos/cmux.iconset"
+# Ensure our app icon is bundled and used by macOS from build/*
 BUILD_ICON_ICNS="$(pwd)/build/icon.icns"
-if [ -d "$ICONSET_SRC" ]; then
-  echo "Copying iconset into Resources..."
-  mkdir -p "$RESOURCES_DIR/cmux-logos"
-  rsync -a "$ICONSET_SRC/" "$RESOURCES_DIR/cmux-logos/cmux.iconset/"
-  if [ ! -f "$BUILD_ICON_ICNS" ] && command -v iconutil >/dev/null 2>&1; then
-    echo "Generating build/icon.icns from iconset..."
-    iconutil -c icns "$ICONSET_SRC" -o "$BUILD_ICON_ICNS"
-  fi
-fi
-
 if [ -f "$BUILD_ICON_ICNS" ]; then
-  echo "Installing app icon..."
-  cp "$BUILD_ICON_ICNS" "$RESOURCES_DIR/Cmux.icns"
-  /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile Cmux" "$APP_DIR/Contents/Info.plist"
+  echo "Installing app icon from build/icon.icns..."
+  cp "$BUILD_ICON_ICNS" "$RESOURCES_DIR/icon.icns"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile icon" "$APP_DIR/Contents/Info.plist"
 else
   echo "WARNING: build/icon.icns not found; app icon may remain default" >&2
 fi


### PR DESCRIPTION
in the release-updates.yml as well as the build:mac:workaround csripts, we need to be setting the app icon from build/... so it doesn't require us to open the application to see the icon (i don't want the default icon to be set before we open it first time)