### PR TITLE
Prevent Redundant Build in Release Workflow

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -1,8 +1,6 @@
 name: Build & Publish Electron Updates (GitHub Releases)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
the @.github/workflows/release-updates.yml seems to build again unnecessarily when we publish the release on github. why is it running the workflow again when we publish? we already bump the version (it builds everytime there is a new version, so there is no need to do this extra build when we publish to github releases)