### PR TITLE
Reinstall Docker CLI plugins after Morph Dockerfile execution

### DIFF
--- a/apps/www/lib/utils/morph-defaults.ts
+++ b/apps/www/lib/utils/morph-defaults.ts
@@ -1,3 +1,4 @@
 // export const DEFAULT_MORPH_SNAPSHOT_ID = "snapshot_nnucpxen";
 // export const DEFAULT_MORPH_SNAPSHOT_ID = "snapshot_osr8ngj4";
-export const DEFAULT_MORPH_SNAPSHOT_ID = "snapshot_r6j3rkmo";
+// export const DEFAULT_MORPH_SNAPSHOT_ID = "snapshot_r6j3rkmo";
+export const DEFAULT_MORPH_SNAPSHOT_ID = "snapshot_xo8ptbkl";


### PR DESCRIPTION
## Summary
- factor out Docker CLI plugin installation into a reusable helper
- re-run the plugin installation after Dockerfile execution so buildx stays pinned

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cc99a1a0d48333ba684eb4b99ee328