### PR TITLE
Implement GitHub repository synchronization via webhooks for new users

### DIFF
--- a/packages/convex/_shared/github.ts
+++ b/packages/convex/_shared/github.ts
@@ -1,0 +1,110 @@
+const MILLIS_THRESHOLD = 1_000_000_000_000;
+
+export function normalizeTimestamp(
+  value: number | string | null | undefined
+): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return undefined;
+    const normalized = value > MILLIS_THRESHOLD ? value : value * 1000;
+    return Math.round(normalized);
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    const normalized = numeric > MILLIS_THRESHOLD ? numeric : numeric * 1000;
+    return Math.round(normalized);
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+  return undefined;
+}
+
+export type GitHubRepository = {
+  id?: number;
+  full_name?: string;
+  name?: string;
+  owner?: {
+    login?: string | null;
+    type?: string | null;
+  } | null;
+  clone_url?: string | null;
+  default_branch?: string | null;
+  visibility?: string | null;
+  private?: boolean | null;
+  pushed_at?: string | number | null;
+};
+
+export type TransformedRepo = {
+  providerRepoId: number;
+  fullName: string;
+  org: string;
+  name: string;
+  gitRemote: string;
+  ownerLogin: string;
+  ownerType?: "User" | "Organization";
+  visibility?: "public" | "private";
+  defaultBranch?: string;
+  lastPushedAt?: number;
+};
+
+export function transformGitHubRepo(
+  repo: GitHubRepository
+): TransformedRepo | null {
+  const providerRepoId = typeof repo.id === "number" ? repo.id : undefined;
+  const fullName =
+    typeof repo.full_name === "string" && repo.full_name
+      ? repo.full_name
+      : undefined;
+  if (!providerRepoId || !fullName) {
+    return null;
+  }
+  const name =
+    typeof repo.name === "string" && repo.name
+      ? repo.name
+      : fullName.split("/")[1] ?? fullName;
+  const ownerLogin =
+    typeof repo.owner?.login === "string" && repo.owner.login
+      ? repo.owner.login
+      : fullName.split("/")[0] ?? "";
+  if (!ownerLogin) {
+    return null;
+  }
+  const ownerTypeRaw = repo.owner?.type ?? undefined;
+  const ownerType =
+    ownerTypeRaw === "Organization"
+      ? "Organization"
+      : ownerTypeRaw === "User"
+      ? "User"
+      : undefined;
+  const visibility =
+    repo.visibility === "public"
+      ? "public"
+      : repo.visibility === "private" || repo.private
+      ? "private"
+      : undefined;
+  const defaultBranch =
+    typeof repo.default_branch === "string" && repo.default_branch
+      ? repo.default_branch
+      : undefined;
+  const gitRemote =
+    typeof repo.clone_url === "string" && repo.clone_url
+      ? repo.clone_url
+      : `https://github.com/${fullName}.git`;
+
+  const lastPushedAt = normalizeTimestamp(repo.pushed_at);
+
+  return {
+    providerRepoId,
+    fullName,
+    org: ownerLogin,
+    name,
+    gitRemote,
+    ownerLogin,
+    ...(ownerType !== undefined && { ownerType }),
+    ...(visibility !== undefined && { visibility }),
+    ...(defaultBranch !== undefined && { defaultBranch }),
+    ...(lastPushedAt !== undefined && { lastPushedAt }),
+  };
+}

