### PR TITLE
Ensure Tooltips and Sonners Appear Above VSCode Instances

### DIFF
--- a/apps/client/src/components/ui/mode-toggle-tooltip.tsx
+++ b/apps/client/src/components/ui/mode-toggle-tooltip.tsx
@@ -139,7 +139,7 @@ export function ModeToggleTooltip({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}
             transition={{ duration: 0.15, ease: "easeOut" }}
-            className="absolute top-full left-1/2 -translate-x-1/2 z-[var(--z-modal)] mt-2"
+            className="absolute top-full left-1/2 -translate-x-1/2 z-[var(--z-tooltip)] mt-2"
           >
             {/* Arrow pointing up - matching shadcn style */}
             <div className="absolute left-[calc(50%_-4px)] translate-y-[calc(-50%_+1px)] size-2.5 rounded-[2px] rotate-45 bg-black" />

--- a/apps/client/src/components/ui/tooltip.tsx
+++ b/apps/client/src/components/ui/tooltip.tsx
@@ -35,7 +35,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         style={{ "--primary": "black" } as React.CSSProperties}
         className={cn(
-          "bg-primary text-primary-foreground z-[var(--z-modal)] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance pointer-events-none select-none will-change-[transform,opacity]",
+          "bg-primary text-primary-foreground z-[var(--z-tooltip)] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance pointer-events-none select-none will-change-[transform,opacity]",
           // enter on delayed-open
           "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
           // instant-open should not animate or transition
@@ -49,7 +49,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-[var(--z-modal)] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] pointer-events-none select-none" />
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-[var(--z-tooltip)] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] pointer-events-none select-none" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/apps/client/src/lib/persistentIframeManager.ts
+++ b/apps/client/src/lib/persistentIframeManager.ts
@@ -64,7 +64,8 @@ class PersistentIframeManager {
         width: 0;
         height: 0;
         pointer-events: none;
-        z-index: var(--z-overlay);
+        /* Keep VS Code/webviews beneath app overlays (tooltips, toasts, modals) */
+        z-index: var(--z-base);
       `;
       document.body.appendChild(this.container);
     };


### PR DESCRIPTION
toast sonners and other tooltips now get hidden behind the vscode instances, but they should pop ontop of them. fix these issues. (mainly for the crown implementation and when we create a pr and then go straight to a vscode instance or autoupdate sonner).. just make it universal that the vscode is below these z-index wise (altho z index is probably not going to fix this0