### PR TITLE
Add omnibar and devtools controls to Electron preview window

### DIFF
--- a/apps/client/electron/main/web-contents-view.ts
+++ b/apps/client/electron/main/web-contents-view.ts
@@ -639,6 +639,66 @@ export function registerWebContentsViewHandlers({
     }
   });
 
+  ipcMain.handle("cmux:webcontents:go-back", (event, id: number) => {
+    if (typeof id !== "number") return { ok: false };
+    const entry = viewEntries.get(id);
+    if (!entry) return { ok: false };
+    if (event.sender.id !== entry.ownerWebContentsId) {
+      return { ok: false };
+    }
+    entry.ownerSender = event.sender;
+    try {
+      if (!entry.view.webContents.canGoBack()) {
+        return { ok: false };
+      }
+      entry.view.webContents.goBack();
+      sendState(entry, logger, "go-back-command");
+      return { ok: true };
+    } catch (error) {
+      logger.warn("Failed to go back", { id, error });
+      return { ok: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle("cmux:webcontents:go-forward", (event, id: number) => {
+    if (typeof id !== "number") return { ok: false };
+    const entry = viewEntries.get(id);
+    if (!entry) return { ok: false };
+    if (event.sender.id !== entry.ownerWebContentsId) {
+      return { ok: false };
+    }
+    entry.ownerSender = event.sender;
+    try {
+      if (!entry.view.webContents.canGoForward()) {
+        return { ok: false };
+      }
+      entry.view.webContents.goForward();
+      sendState(entry, logger, "go-forward-command");
+      return { ok: true };
+    } catch (error) {
+      logger.warn("Failed to go forward", { id, error });
+      return { ok: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle("cmux:webcontents:reload", (event, id: number) => {
+    if (typeof id !== "number") return { ok: false };
+    const entry = viewEntries.get(id);
+    if (!entry) return { ok: false };
+    if (event.sender.id !== entry.ownerWebContentsId) {
+      return { ok: false };
+    }
+    entry.ownerSender = event.sender;
+    try {
+      entry.view.webContents.reload();
+      sendState(entry, logger, "reload-command");
+      return { ok: true };
+    } catch (error) {
+      logger.warn("Failed to reload WebContentsView", { id, error });
+      return { ok: false, error: String(error) };
+    }
+  });
+
   ipcMain.handle("cmux:webcontents:release", (event, options: ReleaseOptions) => {
     const { id, persist } = options ?? {};
     if (typeof id !== "number") return { ok: false };

--- a/apps/client/electron/preload/index.ts
+++ b/apps/client/electron/preload/index.ts
@@ -162,6 +162,12 @@ const cmuxAPI = {
         "cmux:webcontents:update-style",
         options
       ) as Promise<{ ok: boolean }>,
+    goBack: (id: number) =>
+      ipcRenderer.invoke("cmux:webcontents:go-back", id) as Promise<{ ok: boolean }>,
+    goForward: (id: number) =>
+      ipcRenderer.invoke("cmux:webcontents:go-forward", id) as Promise<{ ok: boolean }>,
+    reload: (id: number) =>
+      ipcRenderer.invoke("cmux:webcontents:reload", id) as Promise<{ ok: boolean }>,
     onEvent: (id: number, callback: (event: ElectronWebContentsEvent) => void) => {
       const channel = `cmux:webcontents:event:${id}`;
       const listener = (_event: Electron.IpcRendererEvent, payload: ElectronWebContentsEvent) => {

--- a/apps/client/electron/tsconfig.json
+++ b/apps/client/electron/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "**/*.ts",
-    "../electron-vite.config.ts"
+    "../electron-vite.config.ts",
+    "../src"
   ]
 }

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -1,0 +1,379 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import { ChevronDown, Globe, Inspect, Loader2 } from "lucide-react";
+
+import { PersistentWebView } from "@/components/persistent-webview";
+import { Button } from "@/components/ui/button";
+import { Dropdown } from "@/components/ui/dropdown";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type {
+  ElectronDevToolsMode,
+  ElectronWebContentsEvent,
+  ElectronWebContentsState,
+} from "@/types/electron-webcontents";
+
+interface ElectronPreviewBrowserProps {
+  persistKey: string;
+  src: string;
+  borderRadius?: number;
+}
+
+interface NativeViewHandle {
+  id: number;
+  webContentsId: number;
+  restored: boolean;
+}
+
+const DEVTOOLS_DOCK_OPTIONS: Array<{
+  label: string;
+  mode: ElectronDevToolsMode;
+}> = [
+  { label: "Dock to bottom", mode: "bottom" },
+  { label: "Dock to right", mode: "right" },
+  { label: "Open in separate window", mode: "undocked" },
+];
+
+function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return trimmed;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("//")) {
+    return `https:${trimmed}`;
+  }
+  return `https://${trimmed}`;
+}
+
+function useLoadingProgress(isLoading: boolean) {
+  const [progress, setProgress] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    if (isLoading) {
+      setVisible(true);
+      setProgress((prev) => (prev <= 0 ? 0.08 : prev));
+      interval = setInterval(() => {
+        setProgress((prev) => {
+          const next = prev + (1 - prev) * 0.18;
+          return Math.min(next, 0.95);
+        });
+      }, 120);
+    } else {
+      setProgress((prev) => (prev === 0 ? 0 : 1));
+      timeout = setTimeout(() => {
+        setVisible(false);
+        setProgress(0);
+      }, 260);
+    }
+
+    return () => {
+      if (interval) clearInterval(interval);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [isLoading]);
+
+  return { progress, visible };
+}
+
+export function ElectronPreviewBrowser({
+  persistKey,
+  src,
+  borderRadius,
+}: ElectronPreviewBrowserProps) {
+  const [viewHandle, setViewHandle] = useState<NativeViewHandle | null>(null);
+  const [addressValue, setAddressValue] = useState(src);
+  const [committedUrl, setCommittedUrl] = useState(src);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [devtoolsOpen, setDevtoolsOpen] = useState(false);
+  const [devtoolsMode, setDevtoolsMode] = useState<ElectronDevToolsMode>("bottom");
+  const [lastError, setLastError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const { progress, visible } = useLoadingProgress(isLoading);
+
+  useEffect(() => {
+    setAddressValue(src);
+    setCommittedUrl(src);
+    setLastError(null);
+  }, [src]);
+
+  const applyState = useCallback(
+    (state: ElectronWebContentsState) => {
+      setCommittedUrl(state.url);
+      if (!isEditing) {
+        setAddressValue(state.url);
+      }
+      setIsLoading(state.isLoading);
+      setDevtoolsOpen(state.isDevToolsOpened);
+      if (state.isLoading) {
+        setLastError(null);
+      }
+    },
+    [isEditing]
+  );
+
+  useEffect(() => {
+    if (!viewHandle) return;
+    const getState = window.cmux?.webContentsView?.getState;
+    if (!getState) return;
+    let disposed = false;
+    void getState(viewHandle.id)
+      .then((result) => {
+        if (disposed) return;
+        if (result?.ok && result.state) {
+          applyState(result.state);
+        }
+      })
+      .catch((error) => {
+        console.warn("Failed to get WebContentsView state", error);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [applyState, viewHandle]);
+
+  useEffect(() => {
+    if (!viewHandle) return;
+    const subscribe = window.cmux?.webContentsView?.onEvent;
+    if (!subscribe) return;
+    const unsubscribe = subscribe(viewHandle.id, (event: ElectronWebContentsEvent) => {
+      if (event.type === "state") {
+        applyState(event.state);
+        return;
+      }
+      if (event.type === "load-failed" && event.isMainFrame) {
+        setLastError(event.errorDescription || "Failed to load page");
+      }
+    });
+    return () => {
+      unsubscribe?.();
+    };
+  }, [applyState, viewHandle]);
+
+  const handleViewReady = useCallback((info: NativeViewHandle) => {
+    setViewHandle(info);
+    setLastError(null);
+  }, []);
+
+  const handleViewDestroyed = useCallback(() => {
+    setViewHandle(null);
+    setIsLoading(false);
+    setDevtoolsOpen(false);
+  }, []);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!viewHandle) return;
+      const raw = addressValue.trim();
+      if (!raw) return;
+      const target = normalizeUrl(raw);
+      setCommittedUrl(target);
+      setAddressValue(target);
+      setLastError(null);
+      setIsEditing(false);
+      inputRef.current?.blur();
+      void window.cmux?.webContentsView?.loadURL(viewHandle.id, target).catch((error) => {
+        console.warn("Failed to navigate WebContentsView", error);
+      });
+    },
+    [addressValue, viewHandle]
+  );
+
+  const handleInputFocus = useCallback((event: React.FocusEvent<HTMLInputElement>) => {
+    setIsEditing(true);
+    event.currentTarget.select();
+  }, []);
+
+  const handleInputBlur = useCallback(() => {
+    setIsEditing(false);
+    setAddressValue(committedUrl);
+  }, [committedUrl]);
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.currentTarget.blur();
+        setAddressValue(committedUrl);
+      }
+    },
+    [committedUrl]
+  );
+
+  const handleToggleDevTools = useCallback(() => {
+    if (!viewHandle) return;
+    if (devtoolsOpen) {
+      void window.cmux?.webContentsView?.closeDevTools(viewHandle.id).catch((error) => {
+        console.warn("Failed to close DevTools", error);
+      });
+    } else {
+      void window.cmux?.webContentsView
+        ?.openDevTools(viewHandle.id, { mode: devtoolsMode })
+        .catch((error) => {
+          console.warn("Failed to open DevTools", error);
+        });
+    }
+  }, [devtoolsMode, devtoolsOpen, viewHandle]);
+
+  const handleOpenDevToolsWithMode = useCallback(
+    (mode: ElectronDevToolsMode) => {
+      if (!viewHandle) return;
+      setDevtoolsMode(mode);
+      void window.cmux?.webContentsView
+        ?.openDevTools(viewHandle.id, { mode })
+        .catch((error) => {
+          console.warn("Failed to open DevTools with mode", error);
+        });
+    },
+    [viewHandle]
+  );
+
+  const handleCloseDevTools = useCallback(() => {
+    if (!viewHandle) return;
+    void window.cmux?.webContentsView?.closeDevTools(viewHandle.id).catch((error) => {
+      console.warn("Failed to close DevTools", error);
+    });
+  }, [viewHandle]);
+
+  const devtoolsTooltipLabel = devtoolsOpen ? "Close DevTools" : "Open DevTools";
+
+  const progressStyles = useMemo(() => {
+    return {
+      width: `${Math.min(1, Math.max(progress, 0)) * 100}%`,
+      opacity: visible ? 1 : 0,
+    } satisfies CSSProperties;
+  }, [progress, visible]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="px-4 pt-4 pb-3">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <div
+            className={cn(
+              "relative flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-2 shadow-sm",
+              "transition-[border-color,box-shadow] focus-within:border-primary focus-within:shadow-sm focus-within:ring-2 focus-within:ring-primary/15",
+              "dark:border-neutral-800 dark:bg-neutral-900"
+            )}
+          >
+            {isLoading ? (
+              <Loader2 className="size-4 animate-spin text-primary" />
+            ) : (
+              <Globe className="size-4 text-neutral-400 dark:text-neutral-500" />
+            )}
+            <input
+              ref={inputRef}
+              value={addressValue}
+              onChange={(event) => setAddressValue(event.target.value)}
+              onFocus={handleInputFocus}
+              onBlur={handleInputBlur}
+              onKeyDown={handleInputKeyDown}
+              className="flex-1 bg-transparent text-sm text-neutral-900 outline-none placeholder:text-neutral-400 disabled:cursor-not-allowed disabled:text-neutral-400 dark:text-neutral-100 dark:placeholder:text-neutral-600"
+              placeholder="Enter a URL"
+              spellCheck={false}
+              autoCapitalize="none"
+              autoCorrect="off"
+              disabled={!viewHandle}
+            />
+            <div className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      "size-9 rounded-full text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-100",
+                      devtoolsOpen && "text-primary hover:text-primary"
+                    )}
+                    onClick={handleToggleDevTools}
+                    disabled={!viewHandle}
+                    aria-label={devtoolsTooltipLabel}
+                  >
+                    <Inspect className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" align="end">
+                  {devtoolsTooltipLabel}
+                </TooltipContent>
+              </Tooltip>
+              <Dropdown.Root>
+                <Dropdown.Trigger
+                  className={cn(
+                    "flex size-9 items-center justify-center rounded-full text-neutral-500 transition-colors",
+                    "hover:bg-neutral-100 hover:text-neutral-800 focus-visible:ring-2 focus-visible:ring-primary/20",
+                    "dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100",
+                    !viewHandle && "cursor-not-allowed opacity-50"
+                  )}
+                  disabled={!viewHandle}
+                  aria-label="DevTools docking options"
+                >
+                  <ChevronDown className="size-4" />
+                </Dropdown.Trigger>
+                <Dropdown.Portal>
+                  <Dropdown.Positioner sideOffset={6}>
+                    <Dropdown.Popup>
+                      <Dropdown.Arrow />
+                      {DEVTOOLS_DOCK_OPTIONS.map((option) => (
+                        <Dropdown.Item
+                          key={option.mode}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            handleOpenDevToolsWithMode(option.mode);
+                          }}
+                        >
+                          {option.label}
+                        </Dropdown.Item>
+                      ))}
+                      <Dropdown.Item
+                        onClick={(event) => {
+                          event.preventDefault();
+                          handleCloseDevTools();
+                        }}
+                        disabled={!devtoolsOpen}
+                        className="text-neutral-500 dark:text-neutral-400"
+                      >
+                        Close DevTools
+                      </Dropdown.Item>
+                    </Dropdown.Popup>
+                  </Dropdown.Positioner>
+                </Dropdown.Portal>
+              </Dropdown.Root>
+            </div>
+            <div
+              className="pointer-events-none absolute inset-x-2 top-1.5 h-[3px] overflow-hidden rounded-full bg-neutral-200/70 transition-opacity dark:bg-neutral-800/80"
+              style={{ opacity: visible ? 1 : 0 }}
+            >
+              <div
+                className="h-full rounded-full bg-primary transition-[opacity,width]"
+                style={progressStyles}
+              />
+            </div>
+          </div>
+        </form>
+        {lastError ? (
+          <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive dark:border-red-700/40 dark:bg-red-500/15">
+            Failed to load page: {lastError}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex-1 overflow-hidden bg-white dark:bg-neutral-950">
+        <PersistentWebView
+          persistKey={persistKey}
+          src={src}
+          className="h-full w-full border-0"
+          borderRadius={borderRadius}
+          sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads"
+          onElectronViewReady={handleViewReady}
+          onElectronViewDestroyed={handleViewDestroyed}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -21,6 +21,7 @@ import type {
   ElectronWebContentsEvent,
   ElectronWebContentsState,
 } from "@/types/electron-webcontents";
+import clsx from "clsx";
 
 interface ElectronPreviewBrowserProps {
   persistKey: string;
@@ -126,7 +127,7 @@ export function ElectronPreviewBrowser({
 
   useEffect(() => {
     if (!viewHandle) return;
-    const getState = window.cmux?.webContentsView?.getState;
+    const getState = window.cmux.webContentsView.getState;
     if (!getState) return;
     let disposed = false;
     void getState(viewHandle.id)
@@ -295,6 +296,7 @@ export function ElectronPreviewBrowser({
       opacity: visible ? 1 : 0,
     } satisfies CSSProperties;
   }, [progress, visible]);
+  console.log({ progress });
 
   return (
     <div className="flex h-full flex-col">
@@ -313,7 +315,7 @@ export function ElectronPreviewBrowser({
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className="size-7 rounded-full p-0 text-neutral-400 hover:text-neutral-800 disabled:opacity-30 disabled:hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-100 dark:disabled:hover:text-neutral-500"
+                    className="size-7 rounded-full p-0 text-neutral-600 hover:text-neutral-800 disabled:opacity-30 disabled:hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-100 dark:disabled:hover:text-neutral-500"
                     onClick={handleGoBack}
                     disabled={!viewHandle || !canGoBack}
                     aria-label="Go back"
@@ -329,7 +331,7 @@ export function ElectronPreviewBrowser({
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className="size-7 rounded-full p-0 text-neutral-400 hover:text-neutral-800 disabled:opacity-30 disabled:hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-100 dark:disabled:hover:text-neutral-500"
+                    className="size-7 rounded-full p-0 text-neutral-600 hover:text-neutral-800 disabled:opacity-30 disabled:hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-100 dark:disabled:hover:text-neutral-500"
                     onClick={handleGoForward}
                     disabled={!viewHandle || !canGoForward}
                     aria-label="Go forward"
@@ -392,8 +394,8 @@ export function ElectronPreviewBrowser({
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className={cn(
-                      "size-9 rounded-full text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-100",
+                    className={clsx(
+                      "size-7 rounded-full p-0 text-neutral-600 hover:text-neutral-800 disabled:opacity-30 disabled:hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-100 dark:disabled:hover:text-neutral-500",
                       devtoolsOpen && "text-primary hover:text-primary"
                     )}
                     onClick={handleToggleDevTools}
@@ -409,7 +411,7 @@ export function ElectronPreviewBrowser({
               </Tooltip>
             </div>
             <div
-              className="pointer-events-none absolute inset-x-0 -top-px h-[2px] overflow-hidden bg-neutral-200/70 transition-opacity dark:bg-neutral-800/80"
+              className="pointer-events-none absolute inset-x-0 -top-px h-[2px] overflow-hidden bg-neutral-200/70 transition-opacity duration-500 dark:bg-neutral-800/80"
               style={{ opacity: visible ? 1 : 0 }}
             >
               <div

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -270,7 +270,7 @@ export function ElectronPreviewBrowser({
   const handleGoBack = useCallback(() => {
     if (!viewHandle) return;
     void window.cmux?.webContentsView
-      ?.goBack?.(viewHandle.id)
+      ?.goBack(viewHandle.id)
       .catch((error: unknown) => {
         console.warn("Failed to go back", error);
       });
@@ -279,7 +279,7 @@ export function ElectronPreviewBrowser({
   const handleGoForward = useCallback(() => {
     if (!viewHandle) return;
     void window.cmux?.webContentsView
-      ?.goForward?.(viewHandle.id)
+      ?.goForward(viewHandle.id)
       .catch((error: unknown) => {
         console.warn("Failed to go forward", error);
       });
@@ -349,7 +349,7 @@ export function ElectronPreviewBrowser({
                     onClick={() => {
                       if (!viewHandle) return;
                       void window.cmux?.webContentsView
-                        ?.reload?.(viewHandle.id)
+                        ?.reload(viewHandle.id)
                         .catch((error: unknown) => {
                           console.warn(
                             "Failed to reload WebContentsView",

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties } from "react";
 import { ChevronDown, Globe, Inspect, Loader2 } from "lucide-react";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { PersistentWebView } from "@/components/persistent-webview";
 import { Button } from "@/components/ui/button";
 import { Dropdown } from "@/components/ui/dropdown";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type {
   ElectronDevToolsMode,
@@ -91,7 +95,8 @@ export function ElectronPreviewBrowser({
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [devtoolsOpen, setDevtoolsOpen] = useState(false);
-  const [devtoolsMode, setDevtoolsMode] = useState<ElectronDevToolsMode>("bottom");
+  const [devtoolsMode, setDevtoolsMode] =
+    useState<ElectronDevToolsMode>("bottom");
   const [lastError, setLastError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -142,15 +147,18 @@ export function ElectronPreviewBrowser({
     if (!viewHandle) return;
     const subscribe = window.cmux?.webContentsView?.onEvent;
     if (!subscribe) return;
-    const unsubscribe = subscribe(viewHandle.id, (event: ElectronWebContentsEvent) => {
-      if (event.type === "state") {
-        applyState(event.state);
-        return;
+    const unsubscribe = subscribe(
+      viewHandle.id,
+      (event: ElectronWebContentsEvent) => {
+        if (event.type === "state") {
+          applyState(event.state);
+          return;
+        }
+        if (event.type === "load-failed" && event.isMainFrame) {
+          setLastError(event.errorDescription || "Failed to load page");
+        }
       }
-      if (event.type === "load-failed" && event.isMainFrame) {
-        setLastError(event.errorDescription || "Failed to load page");
-      }
-    });
+    );
     return () => {
       unsubscribe?.();
     };
@@ -179,17 +187,22 @@ export function ElectronPreviewBrowser({
       setLastError(null);
       setIsEditing(false);
       inputRef.current?.blur();
-      void window.cmux?.webContentsView?.loadURL(viewHandle.id, target).catch((error) => {
-        console.warn("Failed to navigate WebContentsView", error);
-      });
+      void window.cmux?.webContentsView
+        ?.loadURL(viewHandle.id, target)
+        .catch((error) => {
+          console.warn("Failed to navigate WebContentsView", error);
+        });
     },
     [addressValue, viewHandle]
   );
 
-  const handleInputFocus = useCallback((event: React.FocusEvent<HTMLInputElement>) => {
-    setIsEditing(true);
-    event.currentTarget.select();
-  }, []);
+  const handleInputFocus = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      setIsEditing(true);
+      event.currentTarget.select();
+    },
+    []
+  );
 
   const handleInputBlur = useCallback(() => {
     setIsEditing(false);
@@ -210,9 +223,11 @@ export function ElectronPreviewBrowser({
   const handleToggleDevTools = useCallback(() => {
     if (!viewHandle) return;
     if (devtoolsOpen) {
-      void window.cmux?.webContentsView?.closeDevTools(viewHandle.id).catch((error) => {
-        console.warn("Failed to close DevTools", error);
-      });
+      void window.cmux?.webContentsView
+        ?.closeDevTools(viewHandle.id)
+        .catch((error) => {
+          console.warn("Failed to close DevTools", error);
+        });
     } else {
       void window.cmux?.webContentsView
         ?.openDevTools(viewHandle.id, { mode: devtoolsMode })
@@ -237,12 +252,16 @@ export function ElectronPreviewBrowser({
 
   const handleCloseDevTools = useCallback(() => {
     if (!viewHandle) return;
-    void window.cmux?.webContentsView?.closeDevTools(viewHandle.id).catch((error) => {
-      console.warn("Failed to close DevTools", error);
-    });
+    void window.cmux?.webContentsView
+      ?.closeDevTools(viewHandle.id)
+      .catch((error) => {
+        console.warn("Failed to close DevTools", error);
+      });
   }, [viewHandle]);
 
-  const devtoolsTooltipLabel = devtoolsOpen ? "Close DevTools" : "Open DevTools";
+  const devtoolsTooltipLabel = devtoolsOpen
+    ? "Close DevTools"
+    : "Open DevTools";
 
   const progressStyles = useMemo(() => {
     return {
@@ -253,12 +272,12 @@ export function ElectronPreviewBrowser({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="px-4 pt-4 pb-3">
+      <div className="">
         <form onSubmit={handleSubmit} className="flex flex-col gap-2">
           <div
             className={cn(
-              "relative flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-3 py-2 shadow-sm",
-              "transition-[border-color,box-shadow] focus-within:border-primary focus-within:shadow-sm focus-within:ring-2 focus-within:ring-primary/15",
+              "relative flex items-center gap-2 border border-neutral-200 bg-white px-3 font-mono",
+              "focus-within:ring-2 focus-within:ring-primary/15",
               "dark:border-neutral-800 dark:bg-neutral-900"
             )}
           >
@@ -274,7 +293,7 @@ export function ElectronPreviewBrowser({
               onFocus={handleInputFocus}
               onBlur={handleInputBlur}
               onKeyDown={handleInputKeyDown}
-              className="flex-1 bg-transparent text-sm text-neutral-900 outline-none placeholder:text-neutral-400 disabled:cursor-not-allowed disabled:text-neutral-400 dark:text-neutral-100 dark:placeholder:text-neutral-600"
+              className="flex-1 bg-transparent text-[11px] text-neutral-900 outline-none placeholder:text-neutral-400 disabled:cursor-not-allowed disabled:text-neutral-400 dark:text-neutral-100 dark:placeholder:text-neutral-600"
               placeholder="Enter a URL"
               spellCheck={false}
               autoCapitalize="none"
@@ -347,7 +366,7 @@ export function ElectronPreviewBrowser({
               </Dropdown.Root>
             </div>
             <div
-              className="pointer-events-none absolute inset-x-2 top-1.5 h-[3px] overflow-hidden rounded-full bg-neutral-200/70 transition-opacity dark:bg-neutral-800/80"
+              className="pointer-events-none absolute inset-x-2 top-0 h-[3px] overflow-hidden rounded-full bg-neutral-200/70 transition-opacity dark:bg-neutral-800/80"
               style={{ opacity: visible ? 1 : 0 }}
             >
               <div

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -277,7 +277,6 @@ export function ElectronPreviewBrowser({
           <div
             className={cn(
               "relative flex items-center gap-2 border border-neutral-200 bg-white px-3 font-mono",
-              "focus-within:ring-2 focus-within:ring-primary/15",
               "dark:border-neutral-800 dark:bg-neutral-900"
             )}
           >
@@ -366,7 +365,7 @@ export function ElectronPreviewBrowser({
               </Dropdown.Root>
             </div>
             <div
-              className="pointer-events-none absolute inset-x-2 top-0 h-[3px] overflow-hidden rounded-full bg-neutral-200/70 transition-opacity dark:bg-neutral-800/80"
+              className="pointer-events-none absolute inset-x-0 top-0 h-[2px] overflow-hidden rounded-full bg-neutral-200/70 transition-opacity dark:bg-neutral-800/80"
               style={{ opacity: visible ? 1 : 0 }}
             >
               <div

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -84,7 +84,6 @@ function useLoadingProgress(isLoading: boolean) {
 export function ElectronPreviewBrowser({
   persistKey,
   src,
-  borderRadius,
 }: ElectronPreviewBrowserProps) {
   const [viewHandle, setViewHandle] = useState<NativeViewHandle | null>(null);
   const [addressValue, setAddressValue] = useState(src);
@@ -296,7 +295,6 @@ export function ElectronPreviewBrowser({
       opacity: visible ? 1 : 0,
     } satisfies CSSProperties;
   }, [progress, visible]);
-  console.log({ progress });
 
   return (
     <div className="flex h-full flex-col">
@@ -432,7 +430,7 @@ export function ElectronPreviewBrowser({
           persistKey={persistKey}
           src={src}
           className="h-full w-full border-0"
-          borderRadius={borderRadius}
+          borderRadius={0}
           sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads"
           onElectronViewReady={handleViewReady}
           onElectronViewDestroyed={handleViewDestroyed}

--- a/apps/client/src/components/persistent-webview.tsx
+++ b/apps/client/src/components/persistent-webview.tsx
@@ -22,6 +22,12 @@ interface PersistentWebViewProps {
   fallback?: ReactNode;
   onLoad?: () => void;
   onError?: (error: Error) => void;
+  onElectronViewReady?: (info: {
+    id: number;
+    webContentsId: number;
+    restored: boolean;
+  }) => void;
+  onElectronViewDestroyed?: () => void;
 }
 
 export function PersistentWebView({
@@ -41,6 +47,8 @@ export function PersistentWebView({
   fallback,
   onLoad,
   onError,
+  onElectronViewReady,
+  onElectronViewDestroyed,
 }: PersistentWebViewProps) {
   const resolvedRetain = true;
 
@@ -56,6 +64,8 @@ export function PersistentWebView({
         persistKey={persistKey}
         retainOnUnmount={resolvedRetain}
         fallback={fallback}
+        onNativeViewReady={onElectronViewReady}
+        onNativeViewDestroyed={onElectronViewDestroyed}
       />
     );
   }

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -1,6 +1,8 @@
 import { FloatingPane } from "@/components/floating-pane";
+import { ElectronPreviewBrowser } from "@/components/electron-preview-browser";
 import { PersistentWebView } from "@/components/persistent-webview";
 import { getTaskRunPreviewPersistKey } from "@/lib/persistent-webview-keys";
+import { isElectron } from "@/lib/electron";
 import { api } from "@cmux/convex/api";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { createFileRoute } from "@tanstack/react-router";
@@ -63,13 +65,21 @@ function PreviewPage() {
   return (
     <FloatingPane>
       {previewUrl ? (
-        <PersistentWebView
-          persistKey={persistKey}
-          src={previewUrl}
-          className="w-full h-full border-0"
-          borderRadius={paneBorderRadius}
-          sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads"
-        />
+        isElectron ? (
+          <ElectronPreviewBrowser
+            persistKey={persistKey}
+            src={previewUrl}
+            borderRadius={paneBorderRadius}
+          />
+        ) : (
+          <PersistentWebView
+            persistKey={persistKey}
+            src={previewUrl}
+            className="w-full h-full border-0"
+            borderRadius={paneBorderRadius}
+            sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads"
+          />
+        )
       ) : (
         <div className="flex items-center justify-center h-full bg-white dark:bg-neutral-950">
           <div className="text-center">

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -1,8 +1,7 @@
-import { FloatingPane } from "@/components/floating-pane";
 import { ElectronPreviewBrowser } from "@/components/electron-preview-browser";
 import { PersistentWebView } from "@/components/persistent-webview";
-import { getTaskRunPreviewPersistKey } from "@/lib/persistent-webview-keys";
 import { isElectron } from "@/lib/electron";
+import { getTaskRunPreviewPersistKey } from "@/lib/persistent-webview-keys";
 import { api } from "@cmux/convex/api";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { createFileRoute } from "@tanstack/react-router";
@@ -35,7 +34,6 @@ export const Route = createFileRoute(
 function PreviewPage() {
   const { taskId, teamSlugOrId, runId, port } = Route.useParams();
 
-
   const taskRuns = useQuery(api.taskRuns.getByTask, {
     teamSlugOrId,
     taskId,
@@ -63,7 +61,7 @@ function PreviewPage() {
   const paneBorderRadius = 6;
 
   return (
-    <FloatingPane>
+    <>
       {previewUrl ? (
         isElectron ? (
           <ElectronPreviewBrowser
@@ -110,6 +108,6 @@ function PreviewPage() {
           </div>
         </div>
       )}
-    </FloatingPane>
+    </>
   );
 }

--- a/apps/client/src/types/electron-webcontents.ts
+++ b/apps/client/src/types/electron-webcontents.ts
@@ -1,0 +1,31 @@
+export type ElectronDevToolsMode = "right" | "bottom" | "undocked" | "detach";
+
+export interface ElectronWebContentsState {
+  id: number;
+  webContentsId: number;
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+  isDevToolsOpened: boolean;
+}
+
+export interface ElectronWebContentsStateEvent {
+  type: "state";
+  state: ElectronWebContentsState;
+  reason?: string;
+}
+
+export interface ElectronWebContentsLoadFailedEvent {
+  type: "load-failed";
+  id: number;
+  errorCode: number;
+  errorDescription: string;
+  validatedURL: string;
+  isMainFrame: boolean;
+}
+
+export type ElectronWebContentsEvent =
+  | ElectronWebContentsStateEvent
+  | ElectronWebContentsLoadFailedEvent;

--- a/apps/client/src/types/electron.d.ts
+++ b/apps/client/src/types/electron.d.ts
@@ -54,9 +54,9 @@ interface CmuxWebContentsViewAPI {
     backgroundColor?: string;
     borderRadius?: number;
   }) => Promise<{ ok: boolean }>;
-  goBack?: (id: number) => Promise<{ ok: boolean }>;
-  goForward?: (id: number) => Promise<{ ok: boolean }>;
-  reload?: (id: number) => Promise<{ ok: boolean }>;
+  goBack: (id: number) => Promise<{ ok: boolean }>;
+  goForward: (id: number) => Promise<{ ok: boolean }>;
+  reload: (id: number) => Promise<{ ok: boolean }>;
   onEvent: (
     id: number,
     callback: (event: ElectronWebContentsEvent) => void

--- a/apps/client/src/types/electron.d.ts
+++ b/apps/client/src/types/electron.d.ts
@@ -2,6 +2,11 @@ import type {
   ElectronLogsPayload,
   ElectronMainLogMessage,
 } from "../lib/electron-logs/types";
+import type {
+  ElectronDevToolsMode,
+  ElectronWebContentsEvent,
+  ElectronWebContentsState,
+} from "./electron-webcontents";
 
 interface CmuxSocketAPI {
   connect: (query: Record<string, string>) => Promise<{ socketId: string; connected: boolean }>;
@@ -49,6 +54,18 @@ interface CmuxWebContentsViewAPI {
     backgroundColor?: string;
     borderRadius?: number;
   }) => Promise<{ ok: boolean }>;
+  onEvent: (
+    id: number,
+    callback: (event: ElectronWebContentsEvent) => void
+  ) => () => void;
+  getState: (
+    id: number
+  ) => Promise<{ ok: boolean; state?: ElectronWebContentsState }>;
+  openDevTools: (
+    id: number,
+    options?: { mode?: ElectronDevToolsMode }
+  ) => Promise<{ ok: boolean }>;
+  closeDevTools: (id: number) => Promise<{ ok: boolean }>;
 }
 
 interface CmuxAPI {


### PR DESCRIPTION
## Summary
- add an Electron-specific preview browser frame with omnibar, loading progress, and DevTools controls
- expose WebContentsView state and DevTools IPC hooks to the renderer and forward navigation/load events
- update preview routing and shared types to support the new UI in the Electron app

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68cddf1ce27c8333b7d0b4956908a833