### PR TITLE
Fix repository search not showing forked repositories

### DIFF
--- a/apps/www/lib/routes/github.repos.route.ts
+++ b/apps/www/lib/routes/github.repos.route.ts
@@ -109,7 +109,12 @@ githubReposRouter.openapi(
         target.accountType === "Organization"
           ? `org:${target.accountLogin}`
           : `user:${target.accountLogin}`;
-      const q = [ownerQualifier, search ? `${search} in:name` : null]
+      // Include forks explicitly; GitHub search excludes forks by default
+      const q = [
+        ownerQualifier,
+        "fork:true",
+        search ? `${search} in:name` : null,
+      ]
         .filter(Boolean)
         .join(" ");
       const searchRes = await octokit.request("GET /search/repositories", {


### PR DESCRIPTION
for environments, when i try to set up, and i try to set up a new repo, i try searching for a repo i forked (like https://github.com/lawrencecchen/stack-auth) but it doesnt show up. why? how to fix?