### PR TITLE
wrap dev and maintenance scripts in tmux

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,7 @@
     }
   },
   "postCreateCommand": "CI=1 pnpm install --frozen-lockfile --prefer-offline",
-  "postStartCommand": "bash /root/workspace/scripts/dev.sh",
+  "postStartCommand": "bash /root/workspace/scripts/dev-tmux.sh",
   "remoteUser": "root",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},

--- a/scripts/dev-tmux.sh
+++ b/scripts/dev-tmux.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Session name
+SESSION_NAME="cmux-dev"
+
+# Check if tmux session already exists
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    echo "Tmux session '$SESSION_NAME' already exists. Attaching..."
+    exec tmux attach-session -t "$SESSION_NAME"
+fi
+
+# Create a new tmux session with dev.sh
+echo "Creating new tmux session '$SESSION_NAME' with dev and maintenance windows..."
+
+# Start tmux session with dev.sh in the first window
+tmux new-session -d -s "$SESSION_NAME" -n "dev" -c "$APP_DIR" "bash $SCRIPT_DIR/dev.sh"
+
+# Create a second window for maintenance.sh (not auto-running, just ready to use)
+tmux new-window -t "$SESSION_NAME" -n "maintenance" -c "$APP_DIR" "bash"
+
+# Send a message to the maintenance window with instructions
+tmux send-keys -t "$SESSION_NAME:maintenance" "# Run './scripts/maintenance.sh' to clean and rebuild" C-m
+tmux send-keys -t "$SESSION_NAME:maintenance" "# This window is ready for maintenance tasks" C-m
+
+# Select the dev window as the default
+tmux select-window -t "$SESSION_NAME:dev"
+
+# Attach to the session
+echo "Attaching to tmux session '$SESSION_NAME'..."
+exec tmux attach-session -t "$SESSION_NAME"

--- a/startup.sh
+++ b/startup.sh
@@ -85,26 +85,26 @@ start_devcontainer() {
             
             echo "[Startup] Devcontainer started successfully" >> /var/log/cmux/startup.log
             
-            # If devcontainer started successfully and dev.sh exists, run it
-            if [ -f "/root/workspace/scripts/dev.sh" ]; then
-                echo "[Startup] Running ./scripts/dev.sh in devcontainer..." >> /var/log/cmux/startup.log
-                
+            # If devcontainer started successfully and dev-tmux.sh exists, run it
+            if [ -f "/root/workspace/scripts/dev-tmux.sh" ]; then
+                echo "[Startup] Running ./scripts/dev-tmux.sh in devcontainer..." >> /var/log/cmux/startup.log
+
                 # Get the container name/id from the devcontainer CLI output
                 CONTAINER_ID=$(bunx @devcontainers/cli read-configuration --workspace-folder . 2>/dev/null | grep -o '"containerId":"[^"]*"' | cut -d'"' -f4)
-                
+
                 if [ -n "$CONTAINER_ID" ]; then
-                    # Execute dev.sh inside the devcontainer
-                    docker exec -d "$CONTAINER_ID" bash -c "cd /root/workspace && ./scripts/dev.sh" >> /var/log/cmux/devcontainer-dev.log 2>&1 || {
-                        echo "[Startup] Failed to run dev.sh in devcontainer (non-fatal)" >> /var/log/cmux/startup.log
+                    # Execute dev-tmux.sh inside the devcontainer
+                    docker exec -d "$CONTAINER_ID" bash -c "cd /root/workspace && ./scripts/dev-tmux.sh" >> /var/log/cmux/devcontainer-dev.log 2>&1 || {
+                        echo "[Startup] Failed to run dev-tmux.sh in devcontainer (non-fatal)" >> /var/log/cmux/startup.log
                     }
-                    echo "[Startup] Started dev.sh in devcontainer (logs at /var/log/cmux/devcontainer-dev.log)" >> /var/log/cmux/startup.log
+                    echo "[Startup] Started dev-tmux.sh in devcontainer (logs at /var/log/cmux/devcontainer-dev.log)" >> /var/log/cmux/startup.log
                 else
                     # Fallback: try to run it directly if we can't get container ID
-                    bunx @devcontainers/cli exec --workspace-folder . bash -c "./scripts/dev.sh" >> /var/log/cmux/devcontainer-dev.log 2>&1 &
-                    echo "[Startup] Attempted to run dev.sh via devcontainer CLI (logs at /var/log/cmux/devcontainer-dev.log)" >> /var/log/cmux/startup.log
+                    bunx @devcontainers/cli exec --workspace-folder . bash -c "./scripts/dev-tmux.sh" >> /var/log/cmux/devcontainer-dev.log 2>&1 &
+                    echo "[Startup] Attempted to run dev-tmux.sh via devcontainer CLI (logs at /var/log/cmux/devcontainer-dev.log)" >> /var/log/cmux/startup.log
                 fi
             else
-                echo "[Startup] No scripts/dev.sh found in workspace, skipping dev script" >> /var/log/cmux/startup.log
+                echo "[Startup] No scripts/dev-tmux.sh found in workspace, skipping dev script" >> /var/log/cmux/startup.log
             fi
         ) &
         


### PR DESCRIPTION
currently we have our dev and maintenance scripts inside worker and we run them after some logic. we actually want a different approach in which we start them automatically with tmux. like it should be wrapped in the same tmux attach... we should be running both. basically add dev + maintenance scripts in tmux.