### PR TITLE
Set tmux session name to cmux

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -312,9 +312,7 @@ export async function spawnAgent(
     const agentCommand = `${agent.command} ${processedArgs.join(" ")}`;
 
     // Build the tmux session command that will be sent via socket.io
-    const tmuxSessionName = sanitizeTmuxSessionName(
-      `${agent.name}-${taskRunId}`,
-    );
+    const tmuxSessionName = sanitizeTmuxSessionName("cmux");
 
     serverLogger.info(
       `[AgentSpawner] Building command for agent ${agent.name}:`,

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -312,7 +312,7 @@ async function setupDefaultTerminal() {
 
   // Attach to default tmux session with a small delay to ensure it's ready
   setTimeout(() => {
-    terminal.sendText(`tmux attach`);
+    terminal.sendText(`tmux attach-session -t cmux`);
     log("Attached to default tmux session");
   }, 500); // 500ms delay to ensure tmux session is ready
 


### PR DESCRIPTION
## Summary
- update the agent spawner to always create the tmux session with the fixed name `cmux`
- update the VS Code extension to attach the default terminal directly to the `cmux` tmux session

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68ddbf2d72b88333ae8f7d03ed696539