### PR TITLE
Align empty sidebar messages with section headings

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -258,7 +258,7 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
                   />
                 ))
               ) : (
-                <p className="px-2 py-1.5 text-xs text-center text-neutral-500 dark:text-neutral-400 select-none">
+                <p className="pl-2 pr-3 py-1.5 text-xs text-neutral-500 dark:text-neutral-400 select-none">
                   No recent tasks
                 </p>
               )}

--- a/apps/client/src/components/sidebar/SidebarPullRequestList.tsx
+++ b/apps/client/src/components/sidebar/SidebarPullRequestList.tsx
@@ -47,7 +47,7 @@ export function SidebarPullRequestList({
 
   if (list.length === 0) {
     return (
-      <p className="mt-1 px-3 py-2 text-xs text-neutral-500 dark:text-neutral-400 select-none">
+      <p className="mt-1 pl-2 pr-3 py-2 text-xs text-neutral-500 dark:text-neutral-400 select-none">
         No pull requests
       </p>
     );


### PR DESCRIPTION
## Summary
- align the empty pull request state text with the section heading indent
- align the empty recent tasks state with the section heading and remove center alignment

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e354f03ebc83339e6277b408961556