### PR TITLE
Integrate Rust for fuzzy search of @-mentions in Electron

### DIFF
--- a/apps/client/src/components/lexical/MentionPlugin.tsx
+++ b/apps/client/src/components/lexical/MentionPlugin.tsx
@@ -17,6 +17,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { getIconForFile } from "vscode-icons-js";
+import { isElectron } from "@/lib/electron";
 import { useSocket } from "../../contexts/socket/use-socket";
 
 const MENTION_TRIGGER = "@";
@@ -143,7 +144,8 @@ export function MentionPlugin({ repoUrl, branch }: MentionPluginProps) {
   useEffect(() => {
     if (repoUrl && socket) {
       setIsLoading(true);
-      socket.emit("list-files", {
+      const eventName = isElectron ? "list-files-native" : "list-files";
+      socket.emit(eventName, {
         repoPath: repoUrl,
         branch: branch || undefined,
         // Don't send pattern - we want all files

--- a/apps/server/native/core/Cargo.toml
+++ b/apps/server/native/core/Cargo.toml
@@ -17,6 +17,8 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 gix = { version = "0.66", default-features = true, features = ["status", "revision"] }
 similar = "2"
+globset = "0.4"
+fuzzy-matcher = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/server/native/core/src/files.rs
+++ b/apps/server/native/core/src/files.rs
@@ -1,0 +1,253 @@
+use anyhow::{anyhow, Result};
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use gix::bstr::ByteSlice;
+use gix::{hash::ObjectId, Repository};
+use std::path::{Path, PathBuf};
+
+use crate::repo::cache::{
+  ensure_repo,
+  resolve_repo_url,
+  swr_fetch_origin_all_path,
+};
+use crate::types::{ListRepoFilesOptions, RepoFileInfo};
+
+const IGNORE_PATTERNS: &[&str] = &[
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.next/**",
+  "**/coverage/**",
+  "**/.turbo/**",
+  "**/.vscode/**",
+  "**/.idea/**",
+  "**/tmp/**",
+  "**/.DS_Store",
+  "**/npm-debug.log*",
+  "**/yarn-debug.log*",
+  "**/yarn-error.log*",
+];
+
+fn build_ignore_set() -> Result<GlobSet> {
+  let mut builder = GlobSetBuilder::new();
+  for pattern in IGNORE_PATTERNS {
+    builder.add(Glob::new(pattern)?);
+  }
+  Ok(builder.build()?)
+}
+
+fn resolve_branch_oid(repo: &Repository, branch: Option<&str>) -> Result<ObjectId> {
+  if let Some(raw) = branch {
+    let trimmed = raw.trim();
+    if !trimmed.is_empty() {
+      let direct = [
+        trimmed.to_string(),
+        format!("refs/remotes/origin/{}", trimmed),
+        format!("refs/heads/{}", trimmed),
+      ];
+      for candidate in &direct {
+        if let Ok(reference) = repo.find_reference(candidate) {
+          if let Some(id) = reference.target().try_id() {
+            return Ok(id.to_owned());
+          }
+          if let Some(name) = reference.target().try_name() {
+            let s = name.as_bstr().to_str_lossy().into_owned();
+            if let Ok(inner) = repo.find_reference(&s) {
+              if let Some(id) = inner.target().try_id() {
+                return Ok(id.to_owned());
+              }
+            }
+          }
+        }
+        if let Ok(spec) = repo.rev_parse_single(candidate) {
+          if let Ok(obj) = spec.object() {
+            return Ok(obj.id);
+          }
+        }
+      }
+    }
+  }
+
+  let fallbacks = [
+    "HEAD",
+    "refs/remotes/origin/HEAD",
+    "refs/remotes/origin/main",
+    "refs/remotes/origin/master",
+    "refs/heads/main",
+    "refs/heads/master",
+  ];
+
+  for candidate in &fallbacks {
+    if let Ok(reference) = repo.find_reference(candidate) {
+      if let Some(id) = reference.target().try_id() {
+        return Ok(id.to_owned());
+      }
+      if let Some(name) = reference.target().try_name() {
+        let s = name.as_bstr().to_str_lossy().into_owned();
+        if let Ok(inner) = repo.find_reference(&s) {
+          if let Some(id) = inner.target().try_id() {
+            return Ok(id.to_owned());
+          }
+        }
+      }
+    }
+    if let Ok(spec) = repo.rev_parse_single(candidate) {
+      if let Ok(obj) = spec.object() {
+        return Ok(obj.id);
+      }
+    }
+  }
+
+  Err(anyhow!("unable to resolve branch or HEAD for repository"))
+}
+
+fn collect_tree(
+  repo: &Repository,
+  tree: gix::objs::Tree,
+  ignore: &GlobSet,
+  include_directories: bool,
+  prefix: &str,
+  repo_root: &Path,
+  out: &mut Vec<RepoFileInfo>,
+) -> Result<()> {
+  for entry_res in tree.iter() {
+    let entry = entry_res?;
+    let name = entry.filename().to_str_lossy().into_owned();
+    let rel = if prefix.is_empty() {
+      name.clone()
+    } else {
+      format!("{}/{}", prefix, name)
+    };
+    let rel_norm = rel.replace('\\', "/");
+
+    if ignore.is_match(&rel_norm) {
+      continue;
+    }
+
+    let mode = entry.mode();
+    let abs_path = repo_root.join(rel_norm.as_str());
+
+    if mode.is_tree() {
+      if include_directories {
+        out.push(RepoFileInfo {
+          path: abs_path.to_string_lossy().into_owned(),
+          name: name.clone(),
+          isDirectory: true,
+          relativePath: rel_norm.clone(),
+        });
+      }
+
+      let id = entry.oid().to_owned();
+      let obj = repo.find_object(id)?;
+      let subtree = obj.try_into_tree()?;
+      collect_tree(
+        repo,
+        subtree,
+        ignore,
+        include_directories,
+        &rel_norm,
+        repo_root,
+        out,
+      )?;
+    } else {
+      out.push(RepoFileInfo {
+        path: abs_path.to_string_lossy().into_owned(),
+        name: name.clone(),
+        isDirectory: false,
+        relativePath: rel_norm.clone(),
+      });
+    }
+  }
+
+  Ok(())
+}
+
+pub fn list_repository_files(opts: ListRepoFilesOptions) -> Result<Vec<RepoFileInfo>> {
+  let ignore = build_ignore_set()?;
+
+  let origin_override = opts.originPath.clone();
+  let repo_path = if let Some(ref origin) = origin_override {
+    PathBuf::from(origin)
+  } else {
+    let url = resolve_repo_url(opts.repoFullName.as_deref(), opts.repoUrl.as_deref())?;
+    ensure_repo(&url)?
+  };
+
+  let should_fetch = opts.originPath.is_none();
+  if should_fetch {
+    let _ = swr_fetch_origin_all_path(&repo_path, crate::repo::cache::fetch_window_ms());
+  }
+
+  let repo_root_for_paths = origin_override
+    .unwrap_or_else(|| repo_path.to_string_lossy().into_owned());
+  let repo = gix::open(&repo_path)?;
+
+  let branch_oid = resolve_branch_oid(&repo, opts.branch.as_deref())?;
+  let commit = repo.find_object(branch_oid)?.try_into_commit()?;
+  let tree_id = commit.tree_id()?.detach();
+  let tree = repo.find_object(tree_id)?.try_into_tree()?;
+
+  let include_directories = opts
+    .pattern
+    .as_ref()
+    .map(|s| s.trim().is_empty())
+    .unwrap_or(true);
+
+  let mut entries: Vec<RepoFileInfo> = Vec::new();
+  collect_tree(
+    &repo,
+    tree,
+    &ignore,
+    include_directories,
+    "",
+    Path::new(&repo_root_for_paths),
+    &mut entries,
+  )?;
+
+  let pattern = opts
+    .pattern
+    .as_deref()
+    .map(|s| s.trim())
+    .filter(|s| !s.is_empty())
+    .map(|s| s.to_string());
+
+  if let Some(pat) = pattern {
+    let matcher = SkimMatcherV2::default();
+    let limit = opts.limit.unwrap_or(1000).max(1) as usize;
+    let mut matched: Vec<(i64, RepoFileInfo)> = entries
+      .into_iter()
+      .filter(|entry| !entry.isDirectory)
+      .filter_map(|entry| {
+        matcher
+          .fuzzy_match(&entry.relativePath, &pat)
+          .map(|score| (score, entry))
+      })
+      .collect();
+
+    matched.sort_by(|a, b| {
+      b.0.cmp(&a.0)
+        .then_with(|| a.1.relativePath.cmp(&b.1.relativePath))
+    });
+
+    let mut out: Vec<RepoFileInfo> = Vec::new();
+    for (_, entry) in matched.into_iter().take(limit) {
+      out.push(entry);
+    }
+    return Ok(out);
+  }
+
+  entries.sort_by(|a, b| {
+    if a.isDirectory != b.isDirectory {
+      return if a.isDirectory {
+        std::cmp::Ordering::Less
+      } else {
+        std::cmp::Ordering::Greater
+      };
+    }
+    a.relativePath.cmp(&b.relativePath)
+  });
+
+  Ok(entries)
+}

--- a/apps/server/native/core/src/lib.rs
+++ b/apps/server/native/core/src/lib.rs
@@ -6,10 +6,20 @@ mod repo;
 mod diff;
 mod merge_base;
 mod branches;
+mod files;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use types::{BranchInfo, DiffEntry, GitDiffRefsOptions, GitDiffWorkspaceOptions, GitListRemoteBranchesOptions, GitDiffLandedOptions};
+use types::{
+  BranchInfo,
+  DiffEntry,
+  GitDiffRefsOptions,
+  GitDiffWorkspaceOptions,
+  GitListRemoteBranchesOptions,
+  GitDiffLandedOptions,
+  RepoFileInfo,
+  ListRepoFilesOptions,
+};
 
 #[napi]
 pub async fn get_time() -> String {
@@ -84,6 +94,14 @@ pub async fn git_list_remote_branches(opts: GitListRemoteBranchesOptions) -> Res
     opts.originPathOverride
   );
   tokio::task::spawn_blocking(move || branches::list_remote_branches(opts))
+    .await
+    .map_err(|e| Error::from_reason(format!("Join error: {e}")))?
+    .map_err(|e| Error::from_reason(format!("{e:#}")))
+}
+
+#[napi]
+pub async fn list_repository_files(opts: ListRepoFilesOptions) -> Result<Vec<RepoFileInfo>> {
+  tokio::task::spawn_blocking(move || crate::files::list_repository_files(opts))
     .await
     .map_err(|e| Error::from_reason(format!("Join error: {e}")))?
     .map_err(|e| Error::from_reason(format!("{e:#}")))

--- a/apps/server/native/core/src/types.rs
+++ b/apps/server/native/core/src/types.rs
@@ -30,6 +30,26 @@ pub struct BranchInfo {
 
 #[napi(object)]
 #[derive(Default, Debug, Clone)]
+pub struct RepoFileInfo {
+  pub path: String,
+  pub name: String,
+  pub isDirectory: bool,
+  pub relativePath: String,
+}
+
+#[napi(object)]
+#[derive(Default, Debug, Clone)]
+pub struct ListRepoFilesOptions {
+  pub repoUrl: Option<String>,
+  pub repoFullName: Option<String>,
+  pub originPath: Option<String>,
+  pub branch: Option<String>,
+  pub pattern: Option<String>,
+  pub limit: Option<i32>,
+}
+
+#[napi(object)]
+#[derive(Default, Debug, Clone)]
 pub struct GitListRemoteBranchesOptions {
   pub repoFullName: Option<String>,
   pub repoUrl: Option<String>,

--- a/apps/server/src/native/git.ts
+++ b/apps/server/src/native/git.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { ReplaceDiffEntry } from "@cmux/shared/diff-types";
+import type { FileInfo } from "@cmux/shared";
 
 export type GitImplMode = "rust" | "js";
 
@@ -53,6 +54,14 @@ type NativeGitModule = {
       isDefault?: boolean;
     }>
   >;
+  listRepositoryFiles?: (opts: {
+    repoUrl?: string;
+    repoFullName?: string;
+    originPath?: string;
+    branch?: string;
+    pattern?: string;
+    limit?: number;
+  }) => Promise<FileInfo[]>;
 };
 
 function tryLoadNative(): NativeGitModule | null {
@@ -164,4 +173,28 @@ export async function listRemoteBranches(opts: {
     );
   }
   return mod.gitListRemoteBranches(opts);
+}
+
+export async function listRepositoryFilesNative(opts: {
+  repoUrl?: string;
+  repoFullName?: string;
+  originPath?: string;
+  branch?: string;
+  pattern?: string;
+  limit?: number;
+}): Promise<FileInfo[]> {
+  const mod = loadNativeGit();
+  if (!mod?.listRepositoryFiles) {
+    throw new Error(
+      "Native listRepositoryFiles not available; rebuild @cmux/native-core"
+    );
+  }
+  return mod.listRepositoryFiles({
+    repoUrl: opts.repoUrl,
+    repoFullName: opts.repoFullName,
+    originPath: opts.originPath,
+    branch: opts.branch,
+    pattern: opts.pattern,
+    limit: opts.limit,
+  });
 }

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -28,6 +28,7 @@ import { getRunDiffs } from "./diffs/getRunDiffs.js";
 import { execWithEnv } from "./execWithEnv.js";
 import { GitDiffManager } from "./gitDiff.js";
 import { getRustTime } from "./native/core.js";
+import { listRepositoryFilesNative } from "./native/git.js";
 import type { RealtimeServer } from "./realtime.js";
 import { RepositoryManager } from "./repositoryManager.js";
 import type { GitRepoInfo } from "./server.js";
@@ -1270,6 +1271,66 @@ export function setupSocketHandlers(
         socket.emit("list-files-response", { files: fileList });
       } catch (error) {
         serverLogger.error("Error listing files:", error);
+        socket.emit("list-files-response", {
+          files: [],
+          error: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    });
+
+    socket.on("list-files-native", async (data) => {
+      try {
+        const {
+          repoPath: repoUrl,
+          branch,
+          pattern,
+        } = ListFilesRequestSchema.parse(data);
+        const repoManager = RepositoryManager.getInstance();
+
+        const projectPaths = await getProjectPaths(repoUrl, safeTeam);
+
+        await fs.mkdir(projectPaths.projectPath, { recursive: true });
+        await fs.mkdir(projectPaths.worktreesPath, { recursive: true });
+
+        await repoManager.ensureRepository(repoUrl, projectPaths.originPath);
+
+        const baseBranch =
+          branch ||
+          (await repoManager.getDefaultBranch(projectPaths.originPath));
+
+        await repoManager.ensureRepository(
+          repoUrl,
+          projectPaths.originPath,
+          baseBranch
+        );
+
+        try {
+          await fs.access(projectPaths.originPath);
+        } catch {
+          socket.emit("list-files-response", {
+            files: [],
+            error: "Repository directory not found",
+          });
+          return;
+        }
+
+        const trimmedPattern = pattern?.trim();
+        const files = await listRepositoryFilesNative({
+          repoUrl,
+          originPath: projectPaths.originPath,
+          branch: baseBranch,
+          pattern: trimmedPattern && trimmedPattern.length > 0
+            ? trimmedPattern
+            : undefined,
+          limit:
+            trimmedPattern && trimmedPattern.length > 0
+              ? 1000
+              : undefined,
+        });
+
+        socket.emit("list-files-response", { files });
+      } catch (error) {
+        serverLogger.error("Error listing files (native):", error);
         socket.emit("list-files-response", {
           files: [],
           error: error instanceof Error ? error.message : "Unknown error",

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -492,6 +492,7 @@ export interface ClientToServerEvents {
     callback: (response: OpenInEditorResponse) => void
   ) => void;
   "list-files": (data: ListFilesRequest) => void;
+  "list-files-native": (data: ListFilesRequest) => void;
   // GitHub operations
   "github-test-auth": (
     callback: (response: GitHubAuthResponse) => void


### PR DESCRIPTION
when i type the [at] symbol, iff we're in electron, make it use a new codepath that will actually go to rust! write tests for it in rust. make sure to handle the right branch too! for comms with rust, make a new socketio thing. make sure to fuzzy sort/match properly, installing new dependencies is allowed. just make sure to write tests.