### PR TITLE
Implement GitHub checks and actions sync to Convex via webhooks

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as environments from "../environments.js";
 import type * as github from "../github.js";
 import type * as github_app from "../github_app.js";
 import type * as github_prs from "../github_prs.js";
+import type * as github_checks from "../github_checks.js";
 import type * as github_setup from "../github_setup.js";
 import type * as github_webhook from "../github_webhook.js";
 import type * as http from "../http.js";
@@ -56,6 +57,7 @@ declare const fullApi: ApiFromModules<{
   environments: typeof environments;
   github: typeof github;
   github_app: typeof github_app;
+  github_checks: typeof github_checks;
   github_prs: typeof github_prs;
   github_setup: typeof github_setup;
   github_webhook: typeof github_webhook;

--- a/packages/convex/convex/github_checks.ts
+++ b/packages/convex/convex/github_checks.ts
@@ -1,0 +1,175 @@
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import {
+  internalMutation,
+  type MutationCtx,
+} from "./_generated/server";
+
+type GithubCheckExecutionType =
+  | "status"
+  | "check_suite"
+  | "check_run"
+  | "workflow_run"
+  | "workflow_job";
+
+export type UpsertExecutionArgs = {
+  teamId: string;
+  installationId: number;
+  repoFullName: string;
+  commitSha: string;
+  type: GithubCheckExecutionType;
+  externalId: string;
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+  detailsUrl?: string | null;
+  htmlUrl?: string | null;
+  description?: string | null;
+  context?: string | null;
+  appSlug?: string | null;
+  workflowName?: string | null;
+  workflowPath?: string | null;
+  jobName?: string | null;
+  runAttempt?: number | null;
+  checkSuiteId?: number | null;
+  workflowRunId?: number | null;
+  headBranch?: string | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
+  eventAction?: string | null;
+  eventTimestamp?: number | null;
+};
+
+const executionArgs = {
+  teamId: v.string(),
+  installationId: v.number(),
+  repoFullName: v.string(),
+  commitSha: v.string(),
+  type: v.union(
+    v.literal("status"),
+    v.literal("check_suite"),
+    v.literal("check_run"),
+    v.literal("workflow_run"),
+    v.literal("workflow_job")
+  ),
+  externalId: v.string(),
+  name: v.optional(v.string()),
+  status: v.optional(v.string()),
+  conclusion: v.optional(v.string()),
+  detailsUrl: v.optional(v.string()),
+  htmlUrl: v.optional(v.string()),
+  description: v.optional(v.string()),
+  context: v.optional(v.string()),
+  appSlug: v.optional(v.string()),
+  workflowName: v.optional(v.string()),
+  workflowPath: v.optional(v.string()),
+  jobName: v.optional(v.string()),
+  runAttempt: v.optional(v.number()),
+  checkSuiteId: v.optional(v.number()),
+  workflowRunId: v.optional(v.number()),
+  headBranch: v.optional(v.string()),
+  startedAt: v.optional(v.number()),
+  completedAt: v.optional(v.number()),
+  eventAction: v.optional(v.string()),
+  eventTimestamp: v.optional(v.number()),
+} as const;
+
+const buildExecutionRecord = (args: UpsertExecutionArgs, now: number) => ({
+  provider: "github" as const,
+  installationId: args.installationId,
+  repoFullName: args.repoFullName,
+  commitSha: args.commitSha,
+  type: args.type,
+  externalId: args.externalId,
+  teamId: args.teamId,
+  name: args.name ?? undefined,
+  status: args.status ?? undefined,
+  conclusion: args.conclusion ?? undefined,
+  detailsUrl: args.detailsUrl ?? undefined,
+  htmlUrl: args.htmlUrl ?? undefined,
+  description: args.description ?? undefined,
+  context: args.context ?? undefined,
+  appSlug: args.appSlug ?? undefined,
+  workflowName: args.workflowName ?? undefined,
+  workflowPath: args.workflowPath ?? undefined,
+  jobName: args.jobName ?? undefined,
+  runAttempt: args.runAttempt ?? undefined,
+  checkSuiteId: args.checkSuiteId ?? undefined,
+  workflowRunId: args.workflowRunId ?? undefined,
+  headBranch: args.headBranch ?? undefined,
+  startedAt: args.startedAt ?? undefined,
+  completedAt: args.completedAt ?? undefined,
+  lastEventAction: args.eventAction ?? undefined,
+  lastEventTimestamp: args.eventTimestamp ?? undefined,
+  updatedAt: now,
+});
+
+const insertHistory = async (
+  ctx: MutationCtx,
+  executionId: Id<"githubCheckExecutions">,
+  args: UpsertExecutionArgs,
+  receivedAt: number
+) => {
+  await ctx.db.insert("githubCheckExecutionHistory", {
+    executionId,
+    provider: "github",
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    commitSha: args.commitSha,
+    type: args.type,
+    externalId: args.externalId,
+    teamId: args.teamId,
+    action: args.eventAction ?? undefined,
+    name: args.name ?? undefined,
+    status: args.status ?? undefined,
+    conclusion: args.conclusion ?? undefined,
+    detailsUrl: args.detailsUrl ?? undefined,
+    htmlUrl: args.htmlUrl ?? undefined,
+    description: args.description ?? undefined,
+    context: args.context ?? undefined,
+    appSlug: args.appSlug ?? undefined,
+    workflowName: args.workflowName ?? undefined,
+    workflowPath: args.workflowPath ?? undefined,
+    jobName: args.jobName ?? undefined,
+    runAttempt: args.runAttempt ?? undefined,
+    checkSuiteId: args.checkSuiteId ?? undefined,
+    workflowRunId: args.workflowRunId ?? undefined,
+    headBranch: args.headBranch ?? undefined,
+    startedAt: args.startedAt ?? undefined,
+    completedAt: args.completedAt ?? undefined,
+    eventTimestamp: args.eventTimestamp ?? undefined,
+    receivedAt,
+  });
+};
+
+export const upsertExecutionFromEvent = internalMutation({
+  args: executionArgs,
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const upsertArgs: UpsertExecutionArgs = { ...args };
+    const existing = await ctx.db
+      .query("githubCheckExecutions")
+      .withIndex("by_installation_external", (q) =>
+        q
+          .eq("installationId", upsertArgs.installationId)
+          .eq("type", upsertArgs.type)
+          .eq("externalId", upsertArgs.externalId)
+      )
+      .first();
+
+    const record = buildExecutionRecord(upsertArgs, now);
+
+    if (existing) {
+      await ctx.db.patch(existing._id, record);
+      await insertHistory(ctx, existing._id, upsertArgs, now);
+      return { executionId: existing._id, created: false as const };
+    }
+
+    const executionId = await ctx.db.insert("githubCheckExecutions", {
+      ...record,
+      createdAt: now,
+    });
+    await insertHistory(ctx, executionId, upsertArgs, now);
+    return { executionId, created: true as const };
+  },
+});

