### PR TITLE
Fix Monaco Editor web worker initialization and configuration

### DIFF
--- a/apps/client/src/components/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-viewer.tsx
@@ -1,8 +1,9 @@
-import { useTheme } from "@/components/theme/use-theme";
 import "@/lib/monaco-environment";
+
+import { useTheme } from "@/components/theme/use-theme";
+import { loaderInitPromise } from "@/lib/monaco-environment";
 import { cn } from "@/lib/utils";
 import type { ReplaceDiffEntry } from "@cmux/shared/diff-types";
-import loader from "@monaco-editor/loader";
 import {
   ChevronDown,
   ChevronRight,
@@ -12,7 +13,6 @@ import {
   FilePlus,
   FileText,
 } from "lucide-react";
-import * as monaco from "monaco-editor";
 import { type editor } from "monaco-editor";
 import {
   memo,
@@ -24,13 +24,6 @@ import {
   useState,
 } from "react";
 import { kitties } from "./kitties";
-
-loader.config({
-  monaco,
-});
-const loaderInitPromise = new Promise<typeof monaco>((resolve) => {
-  loader.init().then(resolve);
-});
 
 type FileDiffRowClassNames = {
   button?: string;

--- a/apps/client/src/components/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-viewer.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@/components/theme/use-theme";
+import "@/lib/monaco-environment";
 import { cn } from "@/lib/utils";
 import type { ReplaceDiffEntry } from "@cmux/shared/diff-types";
 import loader from "@monaco-editor/loader";

--- a/apps/client/src/lib/monaco-environment.ts
+++ b/apps/client/src/lib/monaco-environment.ts
@@ -1,40 +1,33 @@
-import type { Environment } from "monaco-editor/esm/vs/editor/editor.api";
+import loader from "@monaco-editor/loader";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 
-import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
-import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
-import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
-import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
-import MarkdownWorker from "monaco-editor/esm/vs/language/markdown/markdown.worker?worker";
-import TsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+import * as monaco from "monaco-editor";
 
-const workerFactories: Record<string, () => Worker> = {
-  css: () => new CssWorker(),
-  javascript: () => new TsWorker(),
-  json: () => new JsonWorker(),
-  markdown: () => new MarkdownWorker(),
-  scss: () => new CssWorker(),
-  typescript: () => new TsWorker(),
-  html: () => new HtmlWorker(),
-  handlebars: () => new HtmlWorker(),
-};
-
-const defaultWorkerFactory = () => new EditorWorker();
-
-const environment: Environment = {
-  getWorker(_moduleId, label) {
-    const workerFactory = workerFactories[label] ?? defaultWorkerFactory;
-    return workerFactory();
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === "json") {
+      return new jsonWorker();
+    }
+    if (label === "css" || label === "scss" || label === "less") {
+      return new cssWorker();
+    }
+    if (label === "html" || label === "handlebars" || label === "razor") {
+      return new htmlWorker();
+    }
+    if (label === "typescript" || label === "javascript") {
+      return new tsWorker();
+    }
+    return new editorWorker();
   },
 };
 
-declare global {
-  // eslint-disable-next-line no-var
-  var MonacoEnvironment: Environment | undefined;
-}
-
-if (typeof globalThis !== "undefined") {
-  const shouldInstall = typeof globalThis.MonacoEnvironment === "undefined";
-  if (shouldInstall) {
-    globalThis.MonacoEnvironment = environment;
-  }
-}
+loader.config({
+  monaco,
+});
+export const loaderInitPromise = new Promise<typeof monaco>((resolve) => {
+  loader.init().then(resolve);
+});

--- a/apps/client/src/lib/monaco-environment.ts
+++ b/apps/client/src/lib/monaco-environment.ts
@@ -1,0 +1,40 @@
+import type { Environment } from "monaco-editor/esm/vs/editor/editor.api";
+
+import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import MarkdownWorker from "monaco-editor/esm/vs/language/markdown/markdown.worker?worker";
+import TsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+const workerFactories: Record<string, () => Worker> = {
+  css: () => new CssWorker(),
+  javascript: () => new TsWorker(),
+  json: () => new JsonWorker(),
+  markdown: () => new MarkdownWorker(),
+  scss: () => new CssWorker(),
+  typescript: () => new TsWorker(),
+  html: () => new HtmlWorker(),
+  handlebars: () => new HtmlWorker(),
+};
+
+const defaultWorkerFactory = () => new EditorWorker();
+
+const environment: Environment = {
+  getWorker(_moduleId, label) {
+    const workerFactory = workerFactories[label] ?? defaultWorkerFactory;
+    return workerFactory();
+  },
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var MonacoEnvironment: Environment | undefined;
+}
+
+if (typeof globalThis !== "undefined") {
+  const shouldInstall = typeof globalThis.MonacoEnvironment === "undefined";
+  if (shouldInstall) {
+    globalThis.MonacoEnvironment = environment;
+  }
+}


### PR DESCRIPTION
[2025-09-22T07:55:22.134Z] [RENDERER] [WARNING] Could not create web worker(s). Falling back to loading web worker code in main thread, which might cause UI freezes. Please see https://github.com/microsoft/monaco-editor#faq (http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:40794)[2025-09-22T07:55:22.134Z] [RENDERER] [WARNING] You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker (http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:40796)[2025-09-22T07:55:22.354Z] [RENDERER] [WARNING] You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker (http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:40796)[2025-09-22T07:55:22.404Z] [RENDERER] [ERROR] [GlobalError] Error: Cannot read properties of undefined (reading 'toUrl')TypeError: Cannot read properties of undefined (reading 'toUrl')    at _FileAccessImpl.toUri (http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:9860:40)    at _FileAccessImpl.asBrowserUri (http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:9816:26)    at http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:45848:32    at new Promise (<anonymous>)    at EditorSimpleWorker.$loadForeignModule (http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:45840:12)    at http://localhost:5173/node_modules/.vite/deps/chunk-YWCRWSBT.js?v=7d549928:83526:22    at async http://localhost:5173/node_modules/.vite/deps/tsMode-YWJHKH32.js?v=7d549928:81:16 (http://localhost:5173/src/main.tsx:10)fix it