### PR TITLE
Add environment context to tasks and runs

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -21,7 +21,7 @@ import { useSocket } from "@/contexts/socket/use-socket";
 import { createFakeConvexId } from "@/lib/fakeConvexId";
 import { branchesQueryOptions } from "@/queries/branches";
 import { api } from "@cmux/convex/api";
-import type { Doc } from "@cmux/convex/dataModel";
+import type { Doc, Id } from "@cmux/convex/dataModel";
 import type { ProviderStatusResponse } from "@cmux/shared";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
@@ -178,6 +178,7 @@ function DashboardComponent() {
           images: args.images,
           userId: "optimistic",
           teamId: teamSlugOrId,
+          environmentId: args.environmentId,
         };
 
         // Add the new task at the beginning (since we order by desc)
@@ -247,6 +248,9 @@ function DashboardComponent() {
     const branch = effectiveSelectedBranch[0];
     const projectFullName = selectedProject[0];
     const envSelected = projectFullName.startsWith("env:");
+    const environmentId = envSelected
+      ? (projectFullName.replace(/^env:/, "") as Id<"environments">)
+      : undefined;
 
     try {
       // Extract content including images from the editor
@@ -304,6 +308,7 @@ function DashboardComponent() {
         projectFullName: envSelected ? undefined : projectFullName,
         baseBranch: envSelected ? undefined : branch,
         images: uploadedImages.length > 0 ? uploadedImages : undefined,
+        environmentId,
       });
 
       // Hint the sidebar to auto-expand this task once it appears
@@ -325,16 +330,7 @@ function DashboardComponent() {
           selectedAgents:
             selectedAgents.length > 0 ? selectedAgents : undefined,
           isCloudMode: envSelected ? true : isCloudMode,
-          ...(envSelected
-            ? {
-                environmentId: projectFullName.replace(
-                  /^env:/,
-                  ""
-                ) as string & {
-                  __tableName: "environments";
-                },
-              }
-            : {}),
+          ...(environmentId ? { environmentId } : {}),
           images: images.length > 0 ? images : undefined,
           theme,
         },

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -52,7 +52,7 @@ export async function spawnAgent(
     branch?: string;
     taskDescription: string;
     isCloudMode?: boolean;
-    environmentId?: Id<"environments"> | string;
+    environmentId?: Id<"environments">;
     images?: Array<{
       src: string;
       fileName?: string;
@@ -341,7 +341,7 @@ export async function spawnAgent(
         repoUrl: options.repoUrl,
         branch: options.branch,
         newBranch,
-        environmentId: options.environmentId as Id<"environments"> | undefined,
+        environmentId: options.environmentId,
       });
 
       worktreePath = "/root/workspace";
@@ -941,7 +941,7 @@ export async function spawnAllAgents(
     prTitle?: string;
     selectedAgents?: string[];
     isCloudMode?: boolean;
-    environmentId?: Id<"environments"> | string;
+    environmentId?: Id<"environments">;
     images?: Array<{
       src: string;
       fileName?: string;

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -87,6 +87,9 @@ export async function spawnAgent(
         prompt: options.taskDescription,
         agentName: agent.name,
         newBranch,
+        environmentId: options.environmentId
+          ? (options.environmentId as Id<"environments">)
+          : undefined,
       }
     );
 

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -87,9 +87,7 @@ export async function spawnAgent(
         prompt: options.taskDescription,
         agentName: agent.name,
         newBranch,
-        environmentId: options.environmentId
-          ? (options.environmentId as Id<"environments">)
-          : undefined,
+        environmentId: options.environmentId,
       }
     );
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -105,6 +105,7 @@ const convexSchema = defineSchema({
     updatedAt: v.optional(v.number()),
     userId: v.string(), // Link to user who created the task
     teamId: v.string(),
+    environmentId: v.optional(v.id("environments")),
     crownEvaluationError: v.optional(v.string()), // Error message if crown evaluation failed
     mergeStatus: v.optional(
       v.union(
@@ -154,6 +155,7 @@ const convexSchema = defineSchema({
     errorMessage: v.optional(v.string()), // Error message when run fails early
     userId: v.string(), // Link to user who created the run
     teamId: v.string(),
+    environmentId: v.optional(v.id("environments")),
     isCrowned: v.optional(v.boolean()), // Whether this run won the crown evaluation
     crownReason: v.optional(v.string()), // LLM's reasoning for why this run was crowned
     pullRequestUrl: v.optional(v.string()), // URL of the PR

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -15,6 +15,7 @@ export const create = authMutation({
     prompt: v.string(),
     agentName: v.optional(v.string()),
     newBranch: v.optional(v.string()),
+    environmentId: v.optional(v.id("environments")),
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
@@ -31,6 +32,7 @@ export const create = authMutation({
       updatedAt: now,
       userId,
       teamId,
+      environmentId: args.environmentId,
     });
     const jwt = await new SignJWT({
       taskRunId,

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -21,6 +21,12 @@ export const create = authMutation({
     const userId = ctx.identity.subject;
     const now = Date.now();
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    if (args.environmentId) {
+      const environment = await ctx.db.get(args.environmentId);
+      if (!environment || environment.teamId !== teamId) {
+        throw new Error("Environment not found");
+      }
+    }
     const taskRunId = await ctx.db.insert("taskRuns", {
       taskId: args.taskId,
       parentRunId: args.parentRunId,

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -116,6 +116,7 @@ export const create = authMutation({
         })
       )
     ),
+    environmentId: v.optional(v.id("environments")),
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
@@ -133,6 +134,7 @@ export const create = authMutation({
       images: args.images,
       userId,
       teamId,
+      environmentId: args.environmentId,
     });
 
     return taskId;

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -121,6 +121,12 @@ export const create = authMutation({
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    if (args.environmentId) {
+      const environment = await ctx.db.get(args.environmentId);
+      if (!environment || environment.teamId !== teamId) {
+        throw new Error("Environment not found");
+      }
+    }
     const now = Date.now();
     const taskId = await ctx.db.insert("tasks", {
       text: args.text,


### PR DESCRIPTION
## Summary
- add optional `environmentId` fields to tasks and task runs in the Convex schema
- thread the optional environment id through task and run creation, including the dashboard create flow
- forward the environment id when spawning agents so task runs preserve the environment linkage

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cdc04315808333989e8e8ba267ea83