### PR TITLE
Improve DashboardInputControls @ input width and file display

### DIFF
--- a/apps/client/src/components/dashboard/DashboardInputControls.tsx
+++ b/apps/client/src/components/dashboard/DashboardInputControls.tsx
@@ -161,13 +161,14 @@ export const DashboardInputControls = memo(function DashboardInputControls({
   return (
     <div className="flex items-end gap-1 grow">
       <div className="flex items-end gap-1">
-        <SearchableSelect
+        <div className="min-w-0 basis-[580px] shrink">
+          <SearchableSelect
           options={projectOptions}
           value={selectedProject}
           onChange={onProjectChange}
           placeholder="Select project"
           singleSelect={true}
-          className="rounded-2xl"
+          className="rounded-2xl w-full max-w-[580px] min-w-0"
           loading={isLoadingProjects}
           maxTagCount={1}
           showSearch
@@ -223,6 +224,7 @@ export const DashboardInputControls = memo(function DashboardInputControls({
             </div>
           }
         />
+        </div>
 
         {branchDisabled ? null : (
           <Tooltip>

--- a/apps/client/src/components/ui/searchable-select.tsx
+++ b/apps/client/src/components/ui/searchable-select.tsx
@@ -23,6 +23,8 @@ export interface SelectOptionObject {
   iconKey?: string;
   // Render as a non-selectable heading row
   heading?: boolean;
+  // Optional secondary text rendered muted after the label
+  secondary?: string;
 }
 
 export type SelectOption = string | SelectOptionObject;
@@ -84,6 +86,11 @@ function OptionItem({ opt, isSelected, onSelectValue }: OptionItemProps) {
           </span>
         ) : null}
         <span className="truncate select-none">{opt.label}</span>
+        {opt.secondary ? (
+          <span className="truncate select-none text-neutral-500 dark:text-neutral-400">
+            {opt.secondary}
+          </span>
+        ) : null}
         {opt.isUnavailable ? (
           <AlertTriangle className="w-3.5 h-3.5 text-amber-500 shrink-0" />
         ) : null}
@@ -160,13 +167,18 @@ export function SearchableSelect({
       const selectedOpt = normOptions.find((o) => o.value === selectedVal);
       const label = selectedLabels[0];
       return (
-        <span className="inline-flex items-center gap-2">
+        <span className="inline-flex items-center gap-2 min-w-0">
           {selectedOpt?.icon ? (
             <span className="shrink-0 inline-flex items-center justify-center">
               {selectedOpt.icon}
             </span>
           ) : null}
           <span className="truncate select-none">{label}</span>
+          {selectedOpt?.secondary ? (
+            <span className="truncate select-none text-neutral-500 dark:text-neutral-400">
+              {selectedOpt.secondary}
+            </span>
+          ) : null}
         </span>
       );
     }

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -430,14 +430,19 @@ function DashboardComponent() {
         )
       )
     );
-    const repoOptions = repoValues.map((fullName) => ({
-      label: fullName,
-      value: fullName,
-      icon: (
-        <GitHubIcon className="w-4 h-4 text-neutral-600 dark:text-neutral-300" />
-      ),
-      iconKey: "github",
-    }));
+    const repoOptions = repoValues.map((fullName) => {
+      const parts = fullName.split("/");
+      const repoName = parts[parts.length - 1] ?? fullName;
+      return {
+        label: repoName,
+        secondary: fullName,
+        value: fullName,
+        icon: (
+          <GitHubIcon className="w-4 h-4 text-neutral-600 dark:text-neutral-300" />
+        ),
+        iconKey: "github",
+      } satisfies SelectOption;
+    });
 
     // Environment options as objects with an icon and stable key
     const envOptions = (environmentsQuery.data || []).map((env) => ({


### PR DESCRIPTION
when we say "@" in the @apps/client/src/components/dashboard/DashboardInputControls.tsx i want it to be a lot wider. give it max width of 580px but still allow it to shrink kinda.also it should show filename first. then the path, slightly more greyed out.