### PR TITLE
refactor diff viewer to manage monaco manually

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -44,7 +44,6 @@
     "@lexical/selection": "^0.32.1",
     "@lexical/utils": "^0.32.1",
     "@mantine/hooks": "^8.1.3",
-    "@monaco-editor/react": "4.7.0-rc.0",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.15",

--- a/apps/client/src/components/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-viewer.tsx
@@ -1,5 +1,4 @@
 import { useTheme } from "@/components/theme/use-theme";
-// No socket usage in refs-only viewer
 import { cn } from "@/lib/utils";
 import type { ReplaceDiffEntry } from "@cmux/shared/diff-types";
 import {
@@ -221,6 +220,7 @@ export function GitDiffViewer({
             classNames={classNames?.fileDiffRow}
           />
         ))}
+        <hr className="border-neutral-200 dark:border-neutral-800" />
         {/* End-of-diff message */}
         <div className="px-3 py-6 text-center">
           <span className="text-xs text-neutral-500 dark:text-neutral-400 select-none">
@@ -514,35 +514,39 @@ function FileDiffRow({
     monaco.editor.setTheme(currentTheme);
 
     return () => {
-      layoutSchedulerRef.current = null;
-      for (const disposable of disposables) {
-        disposable.dispose();
-      }
-      if (rafIdRef.current != null) {
-        cancelAnimationFrame(rafIdRef.current);
-        rafIdRef.current = null;
-      }
-      cancelAnimationFrame(rafHandle);
-      if (resizeObserverRef.current) {
-        resizeObserverRef.current.disconnect();
-        resizeObserverRef.current = null;
-      }
       try {
-        diffEditor.setModel(null);
-      } catch {
-        // ignore
+        layoutSchedulerRef.current = null;
+        for (const disposable of disposables) {
+          disposable.dispose();
+        }
+        if (rafIdRef.current != null) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        cancelAnimationFrame(rafHandle);
+        if (resizeObserverRef.current) {
+          resizeObserverRef.current.disconnect();
+          resizeObserverRef.current = null;
+        }
+        try {
+          diffEditor.setModel(null);
+        } catch {
+          // ignore
+        }
+        if (modelsRef.current) {
+          modelsRef.current.original.dispose();
+          modelsRef.current.modified.dispose();
+          modelsRef.current = null;
+        }
+        diffEditor.dispose();
+        if (diffEditorRef.current === diffEditor) {
+          diffEditorRef.current = null;
+        }
+        setEditorRef(null);
+        revealedRef.current = false;
+      } catch (error) {
+        console.error("Error disposing diff editor", error);
       }
-      if (modelsRef.current) {
-        modelsRef.current.original.dispose();
-        modelsRef.current.modified.dispose();
-        modelsRef.current = null;
-      }
-      diffEditor.dispose();
-      if (diffEditorRef.current === diffEditor) {
-        diffEditorRef.current = null;
-      }
-      setEditorRef(null);
-      revealedRef.current = false;
     };
   }, [diffEditorOptions, file.filePath, isExpanded, runId, setEditorRef]);
 
@@ -576,7 +580,7 @@ function FileDiffRow({
       <button
         onClick={onToggle}
         className={cn(
-          "w-full px-3 py-1.5 flex items-center gap-2 hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-800 sticky  z-[var(--z-sticky-low)]",
+          "w-full px-3 py-1.5 flex items-center gap-2 hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-t border-neutral-200 dark:border-neutral-800 sticky z-[var(--z-sticky-low)]",
           classNames?.button
         )}
       >

--- a/apps/client/src/components/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-viewer.tsx
@@ -382,6 +382,10 @@ function FileDiffRow({
   }, [theme]);
 
   useEffect(() => {
+    if (!isExpanded) {
+      return;
+    }
+
     const container = diffContainerRef.current;
     if (!container) {
       return;
@@ -558,7 +562,7 @@ function FileDiffRow({
       setEditorRef(null);
       revealedRef.current = false;
     };
-  }, [diffEditorOptions, file.filePath, runId, setEditorRef]);
+  }, [diffEditorOptions, file.filePath, isExpanded, runId, setEditorRef]);
 
   useEffect(() => {
     const instance = diffEditorRef.current;

--- a/apps/client/src/components/monaco-worker.ts
+++ b/apps/client/src/components/monaco-worker.ts
@@ -1,0 +1,23 @@
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === "json") {
+      return new jsonWorker();
+    }
+    if (label === "css" || label === "scss" || label === "less") {
+      return new cssWorker();
+    }
+    if (label === "html" || label === "handlebars" || label === "razor") {
+      return new htmlWorker();
+    }
+    if (label === "typescript" || label === "javascript") {
+      return new tsWorker();
+    }
+    return new editorWorker();
+  },
+};

--- a/apps/client/src/providers.tsx
+++ b/apps/client/src/providers.tsx
@@ -1,3 +1,5 @@
+import "@/components/monaco-worker";
+
 import { ThemeProvider } from "@/components/theme/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { HeroUIProvider } from "@heroui/react";
@@ -35,7 +37,10 @@ export function Providers({ children }: ProvidersProps) {
 }
 
 // Minimal error boundary to log render errors and show a friendly message.
-class RootErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+class RootErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
   state = { error: null as Error | null };
 
   static getDerivedStateFromError(error: Error) {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/client": {
       "name": "@cmux/client",
-      "version": "1.0.14",
+      "version": "1.0.20",
       "dependencies": {
         "@base-ui-components/react": "1.0.0-beta.2",
         "@cmux/convex": "workspace:*",
@@ -39,7 +39,6 @@
         "@lexical/selection": "^0.32.1",
         "@lexical/utils": "^0.32.1",
         "@mantine/hooks": "^8.1.3",
-        "@monaco-editor/react": "4.7.0-rc.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-popover": "^1.1.15",
@@ -1144,10 +1143,6 @@
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
 
     "@mantine/hooks": ["@mantine/hooks@8.3.0", "", { "peerDependencies": { "react": "^18.x || ^19.x" } }, "sha512-y/D8Hi4C1iEjTpjeMWKmz9QHMdPm5qQsBsRz6rpdRlVurtBhNf3DCJEtvwtmmKN1F9vBK8DDGy/OjQPUHLDqcA=="],
-
-    "@monaco-editor/loader": ["@monaco-editor/loader@1.5.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw=="],
-
-    "@monaco-editor/react": ["@monaco-editor/react@4.7.0-rc.0", "", { "dependencies": { "@monaco-editor/loader": "^1.4.0" }, "peerDependencies": { "monaco-editor": ">= 0.25.0 < 1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YfjXkDK0bcwS0zo8PXptvQdCQfOPPtzGsAzmIv7PnoUGFdIohsR+NVDyjbajMddF+3cWUm/3q9NzP/DUke9a+w=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.3", "", { "dependencies": { "@emnapi/core": "^1.4.5", "@emnapi/runtime": "^1.4.5", "@tybys/wasm-util": "^0.10.0" } }, "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q=="],
 
@@ -4084,8 +4079,6 @@
     "stacktracey": ["stacktracey@2.1.8", "", { "dependencies": { "as-table": "^1.0.36", "get-source": "^2.0.12" } }, "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw=="],
 
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
-
-    "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 


### PR DESCRIPTION
## Summary
- replace the DiffEditor wrapper with manual monaco diff editor instantiation
- add explicit lifecycle management for diff editor models, resize observers, and layout scheduling
- drop the unused @monaco-editor/react dependency from the client workspace

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cb51d97eb4833397421f3244ae8103