### PR TITLE
feat(docker): wait for Docker daemon to become available

### DIFF
--- a/packages/cmux/src/cli.ts
+++ b/packages/cmux/src/cli.ts
@@ -89,7 +89,17 @@ program
   )
   .action(async (repoPath, options) => {
     // Ensure Docker is installed and the daemon is running before proceeding
-    const dockerStatus = checkDockerStatus();
+    let announcedDockerWait = false;
+    const dockerStatus = await checkDockerStatus({
+      onRetry: (attempt) => {
+        if (!announcedDockerWait && attempt === 1) {
+          console.log(
+            "\x1b[33m…\x1b[0m Waiting for Docker to become available before continuing"
+          );
+          announcedDockerWait = true;
+        }
+      },
+    });
     if (dockerStatus !== "ok") {
       const isMac = process.platform === "darwin";
       if (dockerStatus === "not_installed") {

--- a/packages/cmux/src/utils/checkDocker.ts
+++ b/packages/cmux/src/utils/checkDocker.ts
@@ -2,33 +2,82 @@ import { spawnSync } from "node:child_process";
 
 export type DockerStatus = "ok" | "not_installed" | "not_running";
 
-export function checkDockerStatus(): DockerStatus {
+type CheckDockerOptions = {
+  maxWaitMs?: number;
+  retryDelayMs?: number;
+  infoTimeoutMs?: number;
+  versionTimeoutMs?: number;
+  onRetry?: (attempt: number, error: NodeJS.ErrnoException | null) => void;
+};
+
+const DEFAULT_OPTIONS: Required<Omit<CheckDockerOptions, "onRetry">> = {
+  maxWaitMs: 12_000,
+  retryDelayMs: 1_000,
+  infoTimeoutMs: 5_000,
+  versionTimeoutMs: 5_000,
+};
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function ensureDockerInstalled(versionTimeoutMs: number): DockerStatus | null {
   try {
     const version = spawnSync("docker", ["--version"], {
       stdio: "ignore",
-      timeout: 1500,
+      timeout: versionTimeoutMs,
     });
-    if (version.error) {
-      return "not_installed";
-    }
-    if (version.status !== 0) {
+
+    if (version.error || version.status !== 0) {
       return "not_installed";
     }
   } catch {
     return "not_installed";
   }
 
-  try {
-    const info = spawnSync("docker", ["info"], {
-      stdio: "ignore",
-      timeout: 3000,
-    });
-    if (info.status === 0) {
-      return "ok";
-    }
-    return "not_running";
-  } catch {
-    return "not_running";
-  }
+  return null;
 }
 
+export async function checkDockerStatus(
+  options: CheckDockerOptions = {}
+): Promise<DockerStatus> {
+  const {
+    maxWaitMs,
+    retryDelayMs,
+    infoTimeoutMs,
+    versionTimeoutMs,
+  } = { ...DEFAULT_OPTIONS, ...options };
+
+  const installedStatus = ensureDockerInstalled(versionTimeoutMs);
+  if (installedStatus) {
+    return installedStatus;
+  }
+
+  const start = Date.now();
+  let attempt = 0;
+
+  while (true) {
+    const info = spawnSync("docker", ["info"], {
+      stdio: "ignore",
+      timeout: infoTimeoutMs,
+    });
+
+    if (!info.error && info.status === 0) {
+      return "ok";
+    }
+
+    if (info.error && (info.error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "not_installed";
+    }
+
+    const elapsed = Date.now() - start;
+    if (elapsed >= maxWaitMs) {
+      return "not_running";
+    }
+
+    attempt += 1;
+    options.onRetry?.(attempt, info.error as NodeJS.ErrnoException | null);
+
+    const remaining = Math.max(0, maxWaitMs - elapsed);
+    await sleep(Math.min(retryDelayMs, remaining));
+  }
+}


### PR DESCRIPTION
- `checkDockerStatus` now retries checking daemon status for a duration
- Add `onRetry` callback to `checkDockerStatus` for progress feedback
- Update CLI to display a message when waiting for Docker
- Convert `checkDockerStatus` to an async function