--- a/packages/convex/_shared/githubApp.ts
+++ b/packages/convex/_shared/githubApp.ts
@@ -1,0 +1,139 @@
+import { base64urlFromBytes, base64urlToBytes } from "./encoding";
+
+const textEncoder = new TextEncoder();
+const privateKeyCache = new Map<string, CryptoKey>();
+
+export function normalizeGithubPrivateKey(pem: string): string {
+  return pem.replace(/\\n/g, "\n");
+}
+
+function pemToDer(pem: string): Uint8Array {
+  const cleaned = pem
+    .replace(/-----BEGIN [A-Z ]+-----/g, "")
+    .replace(/-----END [A-Z ]+-----/g, "")
+    .replace(/\s+/g, "");
+  const base64Url = cleaned
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  return base64urlToBytes(base64Url);
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const cached = privateKeyCache.get(pem);
+  if (cached) return cached;
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error("SubtleCrypto is not available in this environment");
+  }
+  const der = pemToDer(pem);
+  const keyData =
+    der.byteOffset === 0 && der.byteLength === der.buffer.byteLength
+      ? der
+      : der.slice();
+  const key = await subtle.importKey(
+    "pkcs8",
+    keyData,
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+    },
+    false,
+    ["sign"]
+  );
+  privateKeyCache.set(pem, key);
+  return key;
+}
+
+function base64urlEncodeJson(value: unknown): string {
+  return base64urlFromBytes(textEncoder.encode(JSON.stringify(value)));
+}
+
+export async function createGithubAppJwt({
+  appId,
+  privateKey,
+  now,
+}: {
+  appId: string;
+  privateKey: string;
+  now?: number;
+}): Promise<string> {
+  const seconds = Math.floor((now ?? Date.now()) / 1000);
+  const header = { alg: "RS256", typ: "JWT" } as const;
+  const payload = {
+    iat: seconds - 60,
+    exp: seconds + 600,
+    iss: appId,
+  } as const;
+  const signingInput = `${base64urlEncodeJson(header)}.${base64urlEncodeJson(
+    payload
+  )}`;
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error("SubtleCrypto is not available in this environment");
+  }
+  const key = await importPrivateKey(privateKey);
+  const signature = await subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    textEncoder.encode(signingInput)
+  );
+  const signaturePart = base64urlFromBytes(new Uint8Array(signature));
+  return `${signingInput}.${signaturePart}`;
+}
+
+export async function generateInstallationAccessToken({
+  installationId,
+  appId,
+  privateKey,
+  userAgent = "cmux-github-webhook",
+}: {
+  installationId: number;
+  appId: string;
+  privateKey: string;
+  userAgent?: string;
+}): Promise<{ token: string; expiresAt?: string } | null> {
+  if (!appId || !privateKey) {
+    return null;
+  }
+  try {
+    const jwt = await createGithubAppJwt({
+      appId,
+      privateKey,
+    });
+    const response = await fetch(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": userAgent,
+        },
+      }
+    );
+    if (!response.ok) {
+      console.error(
+        `[githubApp] Failed to mint installation token ${installationId} (status ${response.status})`
+      );
+      return null;
+    }
+    const data = (await response.json()) as {
+      token?: string;
+      expires_at?: string;
+    };
+    if (!data.token) {
+      console.error(
+        `[githubApp] No token returned for installation ${installationId}`
+      );
+      return null;
+    }
+    return { token: data.token, expiresAt: data.expires_at };
+  } catch (error) {
+    console.error(
+      `[githubApp] Unexpected error generating installation token ${installationId}`,
+      error
+    );
+    return null;
+  }
+}

