### PR TITLE
Handle rename entries in diff viewer

### DIFF
--- a/apps/client/src/components/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-viewer.tsx
@@ -46,6 +46,7 @@ export interface GitDiffViewerProps {
 
 type FileGroup = {
   filePath: string;
+  oldPath?: string;
   status: ReplaceDiffEntry["status"];
   additions: number;
   deletions: number;
@@ -106,6 +107,7 @@ export function GitDiffViewer({
     () =>
       (diffs || []).map((diff) => ({
         filePath: diff.filePath,
+        oldPath: diff.oldPath,
         status: diff.status,
         additions: diff.additions,
         deletions: diff.deletions,
@@ -309,9 +311,19 @@ function FileDiffRow({
           {getStatusIcon(file.status)}
         </div>
         <div className="flex-1 min-w-0 flex items-center gap-3">
-          <span className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
-            {file.filePath}
-          </span>
+          <div className="min-w-0 flex-1">
+            {file.status === "renamed" && file.oldPath ? (
+              <span className="font-mono text-xs text-neutral-700 dark:text-neutral-300 select-none inline-flex items-center gap-2 min-w-0 w-full">
+                <span className="truncate min-w-0">{file.oldPath}</span>
+                <span className="text-neutral-400 dark:text-neutral-500 flex-shrink-0">→</span>
+                <span className="truncate min-w-0">{file.filePath}</span>
+              </span>
+            ) : (
+              <span className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
+                {file.filePath}
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-2 text-[11px]">
             <span className="text-green-600 dark:text-green-400 font-medium select-none">
               +{file.additions}
@@ -325,7 +337,19 @@ function FileDiffRow({
 
       {isExpanded && (
         <div className="border-t border-neutral-200 dark:border-neutral-800 overflow-hidden">
-          {file.isBinary ? (
+          {file.status === "renamed" ? (
+            <div className="px-3 py-6 text-center text-neutral-500 dark:text-neutral-400 text-xs bg-neutral-50 dark:bg-neutral-900/50">
+              File was renamed from{" "}
+              <span className="font-mono text-[11px] text-neutral-700 dark:text-neutral-300">
+                {file.oldPath ?? "(unknown)"}
+              </span>{" "}
+              to{" "}
+              <span className="font-mono text-[11px] text-neutral-700 dark:text-neutral-300">
+                {file.filePath}
+              </span>
+              .
+            </div>
+          ) : file.isBinary ? (
             <div className="px-3 py-6 text-center text-neutral-500 dark:text-neutral-400 text-xs bg-neutral-50 dark:bg-neutral-900/50">
               Binary file not shown
             </div>
@@ -554,6 +578,7 @@ const MemoFileDiffRow = memo(FileDiffRow, (prev, next) => {
     prev.isExpanded === next.isExpanded &&
     prev.theme === next.theme &&
     a.filePath === b.filePath &&
+    a.oldPath === b.oldPath &&
     a.status === b.status &&
     a.additions === b.additions &&
     a.deletions === b.deletions &&

--- a/apps/server/native/core/src/diff/refs.rs
+++ b/apps/server/native/core/src/diff/refs.rs
@@ -204,16 +204,11 @@ pub fn diff_refs(opts: GitDiffRefsOptions) -> Result<Vec<DiffEntry>> {
       None => (true, 0),
     };
     let mut e = DiffEntry{ filePath: new_path.clone(), oldPath: Some(old_path.clone()), status: "renamed".into(), additions: 0, deletions: 0, isBinary: bin, ..Default::default() };
-    if include && !bin {
-      let new_str = String::from_utf8_lossy(new_data.as_ref().unwrap()).into_owned();
+    if new_data.is_some() {
       e.newSize = Some(new_sz as i32);
       e.oldSize = Some(new_sz as i32);
-      if new_sz <= max_bytes {
-        e.oldContent = Some(new_str.clone());
-        e.newContent = Some(new_str);
-        e.contentOmitted = Some(false);
-      } else { e.contentOmitted = Some(true); }
-    } else { e.contentOmitted = Some(false); }
+    }
+    e.contentOmitted = Some(false);
     out.push(e);
   }
 
@@ -421,11 +416,7 @@ pub fn diff_refs(opts: GitDiffRefsOptions) -> Result<Vec<DiffEntry>> {
               let oldp = parts[1].to_string();
               let newp = parts[2].to_string();
               let mut e = DiffEntry{ filePath: newp.clone(), oldPath: Some(oldp.clone()), status: "renamed".into(), additions: 0, deletions: 0, isBinary: false, ..Default::default() };
-              if include {
-                let new_s = crate::util::run_git(&cwd, &["show", &format!("{}:{}", r2_oid, newp)]).unwrap_or_default();
-                let new_sz = new_s.as_bytes().len(); e.newSize = Some(new_sz as i32); e.oldSize = Some(new_sz as i32);
-                if new_sz <= max_bytes { e.oldContent = Some(new_s.clone()); e.newContent = Some(new_s); e.contentOmitted = Some(false);} else { e.contentOmitted = Some(true); }
-              }
+              e.contentOmitted = Some(false);
               fallback.push(e);
             }
           }

--- a/apps/server/src/diffs/compareRefs.test.ts
+++ b/apps/server/src/diffs/compareRefs.test.ts
@@ -48,8 +48,10 @@ describe("compareRefsForRepo (native)", () => {
     // unchanged content, additions/deletions 0
     expect(rename!.additions).toBe(0);
     expect(rename!.deletions).toBe(0);
-    expect(rename!.oldContent).toBe("hello\n");
-    expect(rename!.newContent).toBe("hello\n");
+    expect(rename!.oldContent).toBeUndefined();
+    expect(rename!.newContent).toBeUndefined();
+    expect(rename!.contentOmitted).toBe(false);
+    expect(rename!.newSize).toBeGreaterThan(0);
   });
 
   test("added and deleted without rename when content changes", async () => {


### PR DESCRIPTION
## Summary
- show metadata for renamed files in the diff viewer instead of mounting Monaco editors
- skip fetching file contents for rename entries in the git diff helpers and keep rename metadata
- update the native compare refs test to reflect metadata-only rename payloads

## Testing
- cargo test *(fails: missing git object for refs test)*
- bun run check *(fails: required environment variables not provided in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f5a874448333a6366d330888867e