### PR TITLE
Add GitHub checks, actions, and PR comments sync

### DIFF
--- a/packages/convex/convex/github_actions.ts
+++ b/packages/convex/convex/github_actions.ts
@@ -1,0 +1,214 @@
+import { v } from "convex/values";
+import { internalMutation, type MutationCtx } from "./_generated/server";
+
+function mapStr(vv: unknown): string | undefined {
+  return typeof vv === "string" ? vv : undefined;
+}
+function mapNum(vv: unknown): number | undefined {
+  return typeof vv === "number" ? vv : undefined;
+}
+function ts(vv: unknown): number | undefined {
+  if (typeof vv !== "string") return undefined;
+  const n = Date.parse(vv);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+async function upsertWorkflowRun(
+  ctx: MutationCtx,
+  args: { teamId: string; installationId: number; repoFullName: string; payload: any }
+) {
+  const wr = (args.payload?.workflow_run ?? {}) as Record<string, any>;
+  const runId = Number(wr.id ?? 0);
+  if (!runId) return { ok: false as const };
+
+  const status = mapStr(wr.status) as any;
+  const conclusion = mapStr(wr.conclusion) as any;
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(args.payload?.repository?.id),
+    runId,
+    runNumber: mapNum(wr.run_number),
+    runAttempt: mapNum(wr.run_attempt),
+    workflowId: mapNum(wr.workflow_id),
+    workflowName: mapStr(wr.name) ?? mapStr(wr?.workflow_name),
+    name: mapStr(wr.display_title) ?? mapStr(wr.name),
+    event: mapStr(wr.event),
+    headBranch: mapStr(wr.head_branch),
+    headSha: mapStr(wr.head_sha) ?? "",
+    status,
+    conclusion,
+    checkSuiteId: mapNum(wr.check_suite_id),
+    actorLogin: mapStr(wr?.actor?.login),
+    actorId: mapNum(wr?.actor?.id),
+    htmlUrl: mapStr(wr.html_url),
+    createdAt: ts(wr.created_at),
+    updatedAt: ts(wr.updated_at),
+    runStartedAt: ts(wr.run_started_at),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubWorkflowRuns")
+    .withIndex("by_team_repo_run", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("runId", runId)
+    )
+    .first();
+
+  const now = Date.now();
+  if (existing) {
+    const prevStatus = existing.status;
+    const prevConclusion = existing.conclusion;
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    if (prevStatus !== status || prevConclusion !== conclusion) {
+      // @ts-expect-error: New table will be in generated types after codegen
+      await ctx.db.insert("githubWorkflowRunHistory", {
+        teamId: args.teamId,
+        installationId: args.installationId,
+        repoFullName: args.repoFullName,
+        runId,
+        runAttempt: mapNum(wr.run_attempt),
+        status,
+        conclusion,
+        createdAt:
+          ts(wr.updated_at) ?? ts(wr.run_started_at) ?? ts(wr.created_at) ?? now,
+      });
+    }
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubWorkflowRuns", record);
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubWorkflowRunHistory", {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    runId,
+    runAttempt: mapNum(wr.run_attempt),
+    status,
+    conclusion,
+    createdAt: ts(wr.created_at) ?? now,
+  });
+  return { ok: true as const };
+}
+
+async function upsertWorkflowJob(
+  ctx: MutationCtx,
+  args: { teamId: string; installationId: number; repoFullName: string; payload: any }
+) {
+  const job = (args.payload?.workflow_job ?? {}) as Record<string, any>;
+  const jobId = Number(job.id ?? 0);
+  if (!jobId) return { ok: false as const };
+
+  const status = mapStr(job.status) as any;
+  const conclusion = mapStr(job.conclusion) as any;
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(args.payload?.repository?.id),
+    jobId,
+    runId: Number(job.run_id ?? args.payload?.workflow_run?.id ?? 0) || 0,
+    runAttempt:
+      mapNum(job.run_attempt ?? args.payload?.workflow_run?.run_attempt),
+    name: mapStr(job.name),
+    headSha: mapStr(job?.head_sha),
+    status,
+    conclusion,
+    htmlUrl: mapStr(job.html_url),
+    runnerName: mapStr(job.runner_name),
+    labels: Array.isArray(job.labels)
+      ? (job.labels as unknown[]).map((x) => String(x))
+      : undefined,
+    steps: Array.isArray(job.steps)
+      ? (job.steps as unknown[]).map((s) => {
+          const so = s as Record<string, any>;
+          return {
+            number: mapNum(so.number),
+            name: mapStr(so.name),
+            status: mapStr(so.status) as any,
+            conclusion: mapStr(so.conclusion) as any,
+            startedAt: ts(so.started_at),
+            completedAt: ts(so.completed_at),
+          };
+        })
+      : undefined,
+    startedAt: ts(job.started_at),
+    completedAt: ts(job.completed_at),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubWorkflowJobs")
+    .withIndex("by_team_repo_job", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("jobId", jobId)
+    )
+    .first();
+
+  const now = Date.now();
+  if (existing) {
+    const prevStatus = existing.status;
+    const prevConclusion = existing.conclusion;
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    if (prevStatus !== status || prevConclusion !== conclusion) {
+      // @ts-expect-error: New table will be in generated types after codegen
+      await ctx.db.insert("githubWorkflowJobHistory", {
+        teamId: args.teamId,
+        installationId: args.installationId,
+        repoFullName: args.repoFullName,
+        jobId,
+        runId: record.runId,
+        status,
+        conclusion,
+        createdAt:
+          ts(job.completed_at) ?? ts(job.started_at) ?? ts(job.started_at) ?? now,
+      });
+    }
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubWorkflowJobs", record);
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubWorkflowJobHistory", {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    jobId,
+    runId: record.runId,
+    status,
+    conclusion,
+    createdAt: ts(job.started_at) ?? now,
+  });
+  return { ok: true as const };
+}
+
+export const upsertWorkflowRunFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertWorkflowRun(ctx, args),
+});
+
+export const upsertWorkflowJobFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertWorkflowJob(ctx, args),
+});