--- a/packages/convex/convex/github_webhook.ts
+++ b/packages/convex/convex/github_webhook.ts
@@ -1,13 +1,19 @@
 import type {
+  CheckRunEvent,
+  CheckSuiteEvent,
   InstallationEvent,
   PullRequestEvent,
+  StatusEvent,
   WebhookEvent,
+  WorkflowJobEvent,
+  WorkflowRunEvent,
 } from "@octokit/webhooks-types";
 import { env } from "../_shared/convex-env";
 import { bytesToHex } from "../_shared/encoding";
 import { hmacSha256, safeEqualHex, sha256Hex } from "../_shared/crypto";
 import { internal } from "./_generated/api";
-import { httpAction } from "./_generated/server";
+import { httpAction, type ActionCtx } from "./_generated/server";
+import type { UpsertExecutionArgs } from "./github_checks";
 
 async function verifySignature(
   secret: string,
@@ -20,6 +26,302 @@ async function verifySignature(
   const computedHex = bytesToHex(sigBuf).toLowerCase();
   return safeEqualHex(computedHex, expectedHex);
 }
+
+const parseIsoDate = (value: string | null | undefined) => {
+  if (!value) return undefined;
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : undefined;
+};
+
+const nonEmpty = (value: string | null | undefined) => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const optionalNumber = (value: number | null | undefined) =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const composeExternalId = (
+  prefix:
+    | "status"
+    | "check_suite"
+    | "check_run"
+    | "workflow_run"
+    | "workflow_job",
+  primary: number | string | null | undefined,
+  fallbackParts: Array<string | null | undefined>
+) => {
+  if (typeof primary === "string" && primary.length > 0) {
+    return `${prefix}:${primary}`;
+  }
+  if (typeof primary === "number" && Number.isFinite(primary)) {
+    return `${prefix}:${primary}`;
+  }
+  const fallback = fallbackParts
+    .map((part) => nonEmpty(part ?? undefined))
+    .filter((part): part is string => typeof part === "string")
+    .join(":");
+  if (fallback.length > 0) {
+    return `${prefix}:${fallback}`;
+  }
+  const uuid =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}:${uuid}`;
+};
+
+const resolveTeamIdForInstallation = async (
+  ctx: ActionCtx,
+  installationId: number
+) => {
+  const conn = await ctx.runQuery(
+    internal.github_app.getProviderConnectionByInstallationId,
+    { installationId }
+  );
+  return conn?.teamId;
+};
+
+const recordCheckExecution = async (
+  ctx: ActionCtx,
+  args: UpsertExecutionArgs
+) => {
+  try {
+    await ctx.runMutation(internal.github_checks.upsertExecutionFromEvent, args);
+  } catch (_err) {
+    // swallow to avoid retries; logging can be added later if needed
+  }
+};
+
+const buildCheckSuiteArgs = (
+  payload: CheckSuiteEvent,
+  teamId: string,
+  installationId: number
+): UpsertExecutionArgs | null => {
+  const repoFullName = nonEmpty(payload.repository?.full_name ?? undefined);
+  const suite = payload.check_suite;
+  const commitSha = nonEmpty(suite?.head_sha ?? undefined);
+  if (!repoFullName || !commitSha || !suite) return null;
+  const externalId = composeExternalId(
+    "check_suite",
+    suite.id,
+    [commitSha, suite.app?.slug ?? undefined]
+  );
+  return {
+    teamId,
+    installationId,
+    repoFullName,
+    commitSha,
+    type: "check_suite",
+    externalId,
+    name: nonEmpty(suite.app?.name ?? undefined) ?? nonEmpty(suite.app?.slug ?? undefined),
+    status: suite.status ?? undefined,
+    conclusion: suite.conclusion ?? undefined,
+    detailsUrl: undefined,
+    htmlUrl: undefined,
+    description: undefined,
+    context: undefined,
+    appSlug: nonEmpty(suite.app?.slug ?? undefined),
+    workflowName: undefined,
+    workflowPath: undefined,
+    jobName: undefined,
+    runAttempt: undefined,
+    checkSuiteId: optionalNumber(suite.id ?? undefined),
+    workflowRunId: undefined,
+    headBranch: nonEmpty(suite.head_branch ?? undefined),
+    startedAt: parseIsoDate(suite.created_at ?? undefined),
+    completedAt:
+      suite.conclusion !== null && suite.conclusion !== undefined
+        ? parseIsoDate(suite.updated_at ?? undefined)
+        : undefined,
+    eventAction: payload.action,
+    eventTimestamp: parseIsoDate(suite.updated_at ?? undefined),
+  };
+};
+
+const buildCheckRunArgs = (
+  payload: CheckRunEvent,
+  teamId: string,
+  installationId: number
+): UpsertExecutionArgs | null => {
+  const repoFullName = nonEmpty(payload.repository?.full_name ?? undefined);
+  const checkRun = payload.check_run;
+  const commitSha = nonEmpty(checkRun?.head_sha ?? undefined);
+  if (!repoFullName || !commitSha || !checkRun) return null;
+  const externalId = composeExternalId("check_run", checkRun.id, [
+    commitSha,
+    checkRun.name ?? undefined,
+  ]);
+  const description = nonEmpty(checkRun.output?.summary ?? undefined);
+  const headBranch = nonEmpty(checkRun.check_suite?.head_branch ?? undefined);
+  return {
+    teamId,
+    installationId,
+    repoFullName,
+    commitSha,
+    type: "check_run",
+    externalId,
+    name: nonEmpty(checkRun.name ?? undefined),
+    status: checkRun.status ?? undefined,
+    conclusion: checkRun.conclusion ?? undefined,
+    detailsUrl: nonEmpty(checkRun.details_url ?? undefined),
+    htmlUrl: nonEmpty(checkRun.html_url ?? undefined),
+    description,
+    context: nonEmpty(checkRun.external_id ?? undefined),
+    appSlug: nonEmpty(checkRun.app?.slug ?? undefined),
+    workflowName: undefined,
+    workflowPath: undefined,
+    jobName: undefined,
+    runAttempt: optionalNumber(checkRun.run_attempt ?? undefined),
+    checkSuiteId: optionalNumber(checkRun.check_suite?.id ?? undefined),
+    workflowRunId: undefined,
+    headBranch,
+    startedAt: parseIsoDate(checkRun.started_at ?? undefined),
+    completedAt: parseIsoDate(checkRun.completed_at ?? undefined),
+    eventAction: payload.action,
+    eventTimestamp:
+      parseIsoDate(checkRun.completed_at ?? undefined) ??
+      parseIsoDate(checkRun.started_at ?? undefined),
+  };
+};
+
+const buildStatusArgs = (
+  payload: StatusEvent,
+  teamId: string,
+  installationId: number
+): UpsertExecutionArgs | null => {
+  const repoFullName = nonEmpty(payload.repository?.full_name ?? undefined);
+  const commitSha = nonEmpty(payload.sha ?? undefined);
+  if (!repoFullName || !commitSha) return null;
+  const context = nonEmpty(payload.context ?? undefined) ?? "default";
+  const externalId = composeExternalId("status", payload.id, [
+    commitSha,
+    context,
+  ]);
+  const branchName = nonEmpty(payload.branches?.[0]?.name ?? undefined);
+  return {
+    teamId,
+    installationId,
+    repoFullName,
+    commitSha,
+    type: "status",
+    externalId,
+    name: context,
+    status: payload.state,
+    conclusion: undefined,
+    detailsUrl: nonEmpty(payload.target_url ?? undefined),
+    htmlUrl: nonEmpty(payload.target_url ?? undefined),
+    description: nonEmpty(payload.description ?? undefined),
+    context,
+    appSlug: nonEmpty(payload.app?.slug ?? undefined),
+    workflowName: undefined,
+    workflowPath: undefined,
+    jobName: undefined,
+    runAttempt: undefined,
+    checkSuiteId: undefined,
+    workflowRunId: undefined,
+    headBranch: branchName,
+    startedAt: parseIsoDate(payload.created_at ?? undefined),
+    completedAt: parseIsoDate(payload.updated_at ?? undefined),
+    eventAction: payload.state,
+    eventTimestamp: parseIsoDate(payload.updated_at ?? undefined),
+  };
+};
+
+const buildWorkflowRunArgs = (
+  payload: WorkflowRunEvent,
+  teamId: string,
+  installationId: number
+): UpsertExecutionArgs | null => {
+  const repoFullName = nonEmpty(payload.repository?.full_name ?? undefined);
+  const run = payload.workflow_run;
+  const commitSha = nonEmpty(run?.head_sha ?? undefined);
+  if (!repoFullName || !commitSha || !run) return null;
+  const externalId = composeExternalId("workflow_run", run.id, [
+    commitSha,
+    run.name ?? undefined,
+  ]);
+  return {
+    teamId,
+    installationId,
+    repoFullName,
+    commitSha,
+    type: "workflow_run",
+    externalId,
+    name:
+      nonEmpty(run.display_title ?? undefined) ?? nonEmpty(run.name ?? undefined),
+    status: run.status ?? undefined,
+    conclusion: run.conclusion ?? undefined,
+    detailsUrl: nonEmpty(run.html_url ?? undefined),
+    htmlUrl: nonEmpty(run.html_url ?? undefined),
+    description: nonEmpty(run.display_title ?? undefined),
+    context: nonEmpty(run.event ?? undefined),
+    appSlug: undefined,
+    workflowName: nonEmpty(run.name ?? undefined),
+    workflowPath: nonEmpty(payload.workflow?.path ?? undefined),
+    jobName: undefined,
+    runAttempt: optionalNumber(run.run_attempt ?? undefined),
+    checkSuiteId: undefined,
+    workflowRunId: optionalNumber(run.id ?? undefined),
+    headBranch: nonEmpty(run.head_branch ?? undefined),
+    startedAt:
+      parseIsoDate(run.run_started_at ?? undefined) ??
+      parseIsoDate(run.created_at ?? undefined),
+    completedAt: parseIsoDate(run.updated_at ?? undefined),
+    eventAction: payload.action,
+    eventTimestamp: parseIsoDate(run.updated_at ?? undefined),
+  };
+};
+
+const buildWorkflowJobArgs = (
+  payload: WorkflowJobEvent,
+  teamId: string,
+  installationId: number
+): UpsertExecutionArgs | null => {
+  const repoFullName = nonEmpty(payload.repository?.full_name ?? undefined);
+  const job = payload.workflow_job;
+  const commitSha = nonEmpty(job?.head_sha ?? undefined);
+  if (!repoFullName || !commitSha || !job) return null;
+  const externalId = composeExternalId("workflow_job", job.id, [
+    commitSha,
+    job.name ?? undefined,
+    job.run_id ? String(job.run_id) : undefined,
+  ]);
+  const detailsUrl =
+    nonEmpty(job.html_url ?? undefined) ??
+    nonEmpty(job.url ?? undefined) ??
+    nonEmpty(job.run_url ?? undefined);
+  return {
+    teamId,
+    installationId,
+    repoFullName,
+    commitSha,
+    type: "workflow_job",
+    externalId,
+    name: nonEmpty(job.name ?? undefined),
+    status: job.status ?? undefined,
+    conclusion: job.conclusion ?? undefined,
+    detailsUrl,
+    htmlUrl: nonEmpty(job.html_url ?? undefined),
+    description: undefined,
+    context: undefined,
+    appSlug: undefined,
+    workflowName: undefined,
+    workflowPath: undefined,
+    jobName: nonEmpty(job.name ?? undefined),
+    runAttempt: optionalNumber(job.run_attempt ?? undefined),
+    checkSuiteId: undefined,
+    workflowRunId: optionalNumber(job.run_id ?? undefined),
+    headBranch: nonEmpty(job.head_branch ?? undefined),
+    startedAt: parseIsoDate(job.started_at ?? undefined),
+    completedAt: parseIsoDate(job.completed_at ?? undefined),
+    eventAction: payload.action,
+    eventTimestamp:
+      parseIsoDate(job.completed_at ?? undefined) ??
+      parseIsoDate(job.started_at ?? undefined),
+  };
+};
 
 export const githubWebhook = httpAction(async (_ctx, req) => {
   if (!env.GITHUB_APP_WEBHOOK_SECRET) {
@@ -126,6 +428,49 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
               teamId,
               payload: prPayload,
             });
+          } catch (_err) {
+            // swallow
+          }
+        } else if (
+          event === "check_suite" ||
+          event === "check_run" ||
+          event === "status" ||
+          event === "workflow_run" ||
+          event === "workflow_job"
+        ) {
+          try {
+            const installation = Number(
+              (body as WithInstallation).installation?.id ?? 0
+            );
+            if (!installation) break;
+            const teamId = await resolveTeamIdForInstallation(
+              _ctx,
+              installation
+            );
+            if (!teamId) break;
+            let args: UpsertExecutionArgs | null = null;
+            if (event === "check_suite") {
+              args = buildCheckSuiteArgs(body as CheckSuiteEvent, teamId, installation);
+            } else if (event === "check_run") {
+              args = buildCheckRunArgs(body as CheckRunEvent, teamId, installation);
+            } else if (event === "status") {
+              args = buildStatusArgs(body as StatusEvent, teamId, installation);
+            } else if (event === "workflow_run") {
+              args = buildWorkflowRunArgs(
+                body as WorkflowRunEvent,
+                teamId,
+                installation
+              );
+            } else if (event === "workflow_job") {
+              args = buildWorkflowJobArgs(
+                body as WorkflowJobEvent,
+                teamId,
+                installation
+              );
+            }
+            if (args) {
+              await recordCheckExecution(_ctx, args);
+            }
           } catch (_err) {
             // swallow
           }

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -491,6 +491,100 @@ const convexSchema = defineSchema({
     .index("by_team_repo_number", ["teamId", "repoFullName", "number"]) // upsert key
     .index("by_installation", ["installationId", "updatedAt"]) // debug/ops
     .index("by_repo", ["repoFullName", "updatedAt"]),
+
+  githubCheckExecutions: defineTable({
+    provider: v.literal("github"),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    commitSha: v.string(),
+    type: v.union(
+      v.literal("status"),
+      v.literal("check_suite"),
+      v.literal("check_run"),
+      v.literal("workflow_run"),
+      v.literal("workflow_job")
+    ),
+    externalId: v.string(),
+    teamId: v.string(),
+    name: v.optional(v.string()),
+    status: v.optional(v.string()),
+    conclusion: v.optional(v.string()),
+    detailsUrl: v.optional(v.string()),
+    htmlUrl: v.optional(v.string()),
+    description: v.optional(v.string()),
+    context: v.optional(v.string()),
+    appSlug: v.optional(v.string()),
+    workflowName: v.optional(v.string()),
+    workflowPath: v.optional(v.string()),
+    jobName: v.optional(v.string()),
+    runAttempt: v.optional(v.number()),
+    checkSuiteId: v.optional(v.number()),
+    workflowRunId: v.optional(v.number()),
+    headBranch: v.optional(v.string()),
+    startedAt: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
+    lastEventAction: v.optional(v.string()),
+    lastEventTimestamp: v.optional(v.number()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_installation_external", ["installationId", "type", "externalId"])
+    .index("by_team_repo_commit", [
+      "teamId",
+      "repoFullName",
+      "commitSha",
+    ])
+    .index("by_team_updated", ["teamId", "updatedAt"]),
+
+  githubCheckExecutionHistory: defineTable({
+    executionId: v.id("githubCheckExecutions"),
+    provider: v.literal("github"),
+    installationId: v.number(),
+    repoFullName: v.string(),
+    commitSha: v.string(),
+    type: v.union(
+      v.literal("status"),
+      v.literal("check_suite"),
+      v.literal("check_run"),
+      v.literal("workflow_run"),
+      v.literal("workflow_job")
+    ),
+    externalId: v.string(),
+    teamId: v.string(),
+    action: v.optional(v.string()),
+    name: v.optional(v.string()),
+    status: v.optional(v.string()),
+    conclusion: v.optional(v.string()),
+    detailsUrl: v.optional(v.string()),
+    htmlUrl: v.optional(v.string()),
+    description: v.optional(v.string()),
+    context: v.optional(v.string()),
+    appSlug: v.optional(v.string()),
+    workflowName: v.optional(v.string()),
+    workflowPath: v.optional(v.string()),
+    jobName: v.optional(v.string()),
+    runAttempt: v.optional(v.number()),
+    checkSuiteId: v.optional(v.number()),
+    workflowRunId: v.optional(v.number()),
+    headBranch: v.optional(v.string()),
+    startedAt: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
+    eventTimestamp: v.optional(v.number()),
+    receivedAt: v.number(),
+  })
+    .index("by_execution", ["executionId", "receivedAt"])
+    .index("by_team_commit", [
+      "teamId",
+      "repoFullName",
+      "commitSha",
+      "receivedAt",
+    ])
+    .index("by_installation_external", [
+      "installationId",
+      "type",
+      "externalId",
+      "receivedAt",
+    ]),
 });
 
 export default convexSchema;


### PR DESCRIPTION
help me sync github checks + actions to a convex table, figure out if we can reuse any existing tables, but we might want to store past states too? @packages/convex/convex/schema.ts we need to do webhooks for this @packages/convex/convex/github_webhook.ts