### PR TITLE
Improve Crown Evaluator Data Fetching Method

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -402,12 +402,6 @@ export async function spawnAgent(
           );
           return;
         }
-        // CRITICAL: Add a delay to ensure changes are written to disk
-        serverLogger.info(
-          `[AgentSpawner] Waiting 3 seconds for file system to settle before capturing git diff...`
-        );
-        await new Promise((resolve) => setTimeout(resolve, 3000));
-
         await runWithAuth(capturedAuthToken, capturedAuthHeaderJson, async () =>
           handleTaskCompletion({
             taskRunId,
@@ -457,12 +451,6 @@ export async function spawnAgent(
         serverLogger.info(
           `[AgentSpawner] Task ID matched! Marking task as complete for ${agent.name}`
         );
-        // CRITICAL: Add a delay to ensure changes are written to disk
-        serverLogger.info(
-          `[AgentSpawner] Waiting 3 seconds for file system to settle before capturing git diff...`
-        );
-        await new Promise((resolve) => setTimeout(resolve, 3000));
-
         await runWithAuth(capturedAuthToken, capturedAuthHeaderJson, async () =>
           handleTaskCompletion({
             taskRunId,

--- a/apps/server/src/handle-task-completion.ts
+++ b/apps/server/src/handle-task-completion.ts
@@ -81,145 +81,6 @@ export async function handleTaskCompletion({
     );
 
     if (taskRunData) {
-      serverLogger.info(
-        `[AgentSpawner] Calling checkAndEvaluateCrown for task ${taskRunData.taskId}`
-      );
-
-      const winnerId = await getConvex().mutation(
-        api.tasks.checkAndEvaluateCrown,
-        {
-          teamSlugOrId,
-          taskId: taskRunData.taskId,
-        }
-      );
-
-      serverLogger.info(
-        `[AgentSpawner] checkAndEvaluateCrown returned: ${winnerId}`
-      );
-
-      // If winnerId is "pending", trigger Claude Code evaluation
-      if (winnerId === "pending") {
-        serverLogger.info(
-          `[AgentSpawner] ==========================================`
-        );
-        serverLogger.info(
-          `[AgentSpawner] CROWN EVALUATION NEEDED - TRIGGERING NOW`
-        );
-        serverLogger.info(`[AgentSpawner] Task ID: ${taskRunData.taskId}`);
-        serverLogger.info(
-          `[AgentSpawner] ==========================================`
-        );
-
-        // Trigger crown evaluation immediately for faster response
-        // The periodic checker will also handle retries if this fails
-        serverLogger.info(
-          `[AgentSpawner] Triggering immediate crown evaluation`
-        );
-
-        // Small delay for worker-side file system settle before diff collection
-        // Note: We need to preserve the auth context for the crown evaluation
-        setTimeout(async () => {
-          try {
-            // Check if evaluation is already in progress
-            const task = await getConvex().query(api.tasks.getById, {
-              teamSlugOrId,
-              id: taskRunData.taskId,
-            });
-            if (task?.crownEvaluationError === "in_progress") {
-              serverLogger.info(
-                `[AgentSpawner] Crown evaluation already in progress for task ${taskRunData.taskId}`
-              );
-              return;
-            }
-
-            await evaluateCrown(taskRunData.taskId, teamSlugOrId);
-
-            serverLogger.info(
-              `[AgentSpawner] Crown evaluation completed successfully`
-            );
-
-            // Check if this task run won
-            const updatedTaskRun = await getConvex().query(api.taskRuns.get, {
-              teamSlugOrId,
-              id: taskRunId,
-            });
-
-            if (updatedTaskRun?.isCrowned) {
-              serverLogger.info(
-                `[AgentSpawner] 🏆 This task run won the crown! ${agent.name} is the winner!`
-              );
-            }
-          } catch (error) {
-            serverLogger.error(
-              `[AgentSpawner] Crown evaluation failed:`,
-              error
-            );
-            // The periodic checker will retry
-          }
-        }, 3000); // 3 second delay to ensure data persistence
-      } else if (winnerId) {
-        serverLogger.info(
-          `[AgentSpawner] Task completed with winner: ${winnerId}`
-        );
-
-        // For single agent scenario, trigger auto-PR if enabled
-        const taskRuns = await getConvex().query(api.taskRuns.getByTask, {
-          teamSlugOrId,
-          taskId: taskRunData.taskId,
-        });
-
-        if (taskRuns.length === 1) {
-          serverLogger.info(
-            `[AgentSpawner] Single agent scenario - checking auto-PR settings`
-          );
-
-          // Check if auto-PR is enabled
-          const ws = await getConvex().query(api.workspaceSettings.get, {
-            teamSlugOrId,
-          });
-          const autoPrEnabled = ws?.autoPrEnabled ?? false;
-
-          if (autoPrEnabled && winnerId) {
-            serverLogger.info(
-              `[AgentSpawner] Triggering auto-PR for single agent completion`
-            );
-
-            const githubToken = await getGitHubTokenFromKeychain();
-
-            // Small delay to ensure git diff is persisted
-            setTimeout(async () => {
-              try {
-                await createPullRequestForWinner(
-                  winnerId,
-                  taskRunData.taskId,
-                  githubToken || undefined,
-                  teamSlugOrId
-                );
-                serverLogger.info(
-                  `[AgentSpawner] Auto-PR completed for single agent`
-                );
-              } catch (error) {
-                serverLogger.error(
-                  `[AgentSpawner] Auto-PR failed for single agent:`,
-                  error
-                );
-              }
-            }, 3000);
-          } else {
-            serverLogger.info(
-              `[AgentSpawner] Auto-PR disabled or not applicable for single agent`
-            );
-          }
-        }
-      } else {
-        serverLogger.info(
-          `[AgentSpawner] No crown evaluation needed (winnerId: ${winnerId})`
-        );
-      }
-    }
-
-    // Enable auto-commit after task completion
-    if (taskRunData) {
       const task = await getConvex().query(api.tasks.getById, {
         teamSlugOrId,
         id: taskRunData.taskId,
@@ -247,6 +108,123 @@ export async function handleTaskCompletion({
             error
           );
         }
+      }
+
+      serverLogger.info(
+        `[AgentSpawner] Calling checkAndEvaluateCrown for task ${taskRunData.taskId}`
+      );
+
+      const winnerId = await getConvex().mutation(
+        api.tasks.checkAndEvaluateCrown,
+        {
+          teamSlugOrId,
+          taskId: taskRunData.taskId,
+        }
+      );
+
+      serverLogger.info(
+        `[AgentSpawner] checkAndEvaluateCrown returned: ${winnerId}`
+      );
+
+      if (winnerId === "pending") {
+        serverLogger.info(
+          `[AgentSpawner] ==========================================`
+        );
+        serverLogger.info(
+          `[AgentSpawner] CROWN EVALUATION NEEDED - TRIGGERING NOW`
+        );
+        serverLogger.info(`[AgentSpawner] Task ID: ${taskRunData.taskId}`);
+        serverLogger.info(
+          `[AgentSpawner] ==========================================`
+        );
+
+        serverLogger.info(
+          `[AgentSpawner] Triggering immediate crown evaluation`
+        );
+
+        try {
+          const latestTask = await getConvex().query(api.tasks.getById, {
+            teamSlugOrId,
+            id: taskRunData.taskId,
+          });
+          if (latestTask?.crownEvaluationError === "in_progress") {
+            serverLogger.info(
+              `[AgentSpawner] Crown evaluation already in progress for task ${taskRunData.taskId}`
+            );
+          } else {
+            await evaluateCrown(taskRunData.taskId, teamSlugOrId);
+
+            serverLogger.info(
+              `[AgentSpawner] Crown evaluation completed successfully`
+            );
+
+            const updatedTaskRun = await getConvex().query(api.taskRuns.get, {
+              teamSlugOrId,
+              id: taskRunId,
+            });
+
+            if (updatedTaskRun?.isCrowned) {
+              serverLogger.info(
+                `[AgentSpawner] 🏆 This task run won the crown! ${agent.name} is the winner!`
+              );
+            }
+          }
+        } catch (error) {
+          serverLogger.error(`[AgentSpawner] Crown evaluation failed:`, error);
+        }
+      } else if (winnerId) {
+        serverLogger.info(
+          `[AgentSpawner] Task completed with winner: ${winnerId}`
+        );
+
+        const taskRuns = await getConvex().query(api.taskRuns.getByTask, {
+          teamSlugOrId,
+          taskId: taskRunData.taskId,
+        });
+
+        if (taskRuns.length === 1) {
+          serverLogger.info(
+            `[AgentSpawner] Single agent scenario - checking auto-PR settings`
+          );
+
+          const ws = await getConvex().query(api.workspaceSettings.get, {
+            teamSlugOrId,
+          });
+          const autoPrEnabled = ws?.autoPrEnabled ?? false;
+
+          if (autoPrEnabled) {
+            serverLogger.info(
+              `[AgentSpawner] Triggering auto-PR for single agent completion`
+            );
+
+            const githubToken = await getGitHubTokenFromKeychain();
+
+            try {
+              await createPullRequestForWinner(
+                winnerId,
+                taskRunData.taskId,
+                githubToken || undefined,
+                teamSlugOrId
+              );
+              serverLogger.info(
+                `[AgentSpawner] Auto-PR completed for single agent`
+              );
+            } catch (error) {
+              serverLogger.error(
+                `[AgentSpawner] Auto-PR failed for single agent:`,
+                error
+              );
+            }
+          } else {
+            serverLogger.info(
+              `[AgentSpawner] Auto-PR disabled or not applicable for single agent`
+            );
+          }
+        }
+      } else {
+        serverLogger.info(
+          `[AgentSpawner] No crown evaluation needed (winnerId: ${winnerId})`
+        );
       }
     }
 


### PR DESCRIPTION
can you rewrite crown evaluator to not use the git diff that requires us to wait 3 seconds and then capture. we should look at how we are fetching the data for the git diff viewer and just pull from the source of truth there... instead of doing the diff capture by waiting 3 seconds in the terminal which is janky.