--- a/packages/convex/convex/github.ts
+++ b/packages/convex/convex/github.ts
@@ -500,7 +500,7 @@ export const ingestInstallationRepoPage = internalMutation({
         org: v.string(),
         name: v.string(),
         gitRemote: v.string(),
-        ownerLogin: v.optional(v.string()),
+        ownerLogin: v.string(),
         ownerType: v.optional(
           v.union(v.literal("User"), v.literal("Organization"))
         ),

--- a/packages/convex/convex/github_setup.ts
+++ b/packages/convex/convex/github_setup.ts
@@ -5,6 +5,10 @@ import {
   bytesToHex,
 } from "../_shared/encoding";
 import { hmacSha256, safeEqualHex } from "../_shared/crypto";
+import {
+  createGithubAppJwt,
+  normalizeGithubPrivateKey,
+} from "../_shared/githubApp";
 import { internal } from "./_generated/api";
 import { httpAction } from "./_generated/server";
 
@@ -13,79 +17,6 @@ type InstallationAccountInfo = {
   accountId?: number;
   accountType?: "Organization" | "User";
 };
-
-const textEncoder = new TextEncoder();
-const privateKeyCache = new Map<string, CryptoKey>();
-
-function pemToDer(pem: string): Uint8Array {
-  const cleaned = pem
-    .replace(/-----BEGIN [A-Z ]+-----/g, "")
-    .replace(/-----END [A-Z ]+-----/g, "")
-    .replace(/\s+/g, "");
-  const base64Url = cleaned
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-  return base64urlToBytes(base64Url);
-}
-
-function base64urlEncodeJson(value: unknown): string {
-  return base64urlFromBytes(textEncoder.encode(JSON.stringify(value)));
-}
-
-async function importPrivateKey(pem: string): Promise<CryptoKey> {
-  const cached = privateKeyCache.get(pem);
-  if (cached) return cached;
-  const subtle = globalThis.crypto?.subtle;
-  if (!subtle) {
-    throw new Error("SubtleCrypto is not available in this environment");
-  }
-  const der = pemToDer(pem);
-  const keyData =
-    der.byteOffset === 0 && der.byteLength === der.buffer.byteLength
-      ? der
-      : der.slice();
-  const key = await subtle.importKey(
-    "pkcs8",
-    keyData,
-    {
-      name: "RSASSA-PKCS1-v1_5",
-      hash: "SHA-256",
-    },
-    false,
-    ["sign"]
-  );
-  privateKeyCache.set(pem, key);
-  return key;
-}
-
-async function createGithubAppJwt(
-  appId: string,
-  privateKey: string
-): Promise<string> {
-  const now = Math.floor(Date.now() / 1000);
-  const header = { alg: "RS256", typ: "JWT" } as const;
-  const payload = {
-    iat: now - 60,
-    exp: now + 600,
-    iss: appId,
-  } as const;
-  const signingInput = `${base64urlEncodeJson(header)}.${base64urlEncodeJson(
-    payload
-  )}`;
-  const subtle = globalThis.crypto?.subtle;
-  if (!subtle) {
-    throw new Error("SubtleCrypto is not available in this environment");
-  }
-  const key = await importPrivateKey(privateKey);
-  const signature = await subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    key,
-    textEncoder.encode(signingInput)
-  );
-  const signaturePart = base64urlFromBytes(new Uint8Array(signature));
-  return `${signingInput}.${signaturePart}`;
-}
 
 function normalizeAccountType(
   input: unknown
@@ -105,8 +36,11 @@ async function fetchInstallationAccountInfo(
   }
 
   try {
-    const normalizedPrivateKey = privateKey.replace(/\\n/g, "\n");
-    const jwt = await createGithubAppJwt(appId, normalizedPrivateKey);
+    const normalizedPrivateKey = normalizeGithubPrivateKey(privateKey);
+    const jwt = await createGithubAppJwt({
+      appId,
+      privateKey: normalizedPrivateKey,
+    });
     const response = await fetch(
       `https://api.github.com/app/installations/${installationId}`,
       {

--- a/packages/convex/convex/github_setup.ts
+++ b/packages/convex/convex/github_setup.ts
@@ -227,6 +227,10 @@ export const githubSetup = httpAction(async (ctx, req) => {
     }
   );
 
+  await ctx.runAction(internal.github.syncAllReposForInstallation, {
+    installationId,
+  });
+
   // Resolve slug for nicer redirect when available
   const team = await ctx.runQuery(internal.teams.getByTeamIdInternal, {
     teamId: payload.teamId,

--- a/packages/convex/convex/github_webhook.ts
+++ b/packages/convex/convex/github_webhook.ts
@@ -276,7 +276,6 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
                   account.type === "Organization" ? "Organization" : "User",
               }
             );
-            await ingestAllReposForInstallation(_ctx, installationId);
           }
         } else if (action === "deleted") {
           if (installationId !== undefined) {

--- a/packages/convex/convex/github_webhook.ts
+++ b/packages/convex/convex/github_webhook.ts
@@ -167,13 +167,13 @@ async function ingestAllReposForInstallation(
           name,
           gitRemote,
           ownerLogin: ownerLoginRaw,
-          ownerType,
-          visibility,
-          defaultBranch,
-          lastPushedAt,
-        } satisfies RepoIngestionPayload;
+          ...(ownerType !== undefined && { ownerType }),
+          ...(visibility !== undefined && { visibility }),
+          ...(defaultBranch !== undefined && { defaultBranch }),
+          ...(lastPushedAt !== undefined && { lastPushedAt }),
+        };
       })
-      .filter((row): row is RepoIngestionPayload => row !== null);
+      .filter((row) => row !== null);
 
     if (toIngest.length > 0) {
       await _ctx.scheduler.runAfter(
@@ -213,19 +213,6 @@ type InstallationRepositoriesListResponse = {
     private?: boolean | null;
     pushed_at?: string | number | null;
   }>;
-};
-
-type RepoIngestionPayload = {
-  providerRepoId: number;
-  fullName: string;
-  org: string;
-  name: string;
-  gitRemote: string;
-  ownerLogin: string;
-  ownerType: "User" | "Organization" | undefined;
-  visibility: "public" | "private" | undefined;
-  defaultBranch: string | undefined;
-  lastPushedAt: number | undefined;
 };
 
 export const githubWebhook = httpAction(async (_ctx, req) => {

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -238,8 +238,6 @@ export const getByTask = authQuery({
   },
 });
 
-const SYSTEM_BRANCH_USER_ID = "__system__";
-
 async function fetchBranchMetadataForRepo(
   ctx: QueryCtx,
   teamId: string,
@@ -252,9 +250,7 @@ async function fetchBranchMetadataForRepo(
     .filter((q) => q.eq(q.field("teamId"), teamId))
     .collect();
 
-  const relevant = rows.filter(
-    (row) => row.userId === userId || row.userId === SYSTEM_BRANCH_USER_ID,
-  );
+  const relevant = rows;
 
   const byName = new Map<string, Doc<"branches">>();
   for (const row of relevant) {


### PR DESCRIPTION
Currently, when user sets up their GitHub account for the first time, we do not sync in their repos into the repos table. We have a webhook setup for getting the github repositories. Handle webhook events so that we sync github repositories into the relevant table. We want to create a new webhook setup. When we get the webhook, we should call github's api and paginate; as we paginate, we should kick off insertion tasks in the background so we can kinda "stream" the repositories in. But don't let inserting into the db block the pagination.