### PR TITLE
Implement Correct Electron Autoupdates Configuration

### DIFF
--- a/apps/client/electron-builder.json
+++ b/apps/client/electron-builder.json
@@ -37,6 +37,10 @@
       "to": "cmux-logos/cmux.iconset"
     },
     {
+      "from": "electron/app-update.yml",
+      "to": "app-update.yml"
+    },
+    {
       "from": "../../apps/server/native/core",
       "to": "native/core",
       "filter": [

--- a/apps/client/electron/app-update.yml
+++ b/apps/client/electron/app-update.yml
@@ -1,0 +1,5 @@
+provider: github
+owner: manaflow-ai
+repo: cmux
+releaseType: release
+updaterCacheDirName: cmux-updater


### PR DESCRIPTION
we need to implement electron autoupdates correctly.. currently i get this error in main: [2025-09-15T21:49:33.781Z] [MAIN] [ERROR] [2025-09-15T21:49:33.781Z] [MAIN] [2025-09-15T21:49:33.780Z] [updater] Error: Error: ENOENT: no such file or directory, open '/Users/austinwang/Desktop/cmux2/cmux2/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app-update.yml'[2025-09-15T21:49:33.781Z] [MAIN] [WARN] [2025-09-15T21:49:33.781Z] [MAIN] [2025-09-15T21:49:33.781Z] Updater error [Error: ENOENT: no such file or directory, open '/Users/austinwang/Desktop/cmux2/cmux2/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app-update.yml'] {  errno: -2,  code: 'ENOENT',  syscall: 'open',  path: '/Users/austinwang/Desktop/cmux2/cmux2/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app-update.yml'}[2025-09-15T21:49:33.781Z] [MAIN] [WARN] [2025-09-15T21:49:33.781Z] [MAIN] [2025-09-15T21:49:33.781Z] checkForUpdatesAndNotify failed [Error: ENOENT: no such file or directory, open '/Users/austinwang/Desktop/cmux2/cmux2/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app-update.yml'] {  errno: -2,  code: 'ENOENT',  syscall: 'open',  path: '/Users/austinwang/Desktop/cmux2/cmux2/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app-update.yml'}... we need to create app-update.yml and make this work. you must make it work. do not skip or disable autoupdates. this means that you might need to create the app-update.yml if this is the best solution. no fallbacks.