### PR TITLE
Increase GitHub authentication retries to reduce task start error

### DIFF
--- a/apps/www/lib/routes/sandboxes/git.ts
+++ b/apps/www/lib/routes/sandboxes/git.ts
@@ -34,7 +34,7 @@ export const configureGitIdentity = async (
 export const configureGithubAccess = async (
   instance: MorphInstance,
   token: string,
-  maxRetries = 3
+  maxRetries = 5
 ) => {
   let lastError: Error | undefined;
 


### PR DESCRIPTION
Task start error: "Error: Error invoking remote method 'cmux:rpc': [object Object]" we want to reduce this error, i think this happens because github authentication requires us to retry more than 3 times, try 5 times...