### PR TITLE
Update CMD+K menu shortcut: only CMD+K triggers menu

### DIFF
--- a/apps/client/electron/main/cmdk.ts
+++ b/apps/client/electron/main/cmdk.ts
@@ -94,10 +94,17 @@ export function initCmdK(opts: {
         });
         if (input.type !== "keyDown") return;
         const isMac = process.platform === "darwin";
-        const isCmdK =
-          (isMac ? input.meta : input.control) &&
-          !input.alt &&
-          input.key.toLowerCase() === "k";
+        // Only trigger on EXACT Cmd+K (mac) or Ctrl+K (others)
+        const isCmdK = (() => {
+          if (input.key.toLowerCase() !== "k") return false;
+          if (input.alt || input.shift) return false;
+          if (isMac) {
+            // Require meta only; disallow ctrl on mac
+            return Boolean(input.meta) && !input.control;
+          }
+          // Non-mac: require ctrl only; disallow meta
+          return Boolean(input.control) && !input.meta;
+        })();
         if (!isCmdK) return;
         // Prevent default to avoid in-app conflicts and ensure single toggle
         e.preventDefault();
@@ -345,4 +352,3 @@ export function initCmdK(opts: {
     }
   });
 }
-

--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -53,13 +53,20 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
 
     // Web/non-Electron fallback: local keydown listener for Cmd+K
     const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && e.metaKey) {
+      // Only trigger on EXACT Cmd+K (no Shift/Alt/Ctrl)
+      if (
+        e.key.toLowerCase() === "k" &&
+        e.metaKey &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.ctrlKey
+      ) {
         e.preventDefault();
         if (openRef.current) {
           setOpenedWithShift(false);
           setSearch("");
         } else {
-          setOpenedWithShift(e.shiftKey);
+          setOpenedWithShift(false);
           // Capture the currently focused element before opening (web only)
           prevFocusedElRef.current =
             document.activeElement as HTMLElement | null;


### PR DESCRIPTION
make it so that cmd+shift+k doesnt trigger cmdk menu. must be ONLY cmd+k with nothing else.