### PR TITLE
Reduce getByTask DB bandwidth help

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -534,21 +534,7 @@ export async function spawnAgent(
         }
         hasFailed = true;
 
-        // Append error to log for context
-        if (data.errorMessage) {
-          await runWithAuth(
-            capturedAuthToken,
-            capturedAuthHeaderJson,
-            async () =>
-              retryOnOptimisticConcurrency(() =>
-                getConvex().mutation(api.taskRuns.appendLogPublic, {
-                  teamSlugOrId,
-                  id: taskRunId,
-                  content: `\n\n=== ERROR ===\n${data.errorMessage}\n=== END ERROR ===\n`,
-                })
-              )
-          );
-        }
+        // Do not write failure info to Convex logs; rely on status and errorMessage fields.
 
         // Mark the run as failed with error message
         await runWithAuth(capturedAuthToken, capturedAuthHeaderJson, async () =>

--- a/apps/server/src/crownEvaluator.ts
+++ b/apps/server/src/crownEvaluator.ts
@@ -537,7 +537,7 @@ export async function evaluateCrown(
         const agentName = agentMatch ? agentMatch[1] : "Unknown";
         // Try to collect diff via worker
         const workerDiff: string | null = await collectDiffViaWorker(run._id);
-        const gitDiff: string = workerDiff && workerDiff.length > 0 ? workerDiff : "No changes detected";
+        let gitDiff: string = workerDiff && workerDiff.length > 0 ? workerDiff : "No changes detected";
 
         // Limit to 5000 chars for the prompt
         if (gitDiff.length > 5000) {

--- a/apps/server/src/crownEvaluator.ts
+++ b/apps/server/src/crownEvaluator.ts
@@ -497,7 +497,7 @@ export async function evaluateCrown(
         }
         if (!instance || !instance.isWorkerConnected()) {
           serverLogger.info(
-            `[CrownEvaluator] No live worker for run ${runId}; falling back to log parsing`
+            `[CrownEvaluator] No live worker for run ${runId}; unable to collect diff`
           );
           return null;
         }
@@ -513,7 +513,7 @@ export async function evaluateCrown(
         const diff = stdout?.trim() || "";
         if (diff.length === 0) {
           serverLogger.info(
-            `[CrownEvaluator] Worker diff empty for run ${runId}; falling back to log parsing`
+            `[CrownEvaluator] Worker diff empty for run ${runId}`
           );
           return null;
         }
@@ -537,65 +537,7 @@ export async function evaluateCrown(
         const agentName = agentMatch ? agentMatch[1] : "Unknown";
         // Try to collect diff via worker
         const workerDiff: string | null = await collectDiffViaWorker(run._id);
-        let gitDiff: string = workerDiff ?? "";
-
-        // Fallback: Extract git diff from log - look for the dedicated sections
-        if (!gitDiff) {
-          gitDiff = "No changes detected";
-
-          // Look for our well-defined git diff section - try multiple formats
-          let gitDiffMatch = run.log.match(
-            /=== GIT DIFF ===\n([\s\S]*?)\n=== END GIT DIFF ===/
-          );
-
-          // Also try the new format with "ALL CHANGES"
-          if (!gitDiffMatch) {
-            gitDiffMatch = run.log.match(
-              /=== ALL CHANGES \(git diff HEAD\) ===\n([\s\S]*?)\n=== END ALL CHANGES ===/
-            );
-          }
-
-          if (gitDiffMatch && gitDiffMatch[1]) {
-            gitDiff = gitDiffMatch[1].trim();
-
-            // If the diff includes the stat summary, extract just the detailed diff part
-            if (gitDiff.includes("=== DETAILED DIFF ===")) {
-              const detailedPart = gitDiff.split("=== DETAILED DIFF ===")[1];
-              if (detailedPart) {
-                gitDiff = detailedPart.trim();
-              }
-            }
-
-            serverLogger.info(
-              `[CrownEvaluator] Found git diff in logs for ${agentName}: ${gitDiff.length} chars`
-            );
-          } else {
-            // If no git diff section found, this is a serious problem
-            serverLogger.error(
-              `[CrownEvaluator] NO GIT DIFF SECTION FOUND for ${agentName}!`
-            );
-            serverLogger.error(
-              `[CrownEvaluator] Log contains "=== GIT DIFF ==="?: ${run.log.includes("=== GIT DIFF ===")}`
-            );
-            serverLogger.error(
-              `[CrownEvaluator] Log contains "=== END GIT DIFF ==="?: ${run.log.includes("=== END GIT DIFF ===")}`
-            );
-            serverLogger.error(
-              `[CrownEvaluator] Log contains "=== ALL CHANGES"?: ${run.log.includes("=== ALL CHANGES")}`
-            );
-
-            // As a last resort, check if there's any indication of changes
-            if (
-              run.log.includes("=== ALL STAGED CHANGES") ||
-              run.log.includes("=== AGGRESSIVE DIFF CAPTURE") ||
-              run.log.includes("ERROR: git diff --cached was empty")
-            ) {
-              // Use whatever we can find
-              const lastPart = run.log.slice(-3000);
-              gitDiff = `ERROR: Git diff not properly captured. Last part of log:\n${lastPart}`;
-            }
-          }
-        }
+        const gitDiff: string = workerDiff && workerDiff.length > 0 ? workerDiff : "No changes detected";
 
         // Limit to 5000 chars for the prompt
         if (gitDiff.length > 5000) {
@@ -606,10 +548,7 @@ export async function evaluateCrown(
           `[CrownEvaluator] Implementation ${idx} (${agentName}): ${gitDiff.length} chars of diff`
         );
 
-        // Log last 500 chars of the run log to debug
-        serverLogger.info(
-          `[CrownEvaluator] ${agentName} log tail: ...${run.log.slice(-500)}`
-        );
+        // Do not rely on logs; skip logging log tails.
 
         return {
           index: idx,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -143,7 +143,8 @@ const convexSchema = defineSchema({
       v.literal("completed"),
       v.literal("failed")
     ),
-    log: v.string(), // CLI output log, will be appended to in real-time
+    // Optional log retained for backward compatibility; no longer written to.
+    log: v.optional(v.string()), // CLI output log (deprecated)
     worktreePath: v.optional(v.string()), // Path to the git worktree for this run
     newBranch: v.optional(v.string()), // The generated branch name for this run
     createdAt: v.number(),

--- a/packages/convex/convex/taskRunLogChunks.ts
+++ b/packages/convex/convex/taskRunLogChunks.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { getTeamId } from "../_shared/team";
 import { authMutation, authQuery } from "./users/utils";
 
+// Deprecated: do not write log chunks anymore (no-op)
 export const appendChunk = authMutation({
   args: {
     teamSlugOrId: v.string(),
@@ -9,17 +10,16 @@ export const appendChunk = authMutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
+    // Intentionally not inserting chunks to reduce DB bandwidth and prepare removal.
+    // Validate access but perform no write.
     const userId = ctx.identity.subject;
     const teamId = await getTeamId(ctx, args.teamSlugOrId);
-    await ctx.db.insert("taskRunLogChunks", {
-      taskRunId: args.taskRunId,
-      content: args.content,
-      userId,
-      teamId,
-    });
+    void userId;
+    void teamId;
   },
 });
 
+// Deprecated: do not write log chunks anymore (no-op)
 export const appendChunkPublic = authMutation({
   args: {
     teamSlugOrId: v.string(),
@@ -27,14 +27,11 @@ export const appendChunkPublic = authMutation({
     content: v.string(),
   },
   handler: async (ctx, args) => {
+    // Intentionally not inserting chunks; keep for backward compatibility.
     const userId = ctx.identity.subject;
     const teamId = await getTeamId(ctx, args.teamSlugOrId);
-    await ctx.db.insert("taskRunLogChunks", {
-      taskRunId: args.taskRunId,
-      content: args.content,
-      userId,
-      teamId,
-    });
+    void userId;
+    void teamId;
   },
 });
 


### PR DESCRIPTION
Reduce getByTask DB bandwidth help me make/ensure taskRuns.log column is optional and stop writing to it from everywhere in the codebase. make it so that crown doesnt fall back to using logs, but just uses the diffs properly. dont write to taskRunLogChunks either, just leave it empty in preparation of getting rid of the column entirely.