### PR TITLE
Fix environment repo search to include forked repositories

### DIFF
--- a/apps/www/lib/routes/github.repos.route.ts
+++ b/apps/www/lib/routes/github.repos.route.ts
@@ -109,7 +109,7 @@ githubReposRouter.openapi(
         target.accountType === "Organization"
           ? `org:${target.accountLogin}`
           : `user:${target.accountLogin}`;
-      const q = [ownerQualifier, search ? `${search} in:name` : null]
+      const q = [ownerQualifier, "fork:true", search ? `${search} in:name` : null]
         .filter(Boolean)
         .join(" ");
       const searchRes = await octokit.request("GET /search/repositories", {


### PR DESCRIPTION
for environments, when i try to set up, and i try to set up a new repo, i try searching for a repo i forked (like https://github.com/lawrencecchen/stack-auth) but it doesnt show up. why? how to fix? i want the search to work for both forked repos and my own repos or my org's repos.