### PR TITLE
Hide lockfiles from git diff viewer

### DIFF
--- a/apps/client/src/queries/git-diff.ts
+++ b/apps/client/src/queries/git-diff.ts
@@ -1,6 +1,6 @@
 import { waitForConnectedSocket } from "@/contexts/socket/socket-boot";
 import { normalizeGitRef } from "@/lib/refWithOrigin";
-import type { ReplaceDiffEntry } from "@cmux/shared";
+import { isLockfileDiffEntry, type ReplaceDiffEntry } from "@cmux/shared";
 import { queryOptions } from "@tanstack/react-query";
 
 export interface GitDiffQuery {
@@ -65,7 +65,10 @@ export function gitDiffQueryOptions({
               | { ok: false; error: string; diffs?: [] }
           ) => {
             if (resp.ok) {
-              resolve(resp.diffs);
+              const filteredDiffs = resp.diffs.filter(
+                (entry) => !isLockfileDiffEntry(entry),
+              );
+              resolve(filteredDiffs);
             } else {
               reject(
                 new Error(resp.error || "Failed to load repository diffs")

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./socket-schemas";
 export * from "./terminal-config";
 export * from "./utils/normalize-origin";
 export * from "./utils/reserved-cmux-ports";
+export * from "./utils/is-lockfile-path";
 export * from "./utils/validate-exposed-ports";
 export * from "./vscode-schemas";
 export * from "./worker-schemas";

--- a/packages/shared/src/utils/is-lockfile-path.test.ts
+++ b/packages/shared/src/utils/is-lockfile-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { ReplaceDiffEntry } from "../diff-types";
+import {
+  isLockfileDiffEntry,
+  isLockfilePath,
+} from "./is-lockfile-path";
+
+describe("isLockfilePath", () => {
+  it("detects common lockfile basenames", () => {
+    expect(isLockfilePath("pnpm-lock.yaml")).toBe(true);
+    expect(isLockfilePath("apps/web/yarn.lock")).toBe(true);
+    expect(isLockfilePath("Repo:package-lock.json")).toBe(true);
+    expect(isLockfilePath("packages/api/Pipfile.lock")).toBe(true);
+    expect(isLockfilePath("apps/mobile\\Gemfile.lock")).toBe(true);
+    expect(isLockfilePath("C:/tmp/cargo.lock")).toBe(true);
+  });
+
+  it("returns false for non-lockfiles", () => {
+    expect(isLockfilePath("src/index.ts")).toBe(false);
+    expect(isLockfilePath("docs/requirements.txt")).toBe(false);
+    expect(isLockfilePath("")).toBe(false);
+    expect(isLockfilePath(undefined)).toBe(false);
+  });
+});
+
+describe("isLockfileDiffEntry", () => {
+  it("matches lockfiles on either side of the diff", () => {
+    const entry: ReplaceDiffEntry = {
+      filePath: "apps/web/yarn.lock",
+      status: "modified",
+      additions: 10,
+      deletions: 4,
+      isBinary: false,
+    };
+    expect(isLockfileDiffEntry(entry)).toBe(true);
+
+    const rename: ReplaceDiffEntry = {
+      filePath: "docs/README.md",
+      oldPath: "docs/yarn.lock",
+      status: "renamed",
+      additions: 0,
+      deletions: 0,
+      isBinary: false,
+    };
+    expect(isLockfileDiffEntry(rename)).toBe(true);
+  });
+
+  it("returns false for regular files", () => {
+    const entry: ReplaceDiffEntry = {
+      filePath: "src/components/Button.tsx",
+      status: "modified",
+      additions: 5,
+      deletions: 2,
+      isBinary: false,
+    };
+    expect(isLockfileDiffEntry(entry)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/is-lockfile-path.ts
+++ b/packages/shared/src/utils/is-lockfile-path.ts
@@ -1,0 +1,45 @@
+import type { ReplaceDiffEntry } from "../diff-types";
+
+const LOCKFILE_BASENAMES = new Set([
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "package-lock.json",
+  "pipfile.lock",
+  "poetry.lock",
+  "gemfile.lock",
+  "composer.lock",
+  "cargo.lock",
+  "bun.lock",
+  "bun.lockb",
+  "uv.lock",
+]);
+
+function stripRepoPrefix(rawPath: string): string {
+  const normalized = rawPath.replace(/\\/g, "/");
+  const colonIndex = normalized.indexOf(":");
+  if (colonIndex > -1 && colonIndex < normalized.length - 1) {
+    const prefix = normalized.slice(0, colonIndex);
+    if (!prefix.includes("/") && !prefix.includes("\\")) {
+      return normalized.slice(colonIndex + 1);
+    }
+  }
+  return normalized;
+}
+
+export function isLockfilePath(path: string | undefined | null): boolean {
+  if (!path) {
+    return false;
+  }
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const withoutPrefix = stripRepoPrefix(trimmed);
+  const segments = withoutPrefix.split("/").filter(Boolean);
+  const basename = segments.at(-1)?.toLowerCase() ?? "";
+  return LOCKFILE_BASENAMES.has(basename);
+}
+
+export function isLockfileDiffEntry(entry: ReplaceDiffEntry): boolean {
+  return isLockfilePath(entry.filePath) || isLockfilePath(entry.oldPath);
+}


### PR DESCRIPTION
Currently we don't hide lockfiles in the git diff viewer... we need to do this as well