### PR TITLE
Track GitHub push timestamps via webhooks

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -405,16 +405,31 @@ function DashboardComponent() {
 
   const projectOptions = useMemo(() => {
     // Repo options as objects with GitHub icon
-    const repoValues = Array.from(
-      new Set(
-        Object.entries(reposByOrg || {}).flatMap(([, repos]) =>
-          repos.map((repo) => repo.fullName)
-        )
-      )
-    );
-    const repoOptions = repoValues.map((fullName) => ({
-      label: fullName,
-      value: fullName,
+    const repoDocs = Object.values(reposByOrg || {}).flatMap((repos) => repos);
+    const uniqueRepos = repoDocs.reduce((acc, repo) => {
+      const existing = acc.get(repo.fullName);
+      if (!existing) {
+        acc.set(repo.fullName, repo);
+        return acc;
+      }
+      const existingActivity = existing.lastPushedAt ?? Number.NEGATIVE_INFINITY;
+      const candidateActivity = repo.lastPushedAt ?? Number.NEGATIVE_INFINITY;
+      if (candidateActivity > existingActivity) {
+        acc.set(repo.fullName, repo);
+      }
+      return acc;
+    }, new Map<string, Doc<"repos">>());
+    const sortedRepos = Array.from(uniqueRepos.values()).sort((a, b) => {
+      const aPushedAt = a.lastPushedAt ?? Number.NEGATIVE_INFINITY;
+      const bPushedAt = b.lastPushedAt ?? Number.NEGATIVE_INFINITY;
+      if (aPushedAt !== bPushedAt) {
+        return bPushedAt - aPushedAt;
+      }
+      return a.fullName.localeCompare(b.fullName);
+    });
+    const repoOptions = sortedRepos.map((repo) => ({
+      label: repo.fullName,
+      value: repo.fullName,
       icon: (
         <GitHubIcon className="w-4 h-4 text-neutral-600 dark:text-neutral-300" />
       ),

--- a/packages/convex/convex/github_webhook.ts
+++ b/packages/convex/convex/github_webhook.ts
@@ -5,10 +5,14 @@ import type {
   WebhookEvent,
 } from "@octokit/webhooks-types";
 import { env } from "../_shared/convex-env";
-import { bytesToHex } from "../_shared/encoding";
 import { hmacSha256, safeEqualHex, sha256Hex } from "../_shared/crypto";
+import { bytesToHex } from "../_shared/encoding";
 import { internal } from "./_generated/api";
 import { httpAction } from "./_generated/server";
+
+const DEBUG_FLAGS = {
+  githubWebhook: false, // set true to emit verbose push diagnostics
+};
 
 async function verifySignature(
   secret: string,
@@ -35,8 +39,7 @@ function normalizeTimestamp(
   }
   const numeric = Number(value);
   if (Number.isFinite(numeric)) {
-    const normalized =
-      numeric > MILLIS_THRESHOLD ? numeric : numeric * 1000;
+    const normalized = numeric > MILLIS_THRESHOLD ? numeric : numeric * 1000;
     return Math.round(normalized);
   }
   const parsed = Date.parse(value);
@@ -69,7 +72,8 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
   }
 
   type WithInstallation = { installation?: { id?: number } };
-  const installationId: number | undefined = (body as WithInstallation).installation?.id;
+  const installationId: number | undefined = (body as WithInstallation)
+    .installation?.id;
 
   // Record delivery for idempotency/auditing
   if (delivery) {
@@ -123,8 +127,6 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
       case "repository":
       case "create":
       case "delete":
-      case "push":
-      case "pull_request":
       case "pull_request_review":
       case "pull_request_review_comment":
       case "issue_comment":
@@ -133,63 +135,78 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
       case "status":
       case "workflow_run":
       case "workflow_job": {
-        if (event === "pull_request") {
-          try {
-            const prPayload = body as PullRequestEvent;
-            const repoFullName = String(prPayload.repository?.full_name ?? "");
-            const installation = Number(prPayload.installation?.id ?? 0);
-            if (!repoFullName || !installation) break;
-            const conn = await _ctx.runQuery(
-              internal.github_app.getProviderConnectionByInstallationId,
-              { installationId: installation }
-            );
-            const teamId = conn?.teamId;
-            if (!teamId) break;
-            await _ctx.runMutation(internal.github_prs.upsertFromWebhookPayload, {
-              installationId: installation,
+        // Acknowledge unsupported events without retries for now.
+        break;
+      }
+      case "pull_request": {
+        try {
+          const prPayload = body as PullRequestEvent;
+          const repoFullName = String(prPayload.repository?.full_name ?? "");
+          const installation = Number(prPayload.installation?.id ?? 0);
+          if (!repoFullName || !installation) break;
+          const conn = await _ctx.runQuery(
+            internal.github_app.getProviderConnectionByInstallationId,
+            { installationId: installation }
+          );
+          const teamId = conn?.teamId;
+          if (!teamId) break;
+          await _ctx.runMutation(internal.github_prs.upsertFromWebhookPayload, {
+            installationId: installation,
+            repoFullName,
+            teamId,
+            payload: prPayload,
+          });
+        } catch (err) {
+          console.error("github_webhook pull_request handler failed", {
+            err,
+            delivery,
+          });
+        }
+        break;
+      }
+      case "push": {
+        try {
+          const pushPayload = body as PushEvent;
+          const repoFullName = String(pushPayload.repository?.full_name ?? "");
+          const installation = Number(pushPayload.installation?.id ?? 0);
+          if (!repoFullName || !installation) break;
+          const conn = await _ctx.runQuery(
+            internal.github_app.getProviderConnectionByInstallationId,
+            { installationId: installation }
+          );
+          const teamId = conn?.teamId;
+          if (!teamId) break;
+          const repoPushedAt = normalizeTimestamp(
+            pushPayload.repository?.pushed_at
+          );
+          const headCommitAt = normalizeTimestamp(
+            pushPayload.head_commit?.timestamp
+          );
+          const pushedAtMillis = repoPushedAt ?? headCommitAt ?? Date.now();
+          const providerRepoId =
+            typeof pushPayload.repository?.id === "number"
+              ? pushPayload.repository.id
+              : undefined;
+          if (DEBUG_FLAGS.githubWebhook) {
+            console.debug("github_webhook push handler debug", {
+              delivery,
               repoFullName,
-              teamId,
-              payload: prPayload,
+              installation,
+              pushedAtMillis,
+              providerRepoId,
             });
-          } catch (_err) {
-            // swallow
           }
-        } else if (event === "push") {
-          try {
-            const pushPayload = body as PushEvent;
-            const repoFullName = String(pushPayload.repository?.full_name ?? "");
-            const installation = Number(pushPayload.installation?.id ?? 0);
-            if (!repoFullName || !installation) break;
-            const conn = await _ctx.runQuery(
-              internal.github_app.getProviderConnectionByInstallationId,
-              { installationId: installation }
-            );
-            const teamId = conn?.teamId;
-            if (!teamId) break;
-            const repoPushedAt = normalizeTimestamp(
-              pushPayload.repository?.pushed_at
-            );
-            const headCommitAt = normalizeTimestamp(
-              pushPayload.head_commit?.timestamp
-            );
-            const pushedAtMillis =
-              repoPushedAt ?? headCommitAt ?? Date.now();
-            const providerRepoId =
-              typeof pushPayload.repository?.id === "number"
-                ? pushPayload.repository.id
-                : undefined;
-            await _ctx.runMutation(
-              internal.github.updateRepoActivityFromWebhook,
-              {
-                teamId,
-                repoFullName,
-                pushedAt: pushedAtMillis,
-                providerRepoId,
-              }
-            );
-          } catch (_err) {
-            // swallow
-          }
+          await _ctx.runMutation(internal.github.updateRepoActivityFromWebhook, {
+            teamId,
+            repoFullName,
+            pushedAt: pushedAtMillis,
+            providerRepoId,
+          });
+        } catch (err) {
+          console.error("github_webhook push handler failed", {
+            err,
+            delivery,
+          });
         }
         break;
       }
@@ -198,7 +215,8 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
         break;
       }
     }
-  } catch (_err) {
+  } catch (err) {
+    console.error("github_webhook dispatch failed", { err, delivery, event });
     // Swallow errors to avoid GitHub retries while we iterate
   }
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -257,6 +257,7 @@ const convexSchema = defineSchema({
     defaultBranch: v.optional(v.string()),
     connectionId: v.optional(v.id("providerConnections")),
     lastSyncedAt: v.optional(v.number()),
+    lastPushedAt: v.optional(v.number()),
   })
     .index("by_org", ["org"])
     .index("by_gitRemote", ["gitRemote"])


### PR DESCRIPTION
## Summary
- add an optional `lastPushedAt` column to the `repos` Convex table for storing provider push activity
- add an internal mutation that records the latest push time and provider repo id for a team repository
- normalize GitHub push webhook timestamps and update repo records whenever push events arrive

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cb515462448333859911d31ec1eab8