### PR TITLE
Implement Persistent VSCode Sessions with Docker Volume Management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -215,6 +215,7 @@ ENV PATH="/usr/local/bin:$PATH"
 # Copy only the built artifacts and runtime dependencies from builder
 COPY --from=builder /app/openvscode-server /app/openvscode-server
 COPY --from=builder /root/.openvscode-server /root/.openvscode-server
+COPY --from=builder /root/.openvscode-server /opt/cmux/openvscode-defaults
 COPY --from=builder /builtins /builtins
 COPY --from=builder /usr/local/bin/wait-for-docker.sh /usr/local/bin/wait-for-docker.sh
 COPY --from=builder /cmux/apps/worker/scripts/collect-relevant-diff.sh /usr/local/bin/cmux-collect-relevant-diff.sh

--- a/apps/server/src/agentSpawner.resume.test.ts
+++ b/apps/server/src/agentSpawner.resume.test.ts
@@ -1,0 +1,235 @@
+import type { Id } from "@cmux/convex/dataModel";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resumeDockerRun,
+  terminateDockerRun,
+} from "./agentSpawner.js";
+import { ensureRunWorktreeAndBranch } from "./utils/ensureRunWorktree.js";
+import { getConvex } from "./utils/convexClient.js";
+import { runWithAuth } from "./utils/requestContext.js";
+import {
+  DockerVSCodeInstance,
+  containerMappings,
+} from "./vscode/DockerVSCodeInstance.js";
+
+vi.mock("./utils/ensureRunWorktree.js", () => ({
+  ensureRunWorktreeAndBranch: vi.fn(),
+}));
+
+const queryMock = vi.fn();
+const mutationMock = vi.fn();
+
+vi.mock("./utils/convexClient.js", () => ({
+  getConvex: vi.fn(() => ({
+    query: queryMock,
+    mutation: mutationMock,
+  })),
+}));
+
+describe("run lifecycle helpers", () => {
+  const taskRunId = "test-run" as Id<"taskRuns">;
+  const taskId = "test-task" as Id<"tasks">;
+  const teamSlugOrId = "default";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockReset();
+    mutationMock.mockReset();
+    containerMappings.clear();
+  });
+
+  it("resumes a warm session with existing volumes", async () => {
+    const volumes = {
+      workspace: "cmux_session_test-run_workspace",
+      vscode: "cmux_session_test-run_vscode",
+    };
+
+    const ensureMock = vi.mocked(ensureRunWorktreeAndBranch);
+    ensureMock.mockResolvedValue({
+      run: {
+        _id: taskRunId,
+        taskId,
+        agentName: "cmux/mock",
+        worktreePath: "/tmp/mock-workspace",
+        vscode: {
+          provider: "docker",
+          status: "stopped",
+          volumes,
+          lastActivityAt: Date.now() - 60_000,
+          containerName: `cmux-${taskRunId}`,
+        },
+      } as any,
+      task: {} as any,
+      worktreePath: "/tmp/mock-workspace",
+      branchName: "cmux-branch",
+      baseBranch: "main",
+    });
+
+    const startSpy = vi
+      .spyOn(DockerVSCodeInstance.prototype, "start")
+      .mockResolvedValue({
+        url: "http://localhost:48000",
+        workspaceUrl: "http://localhost:48000/?folder=/root/workspace",
+        instanceId: taskRunId,
+        taskRunId,
+        provider: "docker",
+      });
+
+    const fileWatchSpy = vi
+      .spyOn(DockerVSCodeInstance.prototype, "startFileWatch")
+      .mockImplementation(() => {});
+    const recordSpy = vi
+      .spyOn(DockerVSCodeInstance.prototype, "recordActivity")
+      .mockImplementation(() => {});
+    const volumeSpy = vi
+      .spyOn(DockerVSCodeInstance.prototype, "getSessionVolumes")
+      .mockReturnValue(volumes);
+    const retentionSpy = vi
+      .spyOn(DockerVSCodeInstance.prototype, "getWarmRetentionMs")
+      .mockReturnValue(3_600_000);
+    const containerIdSpy = vi
+      .spyOn(DockerVSCodeInstance.prototype, "getContainerId")
+      .mockReturnValue("container-123");
+
+    await runWithAuth("token", undefined, async () => {
+      const result = await resumeDockerRun(taskRunId, teamSlugOrId);
+      expect(result.info.workspaceUrl).toContain("/root/workspace");
+    });
+
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    const updateCall = mutationMock.mock.calls.find(([, payload]) =>
+      Boolean((payload as Record<string, unknown>).vscode)
+    );
+    expect(updateCall).toBeTruthy();
+    expect(updateCall?.[1]).toMatchObject({
+      teamSlugOrId,
+      id: taskRunId,
+      vscode: expect.objectContaining({
+        volumes,
+        sessionStatus: "active",
+        containerId: "container-123",
+      }),
+    });
+
+    startSpy.mockRestore();
+    fileWatchSpy.mockRestore();
+    recordSpy.mockRestore();
+    volumeSpy.mockRestore();
+    retentionSpy.mockRestore();
+    containerIdSpy.mockRestore();
+  });
+
+  it("terminates a session and removes mapping", async () => {
+    const dockerStop = vi.fn().mockResolvedValue(undefined);
+    const dockerSpy = vi
+      .spyOn(DockerVSCodeInstance, "getDocker")
+      .mockReturnValue({
+        getContainer: () => ({
+          stop: dockerStop,
+        }),
+      } as unknown as ReturnType<typeof DockerVSCodeInstance.getDocker>);
+
+    const terminateSpy = vi
+      .spyOn(DockerVSCodeInstance, "terminateSessionFromMapping")
+      .mockResolvedValue(undefined);
+
+    queryMock.mockResolvedValue({
+      _id: taskRunId,
+      taskId,
+      worktreePath: "/tmp/mock-workspace",
+      vscode: {
+        provider: "docker",
+        status: "stopped",
+        volumes: {
+          workspace: "cmux_session_test-run_workspace",
+          vscode: "cmux_session_test-run_vscode",
+        },
+        containerName: `cmux-${taskRunId}`,
+      },
+    });
+
+    await runWithAuth("token", undefined, async () => {
+      await terminateDockerRun(taskRunId, teamSlugOrId);
+    });
+
+    dockerSpy.mockRestore();
+
+    expect(dockerStop).toHaveBeenCalled();
+    expect(
+      (DockerVSCodeInstance.terminateSessionFromMapping as vi.Mock).mock.calls[0][0]
+        .sessionStatus
+    ).toBe("terminated");
+    const statusCall = mutationMock.mock.calls.find(([, payload]) =>
+      (payload as Record<string, unknown>).status === "stopped"
+    );
+    expect(statusCall).toBeTruthy();
+    expect(statusCall?.[1]).toMatchObject({
+      teamSlugOrId,
+      id: taskRunId,
+      status: "stopped",
+      sessionStatus: "terminated",
+    });
+
+    terminateSpy.mockRestore();
+  });
+
+  it("removes warm sessions that exceed retention window", async () => {
+    const removeVolume = vi.fn().mockResolvedValue(undefined);
+    const dockerStub = {
+      getContainer: () => ({
+        stop: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(undefined),
+      }),
+      getVolume: vi.fn(() => ({ remove: removeVolume })),
+    };
+
+    const dockerLifeSpy = vi
+      .spyOn(DockerVSCodeInstance, "getDocker")
+      .mockReturnValue(
+        dockerStub as unknown as ReturnType<typeof DockerVSCodeInstance.getDocker>
+      );
+
+    const now = Date.now();
+    containerMappings.set(`cmux-${taskRunId}`, {
+      containerName: `cmux-${taskRunId}`,
+      instanceId: taskRunId,
+      teamSlugOrId,
+      authToken: "token",
+      ports: { vscode: "", worker: "" },
+      status: "warm",
+      volumes: {
+        workspace: "cmux_session_test-run_workspace",
+        vscode: "cmux_session_test-run_vscode",
+      },
+      lastActivityAt: now - 120_000,
+      idleTimeoutMs: 60_000,
+      warmExpiresAt: now - 1,
+      sessionStatus: "warm",
+      warmRetentionMs: 60_000,
+    });
+
+    queryMock.mockResolvedValue({
+      _id: taskRunId,
+      taskId,
+      worktreePath: "/tmp/mock-workspace",
+      vscode: {
+        provider: "docker",
+        status: "stopped",
+        volumes: {
+          workspace: "cmux_session_test-run_workspace",
+          vscode: "cmux_session_test-run_vscode",
+        },
+        containerName: `cmux-${taskRunId}`,
+      },
+    });
+
+    await runWithAuth("token", undefined, async () => {
+      await (DockerVSCodeInstance as any).runLifecycleSweep();
+    });
+
+    expect(removeVolume).toHaveBeenCalledTimes(2);
+    expect(containerMappings.has(`cmux-${taskRunId}`)).toBe(false);
+
+    dockerLifeSpy.mockRestore();
+  });
+});

