### PR TITLE
refactor: extract task run token verification helper

### DIFF
--- a/apps/www/lib/utils/task-run-token.ts
+++ b/apps/www/lib/utils/task-run-token.ts
@@ -1,0 +1,27 @@
+import { env } from "@/lib/utils/www-env";
+import { jwtVerify } from "jose";
+import { z } from "zod";
+
+const taskRunJwtSecret = new TextEncoder().encode(
+  env.CMUX_TASK_RUN_JWT_SECRET
+);
+
+const TaskRunTokenPayloadSchema = z.object({
+  taskRunId: z.string().min(1),
+  teamId: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+export type TaskRunTokenPayload = z.infer<typeof TaskRunTokenPayloadSchema>;
+
+export async function verifyTaskRunToken(
+  token: string
+): Promise<TaskRunTokenPayload> {
+  const verification = await jwtVerify(token, taskRunJwtSecret);
+  const parsed = TaskRunTokenPayloadSchema.safeParse(verification.payload);
+  if (!parsed.success) {
+    throw new Error("Invalid CMUX token payload");
+  }
+
+  return parsed.data;
+}


### PR DESCRIPTION
## Summary
- extract task run token verification logic into a reusable helper
- update the Anthropic proxy route to use the helper instead of inlined parsing

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cc92a04c6c8333856e9dbe0334ff44