### PR TITLE
Keep macOS window controls visible when unfocused

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -509,6 +509,18 @@ function createWindow(): void {
 
   mainWindow = new BrowserWindow(windowOptions);
 
+  if (process.platform === "darwin") {
+    const ensureTrafficLightsVisible = () => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.setWindowButtonVisibility(true);
+      }
+    };
+
+    ensureTrafficLightsVisible();
+    mainWindow.on("focus", ensureTrafficLightsVisible);
+    mainWindow.on("blur", ensureTrafficLightsVisible);
+  }
+
   // Capture renderer console output into renderer.log
   mainWindow.webContents.on(
     "console-message",


### PR DESCRIPTION
## Summary
- ensure the macOS BrowserWindow keeps its traffic lights visible by forcing window button visibility on focus and blur

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e17bafe62483338208ea1b4b37d649