### PR TITLE
Open snapshot version tooltip immediately

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx
@@ -933,7 +933,7 @@ function EnvironmentDetailsPage() {
                   <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
                     Snapshot Versions
                   </h3>
-                  <Tooltip>
+                  <Tooltip delayDuration={0}>
                     <TooltipTrigger asChild>
                       <button
                         type="button"


### PR DESCRIPTION
## Summary
- make the "New snapshot version" tooltip on the environment page open without delay by setting `delayDuration` to 0

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e1a3f21e6c83339e058eac9c211e81