### PR TITLE
feat: replace create team prompt with guided dialog

### DIFF
--- a/apps/client/src/components/CreateTeamDialog.tsx
+++ b/apps/client/src/components/CreateTeamDialog.tsx
@@ -1,0 +1,337 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import React from "react";
+
+export interface CreateTeamFormValues {
+  name: string;
+  slug: string;
+  invites: string[];
+}
+
+interface CreateTeamDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (values: CreateTeamFormValues) => Promise<void> | void;
+  isSubmitting: boolean;
+  error?: string | null;
+}
+
+function sanitizeSlugInput(value: string): string {
+  const lower = value.toLowerCase();
+  const replaced = lower.replace(/[^a-z0-9-]+/g, "-");
+  const collapsed = replaced.replace(/-+/g, "-");
+  const trimmedEdges = collapsed.replace(/^-+/, "").replace(/-+$/, "");
+  return trimmedEdges.slice(0, 48);
+}
+
+function normalizeSlug(value: string): string {
+  return sanitizeSlugInput(value.trim());
+}
+
+function generateSlugFromName(name: string): string {
+  return sanitizeSlugInput(name.trim());
+}
+
+function parseInvites(raw: string): string[] {
+  const segments = raw
+    .split(/[\s,]+/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  const unique = Array.from(new Set(segments));
+  return unique;
+}
+
+export function CreateTeamDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  isSubmitting,
+  error,
+}: CreateTeamDialogProps) {
+  const [name, setName] = React.useState("");
+  const [slug, setSlug] = React.useState("");
+  const [invitesText, setInvitesText] = React.useState("");
+  const [slugManuallyEdited, setSlugManuallyEdited] = React.useState(false);
+  const [nameError, setNameError] = React.useState<string | null>(null);
+  const [slugError, setSlugError] = React.useState<string | null>(null);
+
+  const nameFieldId = React.useId();
+  const slugFieldId = React.useId();
+  const invitesFieldId = React.useId();
+  const nameHintId = `${nameFieldId}-hint`;
+  const nameErrorId = `${nameFieldId}-error`;
+  const slugHintId = `${slugFieldId}-hint`;
+  const slugErrorId = `${slugFieldId}-error`;
+  const invitesHintId = `${invitesFieldId}-hint`;
+
+  React.useEffect(() => {
+    if (!open) {
+      setName("");
+      setSlug("");
+      setInvitesText("");
+      setSlugManuallyEdited(false);
+      setNameError(null);
+      setSlugError(null);
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (slugManuallyEdited) {
+      return;
+    }
+    const autoSlug = generateSlugFromName(name);
+    if (autoSlug !== slug) {
+      setSlug(autoSlug);
+    }
+  }, [name, slug, slugManuallyEdited]);
+
+  const handleSlugChange = (value: string) => {
+    const sanitized = sanitizeSlugInput(value);
+    setSlug(sanitized);
+    const auto = generateSlugFromName(name);
+    if (sanitized.length === 0 || sanitized === auto) {
+      setSlugManuallyEdited(false);
+    } else {
+      setSlugManuallyEdited(true);
+    }
+    if (slugError && sanitized.length > 0) {
+      setSlugError(null);
+    }
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    const normalizedSlug = normalizeSlug(slug);
+
+    let hasError = false;
+    if (trimmedName.length === 0) {
+      setNameError("Enter a team name");
+      hasError = true;
+    } else if (trimmedName.length > 32) {
+      setNameError("Name must be at most 32 characters");
+      hasError = true;
+    } else {
+      setNameError(null);
+    }
+
+    if (normalizedSlug.length === 0) {
+      setSlugError("Enter a team slug");
+      hasError = true;
+    } else if (normalizedSlug.length < 3 || normalizedSlug.length > 48) {
+      setSlugError("Slug must be 3-48 characters");
+      hasError = true;
+    } else if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(normalizedSlug)) {
+      setSlugError(
+        "Use lowercase letters, numbers, and hyphens. Start and end with a letter or number."
+      );
+      hasError = true;
+    } else {
+      setSlugError(null);
+    }
+
+    if (hasError) {
+      setSlug(normalizedSlug);
+      return;
+    }
+
+    setSlug(normalizedSlug);
+    const invites = parseInvites(invitesText);
+    void onSubmit({
+      name: trimmedName,
+      slug: normalizedSlug,
+      invites,
+    });
+  };
+
+  const helperText = slug.length > 0 ? `/${slug}/dashboard` : "/your-team/dashboard";
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-neutral-950/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border",
+            "border-neutral-200 bg-white shadow-2xl focus:outline-none dark:border-neutral-800 dark:bg-neutral-900"
+          )}
+        >
+          <form onSubmit={handleSubmit} className="flex flex-col">
+            <div className="flex items-start justify-between gap-4 px-6 pt-6">
+              <div>
+                <Dialog.Title className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">
+                  Create a team
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+                  Name your workspace, choose a URL slug, and optionally invite teammates.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+                  disabled={isSubmitting}
+                  aria-label="Close"
+                >
+                  <X className="size-4" />
+                </Button>
+              </Dialog.Close>
+            </div>
+
+            <div className="px-6 py-4 space-y-4">
+              <div className="space-y-2">
+                <label
+                  htmlFor={nameFieldId}
+                  className="block text-sm font-medium text-neutral-800 dark:text-neutral-200"
+                >
+                  Team name
+                </label>
+                <input
+                  id={nameFieldId}
+                  type="text"
+                  value={name}
+                  onChange={(event) => {
+                    const next = event.target.value;
+                    setName(next);
+                    const trimmed = next.trim();
+                    if (
+                      nameError &&
+                      trimmed.length > 0 &&
+                      trimmed.length <= 32
+                    ) {
+                      setNameError(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    if (nameError && name.trim().length > 0 && name.trim().length <= 32) {
+                      setNameError(null);
+                    }
+                  }}
+                  autoFocus
+                  disabled={isSubmitting}
+                  aria-invalid={nameError ? true : undefined}
+                  aria-describedby={nameError ? nameErrorId : nameHintId}
+                  className={cn(
+                    "w-full rounded-lg border px-3 py-2 text-sm shadow-xs focus:outline-none focus:ring-2",
+                    "border-neutral-200 bg-white text-neutral-900 focus:border-primary focus:ring-primary/20",
+                    "dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-primary"
+                  )}
+                  placeholder="My product team"
+                />
+                {nameError ? (
+                  <p
+                    id={nameErrorId}
+                    className="text-sm text-destructive dark:text-red-400"
+                  >
+                    {nameError}
+                  </p>
+                ) : (
+                  <p
+                    id={nameHintId}
+                    className="text-xs text-neutral-500 dark:text-neutral-400"
+                  >
+                    Up to 32 characters. You can change this later.
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor={slugFieldId}
+                  className="block text-sm font-medium text-neutral-800 dark:text-neutral-200"
+                >
+                  Team slug
+                </label>
+                <input
+                  id={slugFieldId}
+                  type="text"
+                  value={slug}
+                  onChange={(event) => handleSlugChange(event.target.value)}
+                  onBlur={() => {
+                    const normalized = normalizeSlug(slug);
+                    handleSlugChange(normalized);
+                  }}
+                  disabled={isSubmitting}
+                  aria-invalid={slugError ? true : undefined}
+                  aria-describedby={slugError ? slugErrorId : slugHintId}
+                  className={cn(
+                    "w-full rounded-lg border px-3 py-2 text-sm shadow-xs focus:outline-none focus:ring-2",
+                    "border-neutral-200 bg-white text-neutral-900 focus:border-primary focus:ring-primary/20",
+                    "dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-primary"
+                  )}
+                  placeholder="my-team"
+                />
+                {slugError ? (
+                  <p
+                    id={slugErrorId}
+                    className="text-sm text-destructive dark:text-red-400"
+                  >
+                    {slugError}
+                  </p>
+                ) : (
+                  <p
+                    id={slugHintId}
+                    className="text-xs text-neutral-500 dark:text-neutral-400"
+                  >
+                    Lowercase letters, numbers, and hyphens. This becomes your URL: {helperText}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor={invitesFieldId}
+                  className="block text-sm font-medium text-neutral-800 dark:text-neutral-200"
+                >
+                  Invite teammates (optional)
+                </label>
+                <textarea
+                  id={invitesFieldId}
+                  value={invitesText}
+                  onChange={(event) => setInvitesText(event.target.value)}
+                  disabled={isSubmitting}
+                  rows={3}
+                  aria-describedby={invitesHintId}
+                  className={cn(
+                    "w-full rounded-lg border px-3 py-2 text-sm shadow-xs focus:outline-none focus:ring-2",
+                    "border-neutral-200 bg-white text-neutral-900 focus:border-primary focus:ring-primary/20",
+                    "dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:focus:border-primary"
+                  )}
+                  placeholder="alice@example.com, bob@example.com"
+                />
+                <p id={invitesHintId} className="text-xs text-neutral-500 dark:text-neutral-400">
+                  Separate emails with commas or new lines. We'll send invitations after the team is created.
+                </p>
+              </div>
+
+              {error ? (
+                <div
+                  role="alert"
+                  className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive dark:border-red-800/40 dark:bg-red-900/20 dark:text-red-300"
+                >
+                  {error}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex items-center justify-end gap-2 border-t border-neutral-200 px-6 py-4 dark:border-neutral-800">
+              <Dialog.Close asChild>
+                <Button type="button" variant="outline" disabled={isSubmitting}>
+                  Cancel
+                </Button>
+              </Dialog.Close>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Creating..." : "Create team"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/client/src/routes/_layout.team-picker.tsx
+++ b/apps/client/src/routes/_layout.team-picker.tsx
@@ -1,3 +1,4 @@
+import { CreateTeamDialog, type CreateTeamFormValues } from "@/components/CreateTeamDialog";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -6,30 +7,50 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { stackClientApp } from "@/lib/stack";
 import { isElectron } from "@/lib/electron";
+import { stackClientApp } from "@/lib/stack";
+import { setLastTeamSlugOrId } from "@/lib/lastTeam";
 import { api } from "@cmux/convex/api";
 import { Skeleton } from "@heroui/react";
 import { useStackApp, useUser, type Team } from "@stackframe/react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { setLastTeamSlugOrId } from "@/lib/lastTeam";
-import { useQuery as useConvexQuery, useMutation } from "convex/react";
-import type React from "react";
+import { useMutation, useQuery as useConvexQuery } from "convex/react";
+import React from "react";
 
 export const Route = createFileRoute("/_layout/team-picker")({
   component: TeamPicker,
 });
 
+function normalizeSlugValue(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
+    .slice(0, 48);
+}
+
 function TeamPicker() {
   const app = useStackApp();
   const user = useUser({ or: "return-null" });
   const navigate = useNavigate();
+  const accountSettingsUrl = app.urls.accountSettings;
   // Call the Stack teams hook at the top level (no memo to satisfy hook rules)
   const teams: Team[] = user?.useTeams() ?? [];
 
   // Convex helpers to immediately reflect team creation/membership locally
   const upsertTeamPublic = useMutation(api.stack.upsertTeamPublic);
   const ensureMembershipPublic = useMutation(api.stack.ensureMembershipPublic);
+  const setTeamSlug = useMutation(api.teams.setSlug);
+
+  const [isCreateTeamDialogOpen, setIsCreateTeamDialogOpen] =
+    React.useState(false);
+  const [isCreatingTeam, setIsCreatingTeam] = React.useState(false);
+  const [createTeamError, setCreateTeamError] = React.useState<string | null>(
+    null
+  );
 
   const getClientSlug = (meta: unknown): string | undefined => {
     if (meta && typeof meta === "object" && meta !== null) {
@@ -40,139 +61,189 @@ function TeamPicker() {
     return undefined;
   };
 
-  const handleCreateTeam = async () => {
+  const redirectToAccountSettings = React.useCallback(async () => {
+    await stackClientApp.redirectToAccountSettings?.().catch(() => {
+      void navigate({ to: accountSettingsUrl });
+    });
+  }, [accountSettingsUrl, navigate]);
+
+  const handleOpenCreateTeam = React.useCallback(() => {
     if (!user) {
-      await stackClientApp.redirectToAccountSettings?.().catch(() => {
-        const url = app.urls.accountSettings;
-        void navigate({ to: url });
-      });
+      void redirectToAccountSettings();
       return;
     }
+    setCreateTeamError(null);
+    setIsCreateTeamDialogOpen(true);
+  }, [redirectToAccountSettings, user]);
 
-    const displayName = window.prompt("Name your new team");
-    if (!displayName || !displayName.trim()) return;
-
-    try {
-      const newTeam = await user.createTeam({
-        displayName: displayName.trim(),
-      });
-
-      // Ensure Convex mirrors the new team and membership immediately (webhooks may lag)
-      await upsertTeamPublic({
-        id: newTeam.id,
-        displayName: newTeam.displayName,
-        profileImageUrl: newTeam.profileImageUrl ?? undefined,
-        createdAtMillis: Date.now(),
-      });
-      await ensureMembershipPublic({ teamId: newTeam.id, userId: user.id });
-
-      // Invite onboarding
-      const inviteInput = window.prompt(
-        "Invite teammates (comma-separated emails), or leave blank"
-      );
-      if (inviteInput && inviteInput.trim()) {
-        const emails = inviteInput
-          .split(",")
-          .map((e) => e.trim())
-          .filter((e) => e.length > 0);
-        for (const email of emails) {
-          try {
-            await newTeam.inviteUser({ email });
-          } catch (e) {
-            console.error("Failed to invite", email, e);
-          }
-        }
+  const handleCreateTeam = React.useCallback(
+    async ({ name, slug, invites }: CreateTeamFormValues) => {
+      if (!user) {
+        await redirectToAccountSettings();
+        return;
       }
 
-      // Navigate into the new team's dashboard
-      const teamSlugOrId =
-        (newTeam.clientMetadata &&
-        typeof newTeam.clientMetadata === "object" &&
-        newTeam.clientMetadata !== null &&
-        (newTeam.clientMetadata as Record<string, unknown>).slug &&
-        typeof (newTeam.clientMetadata as Record<string, unknown>).slug ===
-          "string"
-          ? ((newTeam.clientMetadata as Record<string, unknown>).slug as string)
-          : undefined) ?? newTeam.id;
+      const trimmedName = name.trim();
+      const normalizedSlug = normalizeSlugValue(slug);
 
-      await user.setSelectedTeam(newTeam);
-      setLastTeamSlugOrId(teamSlugOrId);
-      await navigate({
-        to: "/$teamSlugOrId/dashboard",
-        params: { teamSlugOrId },
-      });
-    } catch (err) {
-      console.error(
-        "Failed to create team via Stack, redirecting to settings",
-        err
-      );
-      await stackClientApp.redirectToAccountSettings?.().catch(() => {
-        const url = app.urls.accountSettings;
-        void navigate({ to: url });
-      });
-    }
-  };
+      setIsCreatingTeam(true);
+      setCreateTeamError(null);
+
+      try {
+        const newTeam = await user.createTeam({
+          displayName: trimmedName,
+        });
+
+        try {
+          await setTeamSlug({ teamSlugOrId: newTeam.id, slug: normalizedSlug });
+        } catch (slugError) {
+          await newTeam.delete().catch((deleteError) => {
+            console.error("Failed to delete team after slug error", deleteError);
+          });
+          throw slugError;
+        }
+
+        const existingMetadata =
+          typeof newTeam.clientMetadata === "object" &&
+          newTeam.clientMetadata !== null &&
+          !Array.isArray(newTeam.clientMetadata)
+            ? (newTeam.clientMetadata as Record<string, unknown>)
+            : {};
+
+        try {
+          await newTeam.update({
+            clientMetadata: {
+              ...existingMetadata,
+              slug: normalizedSlug,
+            },
+          });
+        } catch (metadataError) {
+          console.warn(
+            "Failed to update team metadata with slug",
+            metadataError
+          );
+        }
+
+        await upsertTeamPublic({
+          id: newTeam.id,
+          displayName: newTeam.displayName,
+          profileImageUrl: newTeam.profileImageUrl ?? undefined,
+          createdAtMillis: Date.now(),
+        });
+
+        await ensureMembershipPublic({ teamId: newTeam.id, userId: user.id });
+
+        for (const email of invites) {
+          try {
+            await newTeam.inviteUser({ email });
+          } catch (inviteError) {
+            console.error("Failed to invite", email, inviteError);
+          }
+        }
+
+        await user.setSelectedTeam(newTeam);
+        const teamSlugOrId = normalizedSlug || newTeam.id;
+        setLastTeamSlugOrId(teamSlugOrId);
+        setIsCreateTeamDialogOpen(false);
+        await navigate({
+          to: "/$teamSlugOrId/dashboard",
+          params: { teamSlugOrId },
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setCreateTeamError(message || "Failed to create team");
+        console.error("Failed to create team", error);
+      } finally {
+        setIsCreatingTeam(false);
+      }
+    },
+    [
+      ensureMembershipPublic,
+      navigate,
+      redirectToAccountSettings,
+      setTeamSlug,
+      upsertTeamPublic,
+      user,
+    ]
+  );
 
   return (
-    <div className="min-h-dvh w-full bg-neutral-50 dark:bg-neutral-950 flex items-center justify-center p-6">
-      {isElectron ? (
-        <div
-          className="fixed top-0 left-0 right-0 h-[24px]"
-          style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-        />
-      ) : null}
-      <div className="mx-auto w-full max-w-3xl">
-        <Card className="border-neutral-200 dark:border-neutral-800 bg-white/70 dark:bg-neutral-900/70 backdrop-blur">
-          <CardHeader>
-            <CardTitle className="text-neutral-900 dark:text-neutral-50">
-              Choose a team
-            </CardTitle>
-            <CardDescription className="text-neutral-600 dark:text-neutral-400">
-              Pick a team to continue. You can switch teams anytime.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {teams.length === 0 ? (
-              <div className="flex flex-col items-center justify-center gap-4 py-12">
-                <div className="text-center">
-                  <p className="text-neutral-800 dark:text-neutral-200 text-lg font-medium">
-                    You’re not in any teams yet
-                  </p>
-                  <p className="text-neutral-600 dark:text-neutral-400 mt-1">
-                    Create a team to get started.
-                  </p>
-                </div>
-                <Button onClick={handleCreateTeam} className="">
-                  Create a team
-                </Button>
-              </div>
-            ) : (
-              <div className="flex flex-col gap-6">
-                <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  {teams.map((team) => (
-                    <TeamItem
-                      key={team.id}
-                      team={team}
-                      getClientSlug={getClientSlug}
-                    />
-                  ))}
-                </ul>
-
-                <div className="flex items-center justify-end pt-2">
-                  <Button
-                    variant="ghost"
-                    onClick={handleCreateTeam}
-                    className="text-neutral-700 dark:text-neutral-300"
-                  >
-                    Create new team
+    <>
+      <CreateTeamDialog
+        open={isCreateTeamDialogOpen}
+        onOpenChange={(open) => {
+          if (!open && isCreatingTeam) {
+            return;
+          }
+          setIsCreateTeamDialogOpen(open);
+          if (!open) {
+            setCreateTeamError(null);
+          }
+        }}
+        onSubmit={handleCreateTeam}
+        isSubmitting={isCreatingTeam}
+        error={createTeamError}
+      />
+      <div className="min-h-dvh w-full bg-neutral-50 dark:bg-neutral-950 flex items-center justify-center p-6">
+        {isElectron ? (
+          <div
+            className="fixed top-0 left-0 right-0 h-[24px]"
+            style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+          />
+        ) : null}
+        <div className="mx-auto w-full max-w-3xl">
+          <Card className="border-neutral-200 dark:border-neutral-800 bg-white/70 dark:bg-neutral-900/70 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-neutral-900 dark:text-neutral-50">
+                Choose a team
+              </CardTitle>
+              <CardDescription className="text-neutral-600 dark:text-neutral-400">
+                Pick a team to continue. You can switch teams anytime.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {teams.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-4 py-12">
+                  <div className="text-center">
+                    <p className="text-neutral-800 dark:text-neutral-200 text-lg font-medium">
+                      You’re not in any teams yet
+                    </p>
+                    <p className="text-neutral-600 dark:text-neutral-400 mt-1">
+                      Create a team to get started.
+                    </p>
+                  </div>
+                  <Button onClick={handleOpenCreateTeam}>
+                    Create a team
                   </Button>
                 </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+              ) : (
+                <div className="flex flex-col gap-6">
+                  <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    {teams.map((team) => (
+                      <TeamItem
+                        key={team.id}
+                        team={team}
+                        getClientSlug={getClientSlug}
+                      />
+                    ))}
+                  </ul>
+
+                  <div className="flex items-center justify-end pt-2">
+                    <Button
+                      variant="ghost"
+                      onClick={handleOpenCreateTeam}
+                      className="text-neutral-700 dark:text-neutral-300"
+                    >
+                      Create new team
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a reusable CreateTeamDialog that walks through naming, slug selection, and optional invites with validation
- wire the team picker to open the dialog, normalize slugs, call the Convex slug mutation, and send invites without browser prompts

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cdab771f5c833385de0268dac220b3