### PR TITLE
Normalize WWW origin handling for production

### DIFF
--- a/apps/client/src/contexts/convex/convex-client-provider.tsx
+++ b/apps/client/src/contexts/convex/convex-client-provider.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { env } from "@/client-env";
 import { getRandomKitty } from "@/components/kitties";
 import CmuxLogoMarkAnimated from "@/components/logo/cmux-logo-mark-animated";
 import { cachedGetUser } from "@/lib/cachedGetUser";
 import { isElectron } from "@/lib/electron";
 import { stackClientApp } from "@/lib/stack";
+import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 import { SignIn, useUser } from "@stackframe/react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Authenticated, ConvexProviderWithAuth } from "convex/react";
@@ -108,8 +108,7 @@ function AuthenticatedOrSignIn({
                 </div>
                 <button
                   onClick={() => {
-                    const origin = env.NEXT_PUBLIC_WWW_ORIGIN;
-                    const url = `${origin}/handler/sign-in/`;
+                    const url = `${WWW_ORIGIN}/handler/sign-in/`;
                     // Open in external browser via Electron handler
                     window.open(url, "_blank", "noopener,noreferrer");
                   }}

--- a/apps/client/src/lib/stack.ts
+++ b/apps/client/src/lib/stack.ts
@@ -5,6 +5,7 @@ import { env } from "../client-env";
 import { signalConvexAuthReady } from "../contexts/convex/convex-auth-ready";
 import { convexQueryClient } from "../contexts/convex/convex-query-client";
 import { cachedGetUser } from "./cachedGetUser";
+import { WWW_ORIGIN } from "./wwwOrigin";
 
 export const stackClientApp = new StackClientApp({
   projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
@@ -91,6 +92,6 @@ const fetchWithAuth = (async (request: Request) => {
 }) as typeof fetch; // TODO: remove when bun types dont conflict with node types
 
 wwwOpenAPIClient.setConfig({
-  baseUrl: env.NEXT_PUBLIC_WWW_ORIGIN,
+  baseUrl: WWW_ORIGIN,
   fetch: fetchWithAuth,
 });

--- a/apps/client/src/lib/wwwOrigin.ts
+++ b/apps/client/src/lib/wwwOrigin.ts
@@ -1,0 +1,4 @@
+import { normalizeOrigin } from "@cmux/shared";
+import { env } from "@/client-env";
+
+export const WWW_ORIGIN = normalizeOrigin(env.NEXT_PUBLIC_WWW_ORIGIN);

--- a/apps/server/src/utils/server-env.ts
+++ b/apps/server/src/utils/server-env.ts
@@ -1,3 +1,4 @@
+import { normalizeOrigin } from "@cmux/shared";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
@@ -14,10 +15,10 @@ export const env = createEnv({
 
 export function getWwwBaseUrl(): string {
   // Read from live process.env first to support tests that mutate env at runtime
-  return (
+  const rawOrigin =
     // Prefer the public origin for the WWW app when available
     process.env.NEXT_PUBLIC_WWW_ORIGIN ||
     env.NEXT_PUBLIC_WWW_ORIGIN ||
-    "http://localhost:9779"
-  );
+    "http://localhost:9779";
+  return normalizeOrigin(rawOrigin);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,4 +6,5 @@ export * from "./terminal-config.js";
 export * from "./vscode-schemas.js";
 export * from "./worker-schemas.js";
 export * from "./diff-types.js";
+export * from "./utils/normalize-origin.js";
 // Do NOT export Node-only utilities here; browser builds import this index.

--- a/packages/shared/src/utils/normalize-origin.test.ts
+++ b/packages/shared/src/utils/normalize-origin.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { normalizeOrigin } from "./normalize-origin.js";
+
+describe("normalizeOrigin", () => {
+  it("upgrades non-local http origins to https", () => {
+    expect(normalizeOrigin("http://cmux.dev")).toBe("https://cmux.dev");
+  });
+
+  it("keeps https origins untouched", () => {
+    expect(normalizeOrigin("https://cmux.dev")).toBe("https://cmux.dev");
+  });
+
+  it("preserves localhost http origins", () => {
+    expect(normalizeOrigin("http://localhost:9779")).toBe("http://localhost:9779");
+  });
+
+  it("preserves numeric loopback hosts", () => {
+    expect(normalizeOrigin("http://127.0.0.1:4000")).toBe("http://127.0.0.1:4000");
+  });
+
+  it("returns trimmed origin when parsing fails", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(normalizeOrigin(" not-a-url ")).toBe("not-a-url");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/shared/src/utils/normalize-origin.ts
+++ b/packages/shared/src/utils/normalize-origin.ts
@@ -1,0 +1,35 @@
+const LOCAL_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+]);
+
+function isLikelyLocalHost(hostname: string): boolean {
+  if (!hostname) return false;
+  const lower = hostname.toLowerCase();
+  if (LOCAL_HOSTS.has(lower)) return true;
+  if (lower.endsWith(".localhost")) return true;
+  if (lower.endsWith(".local")) return true;
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(lower)) return true;
+  return false;
+}
+
+export function normalizeOrigin(rawOrigin: string): string {
+  const trimmed = rawOrigin?.trim();
+  if (!trimmed) return rawOrigin;
+  try {
+    const url = new URL(trimmed);
+    const isLocal = isLikelyLocalHost(url.hostname);
+    if (url.protocol === "http:" && !isLocal) {
+      url.protocol = "https:";
+    }
+    return url.origin;
+  } catch (error) {
+    console.warn(
+      `[normalizeOrigin] Unable to parse origin: ${rawOrigin}`,
+      error instanceof Error ? error.message : error
+    );
+    return trimmed;
+  }
+}

--- a/scripts/debug-start-sandbox.ts
+++ b/scripts/debug-start-sandbox.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import "dotenv/config";
+import { normalizeOrigin } from "@cmux/shared";
 import { StackAdminApp } from "@stackframe/js";
 import { createClient } from "@cmux/www-openapi-client/client";
 import { postApiSandboxesStart } from "@cmux/www-openapi-client";
@@ -111,7 +112,8 @@ async function sleep(ms: number): Promise<void> {
 
 async function main(): Promise<void> {
   const options = parseArgs();
-  const baseUrl = process.env.NEXT_PUBLIC_WWW_ORIGIN ?? "http://localhost:9779";
+  const rawBaseUrl = process.env.NEXT_PUBLIC_WWW_ORIGIN ?? "http://localhost:9779";
+  const baseUrl = normalizeOrigin(rawBaseUrl);
   const client = createClient({ baseUrl });
 
   const authHeader = await getAuthHeader(options.userId);


### PR DESCRIPTION
## Summary
- add shared origin normalizer so production falls back to https
- update client and server callers to use sanitized WWW origin

## Testing
- bun run check