### PR TITLE
Ack rpc start-task immediately

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -493,6 +493,9 @@ function DashboardComponent() {
           if ("error" in response) {
             console.error("Task start error:", response.error);
             toast.error(`Task start error: ${JSON.stringify(response.error)}`);
+          } else if ("acknowledged" in response) {
+            console.log("Task acknowledged:", response);
+            // Success/error will be handled by socket event listeners
           } else {
             console.log("Task started:", response);
           }
@@ -652,6 +655,35 @@ function DashboardComponent() {
 
     return () => {
       socket.off("vscode-spawned", handleVSCodeSpawned);
+    };
+  }, [socket]);
+
+  // Listen for start-task success and error events
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleStartTaskSuccess = (data: {
+      taskId: string;
+      worktreePath: string;
+      terminalId: string;
+    }) => {
+      console.log("Task started successfully:", data);
+    };
+
+    const handleStartTaskError = (data: {
+      taskId: string;
+      error: string;
+    }) => {
+      console.error("Task start error:", data.error);
+      toast.error(`Task start error: ${data.error}`);
+    };
+
+    socket.on("start-task-success", handleStartTaskSuccess);
+    socket.on("start-task-error", handleStartTaskError);
+
+    return () => {
+      socket.off("start-task-success", handleStartTaskSuccess);
+      socket.off("start-task-error", handleStartTaskError);
     };
   }, [socket]);
 

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -84,6 +84,11 @@ export const TaskStartedSchema = z.object({
   terminalId: z.string(),
 });
 
+export const TaskAcknowledgedSchema = z.object({
+  taskId: typedZid("tasks"),
+  acknowledged: z.literal(true),
+});
+
 export const TaskErrorSchema = z.object({
   taskId: typedZid("tasks"),
   error: z.string(),
@@ -384,6 +389,7 @@ export type TerminalClosed = z.infer<typeof TerminalClosedSchema>;
 export type TerminalClear = z.infer<typeof TerminalClearSchema>;
 export type TerminalRestore = z.infer<typeof TerminalRestoreSchema>;
 export type TaskStarted = z.infer<typeof TaskStartedSchema>;
+export type TaskAcknowledged = z.infer<typeof TaskAcknowledgedSchema>;
 export type TaskError = z.infer<typeof TaskErrorSchema>;
 export type GitStatusRequest = z.infer<typeof GitStatusRequestSchema>;
 export type GitDiffRequest = z.infer<typeof GitDiffRequestSchema>;
@@ -430,7 +436,7 @@ export interface ClientToServerEvents {
   // Terminal operations
   "start-task": (
     data: StartTask,
-    callback: (response: TaskStarted | TaskError) => void
+    callback: (response: TaskStarted | TaskAcknowledged | TaskError) => void
   ) => void;
   "git-status": (data: GitStatusRequest) => void;
   "git-diff": (
@@ -525,6 +531,8 @@ export interface ServerToClientEvents {
   "vscode-spawned": (data: VSCodeSpawned) => void;
   "default-repo": (data: DefaultRepo) => void;
   "available-editors": (data: AvailableEditors) => void;
+  "start-task-success": (data: TaskStarted) => void;
+  "start-task-error": (data: TaskError) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
Acknowledge `start-task` RPC immediately to prevent timeouts, with results now communicated via new `start-task-success` and `start-task-error` events.

---
<a href="https://cursor.com/background-agent?bcId=bc-e27f0bc4-8621-4d5f-a78d-361a12117da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e27f0bc4-8621-4d5f-a78d-361a12117da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