--- a/packages/convex/convex/github_checks.ts
+++ b/packages/convex/convex/github_checks.ts
@@ -1,0 +1,191 @@
+import { v } from "convex/values";
+import { internalMutation, type MutationCtx } from "./_generated/server";
+
+function mapStr(vv: unknown): string | undefined {
+  return typeof vv === "string" ? vv : undefined;
+}
+function mapNum(vv: unknown): number | undefined {
+  return typeof vv === "number" ? vv : undefined;
+}
+function mapBool(vv: unknown): boolean | undefined {
+  return typeof vv === "boolean" ? vv : undefined;
+}
+function ts(vv: unknown): number | undefined {
+  if (typeof vv !== "string") return undefined;
+  const n = Date.parse(vv);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+async function upsertCheckSuite(
+  ctx: MutationCtx,
+  args: {
+    teamId: string;
+    installationId: number;
+    repoFullName: string;
+    payload: any;
+  }
+) {
+  const suite = (args.payload?.check_suite ?? {}) as Record<string, any>;
+  const checkSuiteId = Number(suite.id ?? 0);
+  if (!checkSuiteId) return { ok: false as const };
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(args.payload?.repository?.id),
+    checkSuiteId,
+    headBranch: mapStr(suite.head_branch),
+    headSha: mapStr(suite.head_sha) ?? "",
+    status: mapStr(suite.status) as any,
+    conclusion: mapStr(suite.conclusion) as any,
+    latestCheckRunsCount: mapNum(suite.latest_check_runs_count),
+    before: mapStr(suite.before),
+    after: mapStr(suite.after),
+    appSlug: mapStr(suite?.app?.slug),
+    createdAt: ts(suite.created_at),
+    updatedAt: ts(suite.updated_at),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubCheckSuites")
+    .withIndex("by_team_repo_suite", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("checkSuiteId", checkSuiteId)
+    )
+    .first();
+  if (existing) {
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubCheckSuites", record);
+  return { ok: true as const };
+}
+
+async function upsertCheckRun(
+  ctx: MutationCtx,
+  args: {
+    teamId: string;
+    installationId: number;
+    repoFullName: string;
+    payload: any;
+  }
+) {
+  const run = (args.payload?.check_run ?? {}) as Record<string, any>;
+  const checkRunId = Number(run.id ?? 0);
+  if (!checkRunId) return { ok: false as const };
+
+  const status = mapStr(run.status) as any;
+  const conclusion = mapStr(run.conclusion) as any;
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(args.payload?.repository?.id),
+    checkRunId,
+    checkSuiteId: mapNum(run?.check_suite?.id ?? args.payload?.check_suite?.id),
+    name: mapStr(run.name),
+    headSha: mapStr(run.head_sha) ?? "",
+    status,
+    conclusion,
+    externalId: mapStr(run.external_id),
+    detailsUrl: mapStr(run.details_url),
+    htmlUrl: mapStr(run.html_url),
+    startedAt: ts(run.started_at),
+    completedAt: ts(run.completed_at),
+    output: (():
+      | {
+          title?: string;
+          summary?: string;
+          text?: string;
+          annotationsCount?: number;
+          annotationsUrl?: string;
+        }
+      | undefined => {
+      const out = run.output as Record<string, any> | undefined;
+      if (!out) return undefined;
+      return {
+        title: mapStr(out.title),
+        summary: mapStr(out.summary),
+        text: mapStr(out.text),
+        annotationsCount: mapNum(out.annotations_count),
+        annotationsUrl: mapStr(out.annotations_url),
+      };
+    })(),
+    appSlug: mapStr(run?.app?.slug),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubCheckRuns")
+    .withIndex("by_team_repo_run", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("checkRunId", checkRunId)
+    )
+    .first();
+
+  const now = Date.now();
+  if (existing) {
+    const prevStatus = existing.status;
+    const prevConclusion = (existing as any).conclusion as
+      | string
+      | undefined;
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    if (prevStatus !== status || prevConclusion !== conclusion) {
+      // @ts-expect-error: New table will be in generated types after codegen
+      await ctx.db.insert("githubCheckRunHistory", {
+        teamId: args.teamId,
+        installationId: args.installationId,
+        repoFullName: args.repoFullName,
+        checkRunId,
+        status,
+        conclusion,
+        createdAt:
+          ts(run.completed_at) ?? ts(run.started_at) ?? ts(run.created_at) ?? now,
+      });
+    }
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubCheckRuns", record);
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubCheckRunHistory", {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    checkRunId,
+    status,
+    conclusion,
+    createdAt: ts(run.created_at) ?? now,
+  });
+  return { ok: true as const };
+}
+
+export const upsertCheckSuiteFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertCheckSuite(ctx, args),
+});
+
+export const upsertCheckRunFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertCheckRun(ctx, args),
+});

