### PR TITLE
feat(tasks): infer repository from environment

### DIFF
--- a/apps/client/src/components/task-detail-header.tsx
+++ b/apps/client/src/components/task-detail-header.tsx
@@ -421,8 +421,20 @@ function SocketActions({
   ref2: string;
 }) {
   const { socket } = useSocketSuspense();
+
+  // For environments, get repos from selectedRun.environment.selectedRepos
+  const environmentRepos = useMemo(() => {
+    const repos = selectedRun?.environment?.selectedRepos ?? [];
+    const trimmed = repos
+      .map((repo) => repo?.trim())
+      .filter((repo): repo is string => Boolean(repo));
+    return Array.from(new Set(trimmed));
+  }, [selectedRun?.environment?.selectedRepos]);
+
+  const primaryRepo = repoFullName || environmentRepos[0] || "";
+
   const diffsQuery = useRQ(
-    diffSmartQueryOptions({ repoFullName, baseRef: ref1, headRef: ref2 })
+    primaryRepo ? diffSmartQueryOptions({ repoFullName: primaryRepo, baseRef: ref1, headRef: ref2 }) : { queryKey: ["diff-smart-disabled"], queryFn: async () => [] }
   );
   const hasChanges = (diffsQuery.data || []).length > 0;
 

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -1514,6 +1514,20 @@ Please address the issue mentioned in the comment above.`;
         const { run, task, worktreePath, branchName, baseBranch } =
           await ensureRunWorktreeAndBranch(taskRunId, safeTeam);
 
+        // Get repo for PR creation
+        let repoFullName = task.projectFullName;
+        if (!repoFullName && task.environmentId) {
+          const environment = await getConvex().query(api.environments.get, {
+            teamSlugOrId: safeTeam,
+            id: task.environmentId,
+          });
+          repoFullName = environment?.selectedRepos?.[0] || null;
+        }
+        if (!repoFullName) {
+          callback({ success: false, error: "No repository found for PR creation" });
+          return;
+        }
+
         // Get GitHub token from keychain/Convex
         const githubToken = await getGitHubTokenFromKeychain();
         if (!githubToken) {
@@ -1742,6 +1756,20 @@ Please address the issue mentioned in the comment above.`;
         const { run, task, worktreePath, branchName, baseBranch } =
           await ensureRunWorktreeAndBranch(taskRunId, safeTeam);
 
+        // Get repo for PR creation
+        let repoFullName = task.projectFullName;
+        if (!repoFullName && task.environmentId) {
+          const environment = await getConvex().query(api.environments.get, {
+            teamSlugOrId: safeTeam,
+            id: task.environmentId,
+          });
+          repoFullName = environment?.selectedRepos?.[0] || null;
+        }
+        if (!repoFullName) {
+          callback({ success: false, error: "No repository found for PR creation" });
+          return;
+        }
+
         const githubToken = await getGitHubTokenFromKeychain();
         if (!githubToken) {
           callback({ success: false, error: "GitHub token is not configured" });
@@ -1755,7 +1783,7 @@ Please address the issue mentioned in the comment above.`;
         const body = task.text || `## Summary\n\n${title}`;
 
         const cwd = worktreePath;
-        const repoFullNameOpen = task.projectFullName || ""; // e.g. owner/name
+        const repoFullNameOpen = repoFullName; // e.g. owner/name
         const [owner, repo] = repoFullNameOpen.split("/");
 
         // Stage/commit/push branch, similar to draft flow, but tolerant to no-op


### PR DESCRIPTION
- Derive primary repository from task's environment if `projectFullName` is unset
- Apply environment-derived repo for diff fetching in the client
- Use environment-derived repo for PR creation in the server
- Utilize environment-derived repo for worktree setup in the server