### PR TITLE
Fix napi config to use binaryName

### DIFF
--- a/apps/server/native/core/package.json
+++ b/apps/server/native/core/package.json
@@ -10,7 +10,7 @@
     "build:release": "bunx --bun @napi-rs/cli build --platform --release"
   },
   "napi": {
-    "name": "cmux_native_core",
+    "binaryName": "cmux_native_core",
     "triples": [
       "aarch64-apple-darwin",
       "x86_64-apple-darwin",


### PR DESCRIPTION
## Summary
- replace the deprecated `napi.name` setting with `binaryName` in the native core package configuration

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cb8c02a3c083339fc96fd887701176