--- a/apps/server/src/vscode/VSCodeInstance.ts
+++ b/apps/server/src/vscode/VSCodeInstance.ts
@@ -18,6 +18,14 @@ export interface VSCodeInstanceConfig {
   newBranch?: string;
   // Optional: when starting from an environment
   environmentId?: Id<"environments"> | string;
+  sessionVolumes?: {
+    workspace: string;
+    vscode: string;
+  };
+  resume?: boolean;
+  lastActivityAt?: number;
+  idleTimeoutMinutes?: number;
+  warmRetentionMinutes?: number;
 }
 
 export interface VSCodeInstanceInfo {
@@ -248,5 +256,11 @@ export abstract class VSCodeInstance extends EventEmitter {
     this.stopFileWatch();
     await this.disconnectFromWorker();
     VSCodeInstance.instances.delete(this.instanceId);
+  }
+
+  // Optional activity hook overridden by subclasses
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  recordActivity(_timestamp: number): void {
+    // no-op by default
   }
 }

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -201,6 +201,22 @@ const convexSchema = defineSchema({
         lastAccessedAt: v.optional(v.number()), // Track when user last accessed the container
         keepAlive: v.optional(v.boolean()), // User requested to keep container running
         scheduledStopAt: v.optional(v.number()), // When container is scheduled to stop
+        containerId: v.optional(v.string()),
+        sessionStatus: v.optional(
+          v.union(
+            v.literal("active"),
+            v.literal("warm"),
+            v.literal("terminated")
+          )
+        ),
+        volumes: v.optional(
+          v.object({
+            workspace: v.string(),
+            vscode: v.string(),
+          })
+        ),
+        lastActivityAt: v.optional(v.number()),
+        warmExpiresAt: v.optional(v.number()),
       })
     ),
     networking: v.optional(


### PR DESCRIPTION
Your goal is to accomplish this task. Right now, VSCode instances on local (Docker) die after they timeout ~30 min of inactivity. We want to create the opportunity for our users to resume these VSCode instances. You will do this by following these implementation details. Implementation Outline

  - Name per-session Docker volumes (e.g. cmux_session_<id>_workspace and
  cmux_session_<id>_vscode) and create them when a run is provisioned; mount
  them at /workspace (or whatever cmux uses) and /home/.openvscode-server in
  the worker container. On resume, reattach the same volume names when you
  docker run the replacement container.
  - Extend the run/session metadata we store (Convex table or whatever
  persistence layer you use) to include: volume names, last activity timestamp,
  container ID (if live), and run status (active, warm, terminated). That lets
  the orchestrator decide whether to reuse a warm container or create a fresh
  one.
  - Update the orchestrator code that currently starts workers so it:
      1. Checks for an existing entry with reusable volumes.
      2. Calls docker create/run with --mount source=<volume>,target=<path> for
  both the project workspace and openvscode data.
      3. Passes the usual env vars/startup command, but skips any path
  initialization that would wipe the mounted volumes.
  - Add a bootstrap script (entrypoint or first-run hook) inside the worker
  image that detects “first run” vs “resume”. On new runs it should clone/
  fetch tasks, configure git diff UI, and start the dev server/terminals; on
  resume it should just launch supervisord/PM2/openvscode without resetting
  the workspace so persisted state (terminal history, settings, opened editors)
  comes back.
  - Ensure openvscode is configured to restore sessions from its data
  directory; verify its argv.json/settings.json live inside the mounted data
  volume so it repopulates the previous layout automatically.
  - Implement lifecycle management: background job scans for runs whose last
  activity exceeds your TTL, stops their containers, and removes their volumes.
  Provide an explicit “Terminate” action that does the same immediately.
  - Expose a resumeRun API endpoint that looks up run metadata, decides whether
  to unpause an existing container (if still active) or start a new one with
  the stored volumes, and updates the run status accordingly.
  - Update automated tests/integration harness to cover: fresh run bootstraps
  correctly, resume reuses volumes (e.g., create a file, terminate container,
  resume and confirm file exists), TTL cleanup removes volumes, and manual
  termination does the same.

  That delivers the simple, reliable recreate-with-volumes flow while keeping
  cmux’s orchestration logic clear and easy to maintain.