### PR TITLE
Optimize Crown Evaluator Direct Server Communication

### DIFF
--- a/apps/worker/src/crownEvaluatorClient.ts
+++ b/apps/worker/src/crownEvaluatorClient.ts
@@ -1,0 +1,118 @@
+import { createClient } from "@cmux/www-openapi-client/client";
+import {
+  postApiCrownEvaluate,
+  postApiCrownSummarize,
+} from "@cmux/www-openapi-client";
+import { log } from "./logger.js";
+
+interface CrownEvaluationOptions {
+  prompt: string;
+  teamSlugOrId: string;
+  authToken: string;
+  wwwBaseUrl: string;
+}
+
+interface CrownSummarizationOptions {
+  prompt: string;
+  teamSlugOrId?: string;
+  authToken: string;
+  wwwBaseUrl: string;
+}
+
+export async function evaluateCrownDirectly({
+  prompt,
+  teamSlugOrId,
+  authToken,
+  wwwBaseUrl,
+}: CrownEvaluationOptions): Promise<{
+  winner: number;
+  reason: string;
+} | null> {
+  try {
+    log("INFO", "[CrownEvaluatorClient] Starting crown evaluation", {
+      teamSlugOrId,
+      promptLength: prompt.length,
+    });
+
+    const client = createClient();
+    const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("x-stack-auth", authToken);
+      return fetch(input, { ...init, headers });
+    };
+    client.setConfig({
+      baseUrl: wwwBaseUrl,
+      fetch: customFetch as typeof fetch,
+    });
+
+    const response = await postApiCrownEvaluate({
+      client,
+      body: {
+        prompt,
+        teamSlugOrId,
+      },
+    });
+
+    if (!response.data) {
+      log("ERROR", "[CrownEvaluatorClient] No data in crown evaluation response");
+      return null;
+    }
+
+    log("INFO", "[CrownEvaluatorClient] Crown evaluation completed", {
+      winner: response.data.winner,
+      reason: response.data.reason,
+    });
+
+    return response.data;
+  } catch (error) {
+    log("ERROR", "[CrownEvaluatorClient] Crown evaluation failed", error);
+    return null;
+  }
+}
+
+export async function summarizeCrownDirectly({
+  prompt,
+  teamSlugOrId,
+  authToken,
+  wwwBaseUrl,
+}: CrownSummarizationOptions): Promise<string | null> {
+  try {
+    log("INFO", "[CrownEvaluatorClient] Starting crown summarization", {
+      teamSlugOrId,
+      promptLength: prompt.length,
+    });
+
+    const client = createClient();
+    const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("x-stack-auth", authToken);
+      return fetch(input, { ...init, headers });
+    };
+    client.setConfig({
+      baseUrl: wwwBaseUrl,
+      fetch: customFetch as typeof fetch,
+    });
+
+    const response = await postApiCrownSummarize({
+      client,
+      body: {
+        prompt,
+        teamSlugOrId,
+      },
+    });
+
+    if (!response.data) {
+      log("ERROR", "[CrownEvaluatorClient] No data in crown summarization response");
+      return null;
+    }
+
+    log("INFO", "[CrownEvaluatorClient] Crown summarization completed", {
+      summaryLength: response.data.summary.length,
+    });
+
+    return response.data.summary;
+  } catch (error) {
+    log("ERROR", "[CrownEvaluatorClient] Crown summarization failed", error);
+    return null;
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -683,6 +683,62 @@ managementIO.on("connection", (socket) => {
     }
   });
 
+  // Handle crown evaluation request from server
+  socket.on("worker:crownEvaluate", async (data: any, callback: any) => {
+    try {
+      const { evaluateCrownDirectly } = await import("./crownEvaluatorClient.js");
+
+      log("INFO", "[Worker] Received crown evaluation request", {
+        promptLength: data.prompt?.length,
+        teamSlugOrId: data.teamSlugOrId,
+      });
+
+      const result = await evaluateCrownDirectly({
+        prompt: data.prompt,
+        teamSlugOrId: data.teamSlugOrId,
+        authToken: data.authToken,
+        wwwBaseUrl: data.wwwBaseUrl,
+      });
+
+      if (result) {
+        callback(null, { data: result });
+      } else {
+        callback(new Error("Crown evaluation failed"), null);
+      }
+    } catch (error) {
+      log("ERROR", "[Worker] Crown evaluation error", error);
+      callback(error instanceof Error ? error : new Error(String(error)), null);
+    }
+  });
+
+  // Handle crown summarization request from server
+  socket.on("worker:crownSummarize", async (data: any, callback: any) => {
+    try {
+      const { summarizeCrownDirectly } = await import("./crownEvaluatorClient.js");
+
+      log("INFO", "[Worker] Received crown summarization request", {
+        promptLength: data.prompt?.length,
+        teamSlugOrId: data.teamSlugOrId,
+      });
+
+      const summary = await summarizeCrownDirectly({
+        prompt: data.prompt,
+        teamSlugOrId: data.teamSlugOrId,
+        authToken: data.authToken,
+        wwwBaseUrl: data.wwwBaseUrl,
+      });
+
+      if (summary) {
+        callback(null, { summary });
+      } else {
+        callback(new Error("Crown summarization failed"), null);
+      }
+    } catch (error) {
+      log("ERROR", "[Worker] Crown summarization error", error);
+      callback(error instanceof Error ? error : new Error(String(error)), null);
+    }
+  });
+
   socket.on("worker:shutdown", () => {
     console.log(`Worker ${WORKER_ID} received shutdown command`);
     gracefulShutdown();

--- a/packages/shared/src/worker-schemas.ts
+++ b/packages/shared/src/worker-schemas.ts
@@ -265,6 +265,33 @@ export interface ServerToWorkerEvents {
   "worker:check-docker": (
     callback: (response: DockerReadinessResponse) => void
   ) => void;
+
+  // Crown evaluation events
+  "worker:crownEvaluate": (
+    data: {
+      prompt: string;
+      teamSlugOrId: string;
+      authToken: string;
+      wwwBaseUrl: string;
+    },
+    callback: (
+      error: Error | null,
+      response: { data: { winner: number; reason: string } } | null
+    ) => void
+  ) => void;
+
+  "worker:crownSummarize": (
+    data: {
+      prompt: string;
+      teamSlugOrId?: string;
+      authToken: string;
+      wwwBaseUrl: string;
+    },
+    callback: (
+      error: Error | null,
+      response: { summary: string } | null
+    ) => void
+  ) => void;
 }
 
 export interface WorkerFileChange {


### PR DESCRIPTION
refactor crown evaluator to go from worker directly to central server instead of a different method around