### PR TITLE
Fix CI/CD to build Rust cmux/native binary for releases

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -112,6 +112,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.21
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          profile: minimal
+          targets: x86_64-apple-darwin
       - name: Install dependencies (bun)
         run: bun install --frozen-lockfile
       - name: Install app deps in apps/client (bun)
@@ -144,6 +150,10 @@ jobs:
           NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
           NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
           EOF
+      - name: Build native Rust addon
+        working-directory: apps/server/native/core
+        shell: bash
+        run: bunx --bun @napi-rs/cli build --platform --release
       - name: Build, sign, and notarize (x64) via publish script
         env:
           MAC_CERT_BASE64: ${{ secrets.MAC_CERT_BASE64 }}
@@ -202,6 +212,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.21
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          profile: minimal
+          targets: aarch64-apple-darwin
       - name: Install dependencies (bun)
         run: bun install --frozen-lockfile
       - name: Install app deps in apps/client (bun)
@@ -234,6 +250,10 @@ jobs:
           NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
           NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
           EOF
+      - name: Build native Rust addon
+        working-directory: apps/server/native/core
+        shell: bash
+        run: bunx --bun @napi-rs/cli build --platform --release
       - name: Build, sign, and notarize (arm64) via publish script
         env:
           MAC_CERT_BASE64: ${{ secrets.MAC_CERT_BASE64 }}
@@ -292,6 +312,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.21
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          profile: minimal
+          targets: x86_64-pc-windows-msvc
       - name: Install dependencies (bun)
         run: bun install --frozen-lockfile
       - name: Write .env for build
@@ -304,6 +330,10 @@ jobs:
           NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
           NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
           EOF
+      - name: Build native Rust addon
+        working-directory: apps/server/native/core
+        shell: pwsh
+        run: bunx --bun @napi-rs/cli build --platform --release
       - name: Generate icons
         working-directory: apps/client
         run: bun run ./scripts/generate-icons.mjs
@@ -330,6 +360,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.21
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          profile: minimal
+          targets: x86_64-unknown-linux-gnu
       - name: Install dependencies (bun)
         run: bun install --frozen-lockfile
       - name: Write .env for build
@@ -342,6 +378,10 @@ jobs:
           NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
           NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
           EOF
+      - name: Build native Rust addon
+        working-directory: apps/server/native/core
+        shell: bash
+        run: bunx --bun @napi-rs/cli build --platform --release
       - name: Generate icons
         working-directory: apps/client
         run: bun run ./scripts/generate-icons.mjs


### PR DESCRIPTION
currently we are not building the rust cmux/native binary in ci/cd for @.github/workflows/release-updates.yml .. wondering why that is the case and how we can fix it to have that directly on it.. this is only a problem in the ci/cd build but not in local

we need to do this for all of the builds (mostly for the mac builds too)