### PR TITLE
Add htop to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pigz \
     xz-utils \
     tmux \
+    htop \
     ripgrep \
     jq \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add htop to the runtime image's apt packages so it's available in containers

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cde34fbb908333aaa24cf2594bde0d