### PR TITLE
Show agent setup warnings in dashboard

### DIFF
--- a/apps/client/src/components/dashboard/DashboardInputControls.tsx
+++ b/apps/client/src/components/dashboard/DashboardInputControls.tsx
@@ -5,6 +5,7 @@ import { GitHubIcon } from "@/components/icons/github";
 import { ModeToggleTooltip } from "@/components/ui/mode-toggle-tooltip";
 import SearchableSelect, {
   type SelectOption,
+  type SelectOptionObject,
 } from "@/components/ui/searchable-select";
 import {
   Tooltip,
@@ -12,6 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { AGENT_CONFIGS } from "@cmux/shared/agentConfig";
+import type { ProviderStatus, ProviderStatusResponse } from "@cmux/shared";
 import { Link, useRouter } from "@tanstack/react-router";
 import { api } from "@cmux/convex/api";
 import { useMutation } from "convex/react";
@@ -35,6 +37,7 @@ interface DashboardInputControlsProps {
   teamSlugOrId: string;
   cloudToggleDisabled?: boolean;
   branchDisabled?: boolean;
+  providerStatus?: ProviderStatusResponse | null;
 }
 
 export const DashboardInputControls = memo(function DashboardInputControls({
@@ -53,9 +56,23 @@ export const DashboardInputControls = memo(function DashboardInputControls({
   teamSlugOrId,
   cloudToggleDisabled = false,
   branchDisabled = false,
+  providerStatus = null,
 }: DashboardInputControlsProps) {
   const router = useRouter();
   const mintState = useMutation(api.github_app.mintInstallState);
+  const providerStatusMap = useMemo(() => {
+    const map = new Map<string, ProviderStatus>();
+    providerStatus?.providers?.forEach((provider) => {
+      map.set(provider.name, provider);
+    });
+    return map;
+  }, [providerStatus?.providers]);
+  const handleOpenSettings = useCallback(() => {
+    void router.navigate({
+      to: "/$teamSlugOrId/settings",
+      params: { teamSlugOrId },
+    });
+  }, [router, teamSlugOrId]);
   const agentOptions = useMemo(() => {
     const vendorKey = (name: string): string => {
       const lower = name.toLowerCase();
@@ -71,13 +88,44 @@ export const DashboardInputControls = memo(function DashboardInputControls({
       if (lower.startsWith("opencode/")) return "opencode";
       return "other";
     };
-    return AGENT_CONFIGS.map((agent) => ({
-      label: agent.name,
-      value: agent.name,
-      icon: <AgentLogo agentName={agent.name} className="w-4 h-4" />,
-      iconKey: vendorKey(agent.name),
-    }));
-  }, []);
+    return AGENT_CONFIGS.map((agent) => {
+      const status = providerStatusMap.get(agent.name);
+      const missingRequirements = status?.missingRequirements ?? [];
+      const isAvailable = status?.isAvailable ?? true;
+      return {
+        label: agent.name,
+        value: agent.name,
+        icon: <AgentLogo agentName={agent.name} className="w-4 h-4" />,
+        iconKey: vendorKey(agent.name),
+        isUnavailable: !isAvailable,
+        warning: !isAvailable
+          ? {
+              tooltip: (
+                <div className="space-y-1">
+                  <p className="text-xs font-semibold text-red-500">
+                    Setup required
+                  </p>
+                  <p className="text-xs text-neutral-700 dark:text-neutral-300">
+                    Add credentials for this agent in Settings.
+                  </p>
+                  {missingRequirements.length > 0 ? (
+                    <ul className="list-disc pl-4 text-xs text-neutral-600 dark:text-neutral-400">
+                      {missingRequirements.map((req) => (
+                        <li key={req}>{req}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  <p className="text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500 pt-1 border-t border-neutral-200 dark:border-neutral-700">
+                    Click to open settings
+                  </p>
+                </div>
+              ),
+              onClick: handleOpenSettings,
+            }
+          : undefined,
+      } satisfies SelectOptionObject;
+    });
+  }, [handleOpenSettings, providerStatusMap]);
   // Determine OS for potential future UI tweaks
   // const isMac = navigator.userAgent.toUpperCase().indexOf("MAC") >= 0;
 

--- a/apps/client/src/components/dashboard/DashboardInputControls.tsx
+++ b/apps/client/src/components/dashboard/DashboardInputControls.tsx
@@ -1,5 +1,4 @@
 import { env } from "@/client-env";
-import { isElectron } from "@/lib/electron";
 import { AgentLogo } from "@/components/icons/agent-logos";
 import { GitHubIcon } from "@/components/icons/github";
 import { ModeToggleTooltip } from "@/components/ui/mode-toggle-tooltip";
@@ -12,12 +11,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { AGENT_CONFIGS } from "@cmux/shared/agentConfig";
-import type { ProviderStatus, ProviderStatusResponse } from "@cmux/shared";
-import { Link, useRouter } from "@tanstack/react-router";
+import { isElectron } from "@/lib/electron";
 import { api } from "@cmux/convex/api";
-import { useMutation } from "convex/react";
+import type { ProviderStatus, ProviderStatusResponse } from "@cmux/shared";
+import { AGENT_CONFIGS } from "@cmux/shared/agentConfig";
+import { Link, useRouter } from "@tanstack/react-router";
 import clsx from "clsx";
+import { useMutation } from "convex/react";
 import { GitBranch, Image, Mic, Server } from "lucide-react";
 import { memo, useCallback, useMemo } from "react";
 
@@ -105,17 +105,17 @@ export const DashboardInputControls = memo(function DashboardInputControls({
                   <p className="text-xs font-semibold text-red-500">
                     Setup required
                   </p>
-                  <p className="text-xs text-neutral-700 dark:text-neutral-300">
+                  <p className="text-xs text-neutral-300">
                     Add credentials for this agent in Settings.
                   </p>
                   {missingRequirements.length > 0 ? (
-                    <ul className="list-disc pl-4 text-xs text-neutral-600 dark:text-neutral-400">
+                    <ul className="list-disc pl-4 text-xs text-neutral-400">
                       {missingRequirements.map((req) => (
                         <li key={req}>{req}</li>
                       ))}
                     </ul>
                   ) : null}
-                  <p className="text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500 pt-1 border-t border-neutral-200 dark:border-neutral-700">
+                  <p className="text-[10px] tracking-wide text-neutral-500 pt-1 border-t border-neutral-700">
                     Click to open settings
                   </p>
                 </div>

--- a/apps/client/src/components/ui/searchable-select.tsx
+++ b/apps/client/src/components/ui/searchable-select.tsx
@@ -22,13 +22,7 @@ import {
   Loader2,
   OctagonAlert,
 } from "lucide-react";
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 interface OptionWarning {
   tooltip: ReactNode;
@@ -75,9 +69,13 @@ interface WarningIndicatorProps {
   className?: string;
 }
 
-function WarningIndicator({ warning, onActivate, className }: WarningIndicatorProps) {
+function WarningIndicator({
+  warning,
+  onActivate,
+  className,
+}: WarningIndicatorProps) {
   return (
-    <Tooltip>
+    <Tooltip delayDuration={0}>
       <TooltipTrigger asChild>
         <button
           type="button"
@@ -121,7 +119,12 @@ interface OptionItemProps {
   onWarningAction?: () => void;
 }
 
-function OptionItem({ opt, isSelected, onSelectValue, onWarningAction }: OptionItemProps) {
+function OptionItem({
+  opt,
+  isSelected,
+  onSelectValue,
+  onWarningAction,
+}: OptionItemProps) {
   if (opt.heading) {
     return (
       <div className="flex items-center gap-2 min-w-0 flex-1 pl-1 pr-3 py-1 h-[28px] text-[11px] font-semibold text-neutral-500 dark:text-neutral-400">
@@ -148,7 +151,10 @@ function OptionItem({ opt, isSelected, onSelectValue, onWarningAction }: OptionI
         ) : null}
         <span className="truncate select-none">{opt.label}</span>
         {opt.warning ? (
-          <WarningIndicator warning={opt.warning} onActivate={onWarningAction} />
+          <WarningIndicator
+            warning={opt.warning}
+            onActivate={onWarningAction}
+          />
         ) : opt.isUnavailable ? (
           <AlertTriangle className="w-3.5 h-3.5 text-amber-500 shrink-0" />
         ) : null}
@@ -253,10 +259,9 @@ export function SearchableSelect({
       .map((v) => valueToOption.get(v)?.warning)
       .filter(Boolean) as OptionWarning[];
     const firstWarning = selectedWarnings[0];
-    const aggregatedWarningTooltip =
-      firstWarning?.tooltip ?? (
-        <span>Some selected agents still need credentials in Settings.</span>
-      );
+    const aggregatedWarningTooltip = firstWarning?.tooltip ?? (
+      <span>Some selected agents still need credentials in Settings.</span>
+    );
     // Deduplicate by icon key (e.g., vendor) while preserving order
     const seen = new Set<string>();
     const uniqueIcons: ReactNode[] = [];


### PR DESCRIPTION
## Summary
- track provider status inside the dashboard route and feed it to the agent selector instead of relying on the old banner
- surface setup warnings in the shared searchable select with a tooltip and link to settings whenever an agent is missing credentials

## Testing
- bun run check *(fails: Cannot find module '@hey-api/openapi-ts')*

------
https://chatgpt.com/codex/tasks/task_e_68c9ae2a0d30833398df7b7662b19413