### PR TITLE
Relax worker agent model validation in worker service

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1025,15 +1025,15 @@ async function createTerminal(
   const stopErrorCaptureAt = Date.now() + INITIAL_ERROR_CAPTURE_WINDOW_MS;
 
   // Config-driven completion detector
-  const agentConfig = AGENT_CONFIGS.find((c) => c.name === options.agentModel);
+  const agentConfig = options.agentModel
+    ? AGENT_CONFIGS.find((c) => c.name === options.agentModel)
+    : undefined;
 
-  // if missing need to return early
-  if (!agentConfig) {
-    log("ERROR", `Agent config not found for ${options.agentModel}`, {
+  if (!agentConfig && options.agentModel) {
+    log("WARN", `Agent config not found for ${options.agentModel}`, {
       agentModel: options.agentModel,
       availableConfigs: AGENT_CONFIGS.map((c) => c.name),
     });
-    return;
   }
 
   if (options.taskRunId && agentConfig?.completionDetector) {

--- a/packages/shared/src/worker-schemas.ts
+++ b/packages/shared/src/worker-schemas.ts
@@ -1,6 +1,5 @@
 import type { Id } from "@cmux/convex/dataModel";
 import { z } from "zod";
-import { AGENT_CONFIGS } from "./agentConfig";
 import { typedZid } from "./utils/typed-zid";
 
 // Auth file schema for file uploads and environment setup
@@ -63,14 +62,9 @@ export const WorkerCreateTerminalSchema = z.object({
   args: z.array(z.string()).optional(),
   taskId: typedZid("tasks").optional(),
   taskRunId: typedZid("taskRuns").optional(),
-  // Preferred: validated against AgentConfig names at runtime (browser-safe)
-  agentModel: z
-    .string()
-    .optional()
-    .refine(
-      (val) => !val || new Set(AGENT_CONFIGS.map((c) => c.name)).has(val),
-      { message: "agentModel must be one of AGENT_CONFIGS names" }
-    ),
+  // Validation happens on the server where configs can be updated without
+  // rebuilding the worker image.
+  agentModel: z.string().optional(),
   authFiles: z.array(AuthFileSchema).optional(),
   startupCommands: z.array(z.string()).optional(),
 });
@@ -125,13 +119,7 @@ export const WorkerTerminalIdleSchema = z.object({
 export const WorkerTaskCompleteSchema = z.object({
   workerId: z.string(),
   taskRunId: typedZid("taskRuns"),
-  agentModel: z
-    .string()
-    .optional()
-    .refine(
-      (val) => !val || new Set(AGENT_CONFIGS.map((c) => c.name)).has(val),
-      { message: "agentModel must be one of AGENT_CONFIGS names" }
-    ),
+  agentModel: z.string().optional(),
   elapsedMs: z.number(),
 });
 


### PR DESCRIPTION
## Summary
- remove worker-side agent model validation from shared worker schemas so the image does not need rebuilding for new models
- allow the worker to continue spawning terminals even when a matching agent config is missing, while logging a warning for visibility

## Testing
- `bun run check`


------
https://chatgpt.com/codex/tasks/task_e_68dc73d03bac8333ab22530c33fabeee