### PR TITLE
Increase Morph sandbox TTL default to one hour

### DIFF
--- a/apps/server/src/vscode/CmuxVSCodeInstance.ts
+++ b/apps/server/src/vscode/CmuxVSCodeInstance.ts
@@ -49,7 +49,7 @@ export class CmuxVSCodeInstance extends VSCodeInstance {
       client: getWwwClient(),
       body: {
         teamSlugOrId: this.teamSlugOrId,
-        ttlSeconds: 20 * 60,
+        ttlSeconds: 60 * 60,
         metadata: {
           instance: `cmux-${this.taskRunId}`,
           agentName: this.config.agentName || "",

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -35,7 +35,7 @@ const StartSandboxBody = z
     ttlSeconds: z
       .number()
       .optional()
-      .default(20 * 60),
+      .default(60 * 60),
     metadata: z.record(z.string(), z.string()).optional(),
     taskRunId: z.string().optional(),
     taskRunJwt: z.string().optional(),
@@ -182,7 +182,7 @@ sandboxesRouter.openapi(
 
       const instance = await client.instances.start({
         snapshotId: resolvedSnapshotId,
-        ttlSeconds: body.ttlSeconds ?? 20 * 60,
+        ttlSeconds: body.ttlSeconds ?? 60 * 60,
         ttlAction: "pause",
         metadata: {
           app: "cmux",

--- a/scripts/debug-start-sandbox.ts
+++ b/scripts/debug-start-sandbox.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
         body: {
           teamSlugOrId: options.teamSlugOrId,
           environmentId: options.environmentId,
-          ttlSeconds: options.ttlSeconds ?? 20 * 60,
+          ttlSeconds: options.ttlSeconds ?? 60 * 60,
         },
       });
 


### PR DESCRIPTION
## Summary
- raise the default Morph sandbox lifetime from 20 minutes to 60 minutes in the API route and server launcher
- update the debug helper script to use the new one-hour default

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e163f5286483339396cc26f75e3611