### PR TITLE
Enhance Landing Page Headline to Highlight Product Value Proposition

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -108,7 +108,7 @@ export default function LandingPage() {
             <div className="bg-blue-500 rounded-sm" aria-hidden="true"></div>
             <div>
               <h1 className="text-4xl sm:text-4xl md:text-4xl font-semibold mb-6">
-                Manage AI coding agents in parallel
+                10x your 10x engineers by managing AI coding agents in parallel
               </h1>
 
               <p className="text-lg text-neutral-300 mb-4 leading-relaxed">


### PR DESCRIPTION
The landing page currently has the headline of "Manage your coding agents in parallel." This is useful but not good enough explaining what value this product brings to engineers and engineering teams. Try using some language in the headline like "This product helps 10x your 10x engineers" or something of the sort. Essentially this product allows 10x engineers who already use Claude Code, codex, and other AI tools to be 10x more productive. We don't want to omit the language about what our product is though, but add some of this value add fluff (not too much) into the website.