--- a/packages/convex/convex/github_comments.ts
+++ b/packages/convex/convex/github_comments.ts
@@ -1,0 +1,195 @@
+import { v } from "convex/values";
+import { internalMutation, type MutationCtx } from "./_generated/server";
+
+function mapStr(vv: unknown): string | undefined {
+  return typeof vv === "string" ? vv : undefined;
+}
+function mapNum(vv: unknown): number | undefined {
+  return typeof vv === "number" ? vv : undefined;
+}
+function ts(vv: unknown): number | undefined {
+  if (typeof vv !== "string") return undefined;
+  const n = Date.parse(vv);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+async function upsertIssueComment(
+  ctx: MutationCtx,
+  args: { teamId: string; installationId: number; repoFullName: string; payload: any }
+) {
+  const payload = args.payload as Record<string, any>;
+  const issue = (payload?.issue ?? {}) as Record<string, any>;
+  const prFlag = issue.pull_request != null; // only keep PR comments
+  if (!prFlag) return { ok: true as const };
+  const number = Number(issue.number ?? payload?.number ?? 0);
+  const comment = (payload?.comment ?? {}) as Record<string, any>;
+  const commentId = Number(comment.id ?? 0);
+  if (!number || !commentId) return { ok: false as const };
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(payload?.repository?.id),
+    number,
+    commentId,
+    body: mapStr(comment.body) ?? "",
+    authorLogin: mapStr(comment?.user?.login),
+    authorId: mapNum(comment?.user?.id),
+    htmlUrl: mapStr(comment.html_url),
+    createdAt: ts(comment.created_at) ?? Date.now(),
+    updatedAt: ts(comment.updated_at) ?? ts(comment.created_at) ?? Date.now(),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubIssueComments")
+    .withIndex("by_team_repo_pr", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("number", number)
+        .eq("commentId", commentId)
+    )
+    .first();
+  if (existing) {
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubIssueComments", record);
+  return { ok: true as const };
+}
+
+async function upsertReview(
+  ctx: MutationCtx,
+  args: { teamId: string; installationId: number; repoFullName: string; payload: any }
+) {
+  const payload = args.payload as Record<string, any>;
+  const pr = (payload?.pull_request ?? {}) as Record<string, any>;
+  const number = Number(pr.number ?? payload?.number ?? 0);
+  const review = (payload?.review ?? {}) as Record<string, any>;
+  const reviewId = Number(review.id ?? 0);
+  if (!number || !reviewId) return { ok: false as const };
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(payload?.repository?.id),
+    number,
+    reviewId,
+    state: mapStr(review.state) ?? "commented",
+    body: mapStr(review.body),
+    authorLogin: mapStr(review?.user?.login),
+    authorId: mapNum(review?.user?.id),
+    commitId: mapStr(review.commit_id),
+    htmlUrl: mapStr(review.html_url),
+    submittedAt: ts(review.submitted_at) ?? ts(review.created_at),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubPullRequestReviews")
+    .withIndex("by_team_repo_pr", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("number", number)
+        .eq("reviewId", reviewId)
+    )
+    .first();
+  if (existing) {
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubPullRequestReviews", record);
+  return { ok: true as const };
+}
+
+async function upsertReviewComment(
+  ctx: MutationCtx,
+  args: { teamId: string; installationId: number; repoFullName: string; payload: any }
+) {
+  const payload = args.payload as Record<string, any>;
+  const pr = (payload?.pull_request ?? {}) as Record<string, any>;
+  const number = Number(pr.number ?? payload?.number ?? 0);
+  const comment = (payload?.comment ?? {}) as Record<string, any>;
+  const commentId = Number(comment.id ?? 0);
+  if (!number || !commentId) return { ok: false as const };
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(payload?.repository?.id),
+    number,
+    commentId,
+    reviewId: mapNum(comment.pull_request_review_id),
+    body: mapStr(comment.body) ?? "",
+    authorLogin: mapStr(comment?.user?.login),
+    authorId: mapNum(comment?.user?.id),
+    path: mapStr(comment.path),
+    diffHunk: mapStr(comment.diff_hunk),
+    position: mapNum(comment.position),
+    line: mapNum(comment.line),
+    originalLine: mapNum(comment.original_line),
+    side: mapStr(comment.side),
+    htmlUrl: mapStr(comment.html_url),
+    createdAt: ts(comment.created_at) ?? Date.now(),
+    updatedAt: ts(comment.updated_at) ?? ts(comment.created_at) ?? Date.now(),
+  } as const;
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubPullRequestReviewComments")
+    .withIndex("by_team_repo_pr", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("number", number)
+        .eq("commentId", commentId)
+    )
+    .first();
+  if (existing) {
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubPullRequestReviewComments", record);
+  return { ok: true as const };
+}
+
+export const upsertIssueCommentFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertIssueComment(ctx, args),
+});
+
+export const upsertPullRequestReviewFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertReview(ctx, args),
+});
+
+export const upsertPullRequestReviewCommentFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertReviewComment(ctx, args),
+});

