### PR TITLE
Prevent anchor dragging in Electron only

### DIFF
--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -518,3 +518,9 @@ pre,
 .diff-hidden-lines-widget {
   user-select: none;
 }
+
+/* Prevent anchor dragging in Electron only */
+.is-electron a {
+  -webkit-user-drag: none;
+  user-drag: none;
+}

--- a/apps/client/src/providers.tsx
+++ b/apps/client/src/providers.tsx
@@ -3,8 +3,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { HeroUIProvider } from "@heroui/react";
 import { StackProvider, StackTheme } from "@stackframe/react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { Component, type ErrorInfo, type ReactNode, Suspense } from "react";
+import { Component, type ErrorInfo, type ReactNode, Suspense, useEffect } from "react";
 import { AntdProvider } from "./components/antd-provider";
+import { isElectron } from "./lib/electron";
 import { stackClientApp } from "./lib/stack";
 import { queryClient } from "./query-client";
 
@@ -13,6 +14,12 @@ interface ProvidersProps {
 }
 
 export function Providers({ children }: ProvidersProps) {
+  useEffect(() => {
+    if (isElectron) {
+      document.documentElement.classList.add("is-electron");
+    }
+  }, []);
+
   return (
     <ThemeProvider>
       <StackTheme>


### PR DESCRIPTION
in electron, for all links (anchors), prevent dragging like the preview thing. it should only apply on electron.