### PR TITLE
Update command palette shortcut to semicolon

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -885,19 +885,21 @@ app.whenReady().then(async () => {
         submenu: [
           {
             label: "Command Palette…",
-            accelerator: "CommandOrControl+K",
+            accelerator: "CommandOrControl+;",
             click: () => {
               try {
                 const target = resolveTargetWindow();
-                keyDebug("menu-accelerator-cmdk", {
+                keyDebug("menu-accelerator-cmd-semicolon", {
                   to: target?.webContents.id,
                 });
                 if (target && !target.isDestroyed()) {
-                  target.webContents.send("cmux:event:shortcut:cmd-k");
+                  target.webContents.send("cmux:event:shortcut:cmd-semicolon");
                 }
               } catch (err) {
-                mainWarn("Failed to emit Cmd+K from menu accelerator", err);
-                keyDebug("menu-accelerator-cmdk-error", { err: String(err) });
+                mainWarn("Failed to emit Cmd+; from menu accelerator", err);
+                keyDebug("menu-accelerator-cmd-semicolon-error", {
+                  err: String(err),
+                });
               }
             },
           },

--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -201,8 +201,8 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   useEffect(() => {
     // In Electron, prefer global shortcut from main via cmux event.
     if (isElectron) {
-      const off = window.cmux.on("shortcut:cmd-k", () => {
-        // Only handle Cmd+K (no shift/ctrl variations)
+      const off = window.cmux.on("shortcut:cmd-semicolon", () => {
+        // Only handle Cmd+; / Ctrl+; (no shift/ctrl variations)
         setOpenedWithShift(false);
         setActivePage("root");
         if (openRef.current) {
@@ -218,15 +218,14 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
       };
     }
 
-    // Web/non-Electron fallback: local keydown listener for Cmd+K
+    // Web/non-Electron fallback: local keydown listener for Cmd+;
     const down = (e: KeyboardEvent) => {
-      // Only trigger on EXACT Cmd+K (no Shift/Alt/Ctrl)
+      // Only trigger on EXACT Cmd+; / Ctrl+; (no Shift/Alt)
       if (
-        e.key.toLowerCase() === "k" &&
-        e.metaKey &&
+        (e.code === "Semicolon" || e.key === ";") &&
         !e.shiftKey &&
         !e.altKey &&
-        !e.ctrlKey
+        ((e.metaKey && !e.ctrlKey) || (!e.metaKey && e.ctrlKey))
       ) {
         e.preventDefault();
         setActivePage("root");


### PR DESCRIPTION
## Summary
- update the electron shortcut handling to trigger the command palette on Cmd+; / Ctrl+;
- align the renderer command bar listener with the new shortcut event name
- change the application menu accelerator and related logging to the semicolon shortcut

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e6df0605e08333802d01bfe809371d