--- a/packages/convex/convex/github_statuses.ts
+++ b/packages/convex/convex/github_statuses.ts
@@ -1,0 +1,96 @@
+import { v } from "convex/values";
+import { internalMutation, type MutationCtx } from "./_generated/server";
+
+function mapStr(vv: unknown): string | undefined {
+  return typeof vv === "string" ? vv : undefined;
+}
+function mapNum(vv: unknown): number | undefined {
+  return typeof vv === "number" ? vv : undefined;
+}
+function ts(vv: unknown): number | undefined {
+  if (typeof vv !== "string") return undefined;
+  const n = Date.parse(vv);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+async function upsertCommitStatus(
+  ctx: MutationCtx,
+  args: { teamId: string; installationId: number; repoFullName: string; payload: any }
+) {
+  const status = (args.payload ?? {}) as Record<string, any>;
+  const sha = mapStr(status.sha) ?? mapStr(status.commit?.sha) ?? "";
+  const context = mapStr(status.context) ?? "default";
+  const state = mapStr(status.state) as "error" | "failure" | "pending" | "success" | undefined;
+  if (!sha || !context || !state) return { ok: false as const };
+
+  const updatedAt = ts(status.updated_at) ?? ts(status.created_at) ?? Date.now();
+
+  // @ts-expect-error: New table will be in generated types after codegen
+  const existing = await ctx.db
+    .query("githubCommitStatuses")
+    .withIndex("by_team_repo_sha_ctx", (q) =>
+      q
+        .eq("teamId", args.teamId)
+        .eq("repoFullName", args.repoFullName)
+        .eq("sha", sha)
+        .eq("context", context)
+    )
+    .first();
+
+  const record = {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    repositoryId: mapNum(args.payload?.repository?.id),
+    sha,
+    context,
+    state,
+    targetUrl: mapStr(status.target_url),
+    description: mapStr(status.description),
+    creatorLogin: mapStr(status?.creator?.login),
+    creatorId: mapNum(status?.creator?.id),
+    updatedAt,
+  } as const;
+
+  if (existing) {
+    const prevState = existing.state;
+    // @ts-expect-error: New table will be in generated types after codegen
+    await ctx.db.patch(existing._id, record);
+    if (prevState !== state) {
+      // @ts-expect-error: New table will be in generated types after codegen
+      await ctx.db.insert("githubCommitStatusHistory", {
+        teamId: args.teamId,
+        installationId: args.installationId,
+        repoFullName: args.repoFullName,
+        sha,
+        context,
+        state,
+        updatedAt,
+      });
+    }
+    return { ok: true as const };
+  }
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubCommitStatuses", record);
+  // @ts-expect-error: New table will be in generated types after codegen
+  await ctx.db.insert("githubCommitStatusHistory", {
+    teamId: args.teamId,
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    sha,
+    context,
+    state,
+    updatedAt,
+  });
+  return { ok: true as const };
+}
+
+export const upsertCommitStatusFromWebhookPayload = internalMutation({
+  args: {
+    teamId: v.string(),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => upsertCommitStatus(ctx, args),
+});


### PR DESCRIPTION
help me sync github checks + actions to a convex table, figure out if we can reuse any existing tables, but we might want to store past states too? @packages/convex/convex/schema.ts we need to do webhooks for this @packages/convex/convex/github_webhook.ts i also want to sync pr comments as well. help me figure out the best schema for this. try to mirror github's data structure as much as possible.