### PR TITLE
Hide branch selector when no project is selected

### DIFF
--- a/apps/client/src/queries/branches.ts
+++ b/apps/client/src/queries/branches.ts
@@ -17,8 +17,11 @@ export function branchesQueryOptions({
           "github-fetch-branches",
           { teamSlugOrId, repo: repoFullName },
           (response) => {
-            if (response.success) resolve(response.branches || []);
-            else reject(new Error(response.error || "Failed to load branches"));
+            if (response.success) {
+              resolve(response.branches);
+            } else {
+              reject(new Error(response.error || "Failed to load branches"));
+            }
           }
         );
       });

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -689,7 +689,7 @@ function DashboardComponent() {
                   }
                   teamSlugOrId={teamSlugOrId}
                   cloudToggleDisabled={isEnvSelected}
-                  branchDisabled={isEnvSelected}
+                  branchDisabled={isEnvSelected || !selectedProject[0]}
                   providerStatus={providerStatus}
                 />
                 <DashboardStartTaskButton

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -241,7 +241,7 @@ export const GitHubFetchBranchesSchema = z.object({
 
 export const GitHubBranchesResponseSchema = z.object({
   success: z.boolean(),
-  branches: z.array(z.string()).optional(),
+  branches: z.array(z.string()),
   error: z.string().optional(),
 });
 
@@ -442,7 +442,11 @@ export interface ClientToServerEvents {
     data: z.infer<typeof GitSmartRefsSchema>,
     callback: (
       response:
-        | { ok: true; diffs: import("./diff-types.js").ReplaceDiffEntry[]; strategy?: "latest" | "landed" }
+        | {
+            ok: true;
+            diffs: import("./diff-types.js").ReplaceDiffEntry[];
+            strategy?: "latest" | "landed";
+          }
         | { ok: false; error: string; diffs?: [] }
     ) => void
   ) => void;


### PR DESCRIPTION
## Summary
- hide the branch selector on the dashboard when no project is selected so the control only appears once a repository is chosen

## Testing
- bun run check *(fails: missing required environment variables in local container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f622858c8333b6be70ef86226715