### PR TITLE
Handle renamed files in diff viewer

### DIFF
--- a/apps/client/src/components/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-viewer.tsx
@@ -46,6 +46,7 @@ export interface GitDiffViewerProps {
 
 type FileGroup = {
   filePath: string;
+  oldPath?: string;
   status: ReplaceDiffEntry["status"];
   additions: number;
   deletions: number;
@@ -106,6 +107,7 @@ export function GitDiffViewer({
     () =>
       (diffs || []).map((diff) => ({
         filePath: diff.filePath,
+        oldPath: diff.oldPath,
         status: diff.status,
         additions: diff.additions,
         deletions: diff.deletions,
@@ -308,10 +310,17 @@ function FileDiffRow({
         <div className={cn("flex-shrink-0", getStatusColor(file.status))}>
           {getStatusIcon(file.status)}
         </div>
-        <div className="flex-1 min-w-0 flex items-center gap-3">
-          <span className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
-            {file.filePath}
-          </span>
+        <div className="flex-1 min-w-0 flex items-start justify-between gap-3">
+          <div className="min-w-0 flex flex-col">
+            <span className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
+              {file.filePath}
+            </span>
+            {file.status === "renamed" && file.oldPath ? (
+              <span className="font-mono text-[10px] text-neutral-500 dark:text-neutral-400 truncate select-none">
+                Renamed from {file.oldPath}
+              </span>
+            ) : null}
+          </div>
           <div className="flex items-center gap-2 text-[11px]">
             <span className="text-green-600 dark:text-green-400 font-medium select-none">
               +{file.additions}
@@ -325,7 +334,16 @@ function FileDiffRow({
 
       {isExpanded && (
         <div className="border-t border-neutral-200 dark:border-neutral-800 overflow-hidden">
-          {file.isBinary ? (
+          {file.status === "renamed" ? (
+            <div className="px-3 py-6 text-center text-neutral-500 dark:text-neutral-400 text-xs bg-neutral-50 dark:bg-neutral-900/50 space-y-2">
+              <p className="select-none">File was renamed.</p>
+              {file.oldPath ? (
+                <p className="font-mono text-[11px] text-neutral-600 dark:text-neutral-300 select-none">
+                  {file.oldPath} → {file.filePath}
+                </p>
+              ) : null}
+            </div>
+          ) : file.isBinary ? (
             <div className="px-3 py-6 text-center text-neutral-500 dark:text-neutral-400 text-xs bg-neutral-50 dark:bg-neutral-900/50">
               Binary file not shown
             </div>
@@ -554,6 +572,7 @@ const MemoFileDiffRow = memo(FileDiffRow, (prev, next) => {
     prev.isExpanded === next.isExpanded &&
     prev.theme === next.theme &&
     a.filePath === b.filePath &&
+    a.oldPath === b.oldPath &&
     a.status === b.status &&
     a.additions === b.additions &&
     a.deletions === b.deletions &&

--- a/apps/server/src/diffs/compareRefs.test.ts
+++ b/apps/server/src/diffs/compareRefs.test.ts
@@ -38,7 +38,7 @@ describe("compareRefsForRepo (native)", () => {
       originPathOverride: repo,
     });
 
-    // Expect a single rename entry with identical content
+    // Expect a single rename entry noting the rename without loading contents
     expect(Array.isArray(diffs)).toBe(true);
     const rename = diffs.find((d) => d.status === "renamed");
     expect(rename).toBeTruthy();
@@ -48,8 +48,9 @@ describe("compareRefsForRepo (native)", () => {
     // unchanged content, additions/deletions 0
     expect(rename!.additions).toBe(0);
     expect(rename!.deletions).toBe(0);
-    expect(rename!.oldContent).toBe("hello\n");
-    expect(rename!.newContent).toBe("hello\n");
+    expect(rename!.contentOmitted).toBe(true);
+    expect(rename!.oldContent).toBeUndefined();
+    expect(rename!.newContent).toBeUndefined();
   });
 
   test("added and deleted without rename when content changes", async () => {


### PR DESCRIPTION
## Summary
- hide the Monaco diff for renamed entries and show a rename notice in the git diff viewer
- avoid loading contents for renamed files in both the Node and native diff generators and mark those entries as omitted
- update the native compareRefs rename test to reflect the new behaviour

## Testing
- `STACK_SECRET_SERVER_KEY=dummy STACK_SUPER_SECRET_ADMIN_KEY=dummy STACK_DATA_VAULT_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa CMUX_GITHUB_APP_ID=dummy CMUX_GITHUB_APP_PRIVATE_KEY=dummy MORPH_API_KEY=dummy CONVEX_DEPLOY_KEY=dummy ANTHROPIC_API_KEY=dummy CMUX_TASK_RUN_JWT_SECRET=dummy NEXT_PUBLIC_STACK_PROJECT_ID=dummy NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=dummy NEXT_PUBLIC_CONVEX_URL=http://localhost bun run check`

------
https://chatgpt.com/codex/tasks/task_e_68cb337e567c8333828646fe29e310a2