### PR TITLE
Make RPC ack timeout errors actionable

### DIFF
--- a/apps/client/electron/main/embedded-server.ts
+++ b/apps/client/electron/main/embedded-server.ts
@@ -306,8 +306,8 @@ function createIPCRealtimeServer(): RealtimeServer {
         // Safety timeout so invoke doesn't hang forever if ack is never called
         const defaultTimeoutMs = 30_000;
         const timeoutOverrides: Record<string, number> = {
-          "start-task": 120_000,
-          "spawn-from-comment": 120_000,
+          "start-task": 300_000,
+          "spawn-from-comment": 300_000,
         };
         const timeoutMs = timeoutOverrides[eventName] ?? defaultTimeoutMs;
         const timer = setTimeout(() => {

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -308,8 +308,7 @@ export function setupSocketHandlers(
       serverLogger.info("starting task!", taskData);
       const taskId = taskData.taskId;
       let ackSent = false;
-      type StartTaskAck = Parameters<typeof callback>[0];
-      const sendAck = (payload: StartTaskAck) => {
+      const sendAck = (payload: Parameters<typeof callback>[0]) => {
         if (ackSent) {
           serverLogger.warn(
             `[Server] Duplicate start-task ack ignored for ${taskId}`,
@@ -1152,8 +1151,7 @@ export function setupSocketHandlers(
       let taskId: Id<"tasks"> | null = null;
       let primaryAgent: AgentSpawnResult | null = null;
 
-      type SpawnFromCommentAck = Parameters<typeof callback>[0];
-      const sendAck = (payload: SpawnFromCommentAck) => {
+      const sendAck = (payload: Parameters<typeof callback>[0]) => {
         if (ackSent) {
           const suffix = taskId ? ` for ${taskId}` : "";
           serverLogger.warn(


### PR DESCRIPTION
we need to fix this issue with "RPC 'start-task' timed out waiting for ack... figure out and debug the root cause of the issue until we can never see this error again. it seems that even after this error, the task still starts. maybe we just need to increase the timeout. dont use anything to supress the error, just make the error message actually useful and indicative of whats going on