### PR TITLE
Preserve agent frequency on task restart

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -68,17 +68,28 @@ function collectAgentNamesFromRuns(
 ): string[] {
   if (!runs) return [];
 
-  const seen = new Set<string>();
-  const ordered: string[] = [];
+  // Top-level runs mirror the user's original agent selection, including duplicates.
+  const rootAgents = runs
+    .map((run) => run.agentName?.trim())
+    .filter((name): name is string => {
+      if (!name) {
+        return false;
+      }
+      return AVAILABLE_AGENT_NAMES.has(name);
+    });
 
+  if (rootAgents.length > 0) {
+    return rootAgents;
+  }
+
+  const ordered: string[] = [];
   const traverse = (items: TaskRunWithChildren[]) => {
     for (const run of items) {
       const trimmed = run.agentName?.trim();
-      if (trimmed && AVAILABLE_AGENT_NAMES.has(trimmed) && !seen.has(trimmed)) {
-        seen.add(trimmed);
+      if (trimmed && AVAILABLE_AGENT_NAMES.has(trimmed)) {
         ordered.push(trimmed);
       }
-      if (run.children && run.children.length > 0) {
+      if (run.children.length > 0) {
         traverse(run.children);
       }
     }


### PR DESCRIPTION
currently restart task doesn't do the right number of agents. sometimes i start an agent with 2 codex-gpt-5-high agents but on my restart task, it will only restart it with 1 codex-gpt-5-high agent. we are missing the frequency of agents when we restart tasks.