### PR TITLE
Fix: Agent icon display for duplicate types on trigger

### DIFF
--- a/apps/client/src/components/ui/searchable-select.tsx
+++ b/apps/client/src/components/ui/searchable-select.tsx
@@ -186,7 +186,7 @@ export function SearchableSelect({
       seen.add(it.key);
       uniqueIcons.push(it.icon);
     }
-    if (uniqueIcons.length >= 2) {
+    if (uniqueIcons.length > 0) {
       const maxIcons = 5;
       return (
         <span className="inline-flex items-center gap-2">


### PR DESCRIPTION
when there are two agents of the same type (like 2 openai codes, or 2 claude codes) the icon doesnt show up on the trigger.