### PR TITLE
Run dev and maintenance scripts on tmux attach

### DIFF
--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -1,11 +1,9 @@
-import { randomUUID } from "node:crypto";
-
 import type { MorphInstance } from "./git";
 import { maskSensitive, singleQuote } from "./shell";
 
-const WORKSPACE_ROOT = "/root/workspace";
 const CMUX_RUNTIME_DIR = "/var/tmp/cmux-scripts";
-const LOG_DIR = "/var/log/cmux";
+const DEV_SCRIPT_PATH = `${CMUX_RUNTIME_DIR}/dev-script.sh`;
+const MAINTENANCE_SCRIPT_PATH = `${CMUX_RUNTIME_DIR}/maintenance-script.sh`;
 
 const previewOutput = (
   value: string | undefined,
@@ -32,134 +30,61 @@ CMUX_SCRIPT_EOF
 chmod +x ${path}
 `;
 
-const ensurePidStoppedCommand = (pidFile: string): string => `
-if [ -f ${pidFile} ]; then
-  (
-    set -euo pipefail
-    trap 'status=$?; echo "Failed to stop process recorded in ${pidFile} (pid \${EXISTING_PID:-unknown}) (exit $status)" >&2' ERR
-    EXISTING_PID=$(cat ${pidFile} 2>/dev/null || true)
-    if [ -n "\${EXISTING_PID}" ] && kill -0 \${EXISTING_PID} 2>/dev/null; then
-      if kill \${EXISTING_PID} 2>/dev/null; then
-        sleep 0.2
-      elif kill -0 \${EXISTING_PID} 2>/dev/null; then
-        echo "Unable to terminate process \${EXISTING_PID}" >&2
-        exit 1
-      fi
-
-      if kill -0 \${EXISTING_PID} 2>/dev/null; then
-        echo "Process \${EXISTING_PID} still running after SIGTERM" >&2
-        exit 1
-      fi
-    fi
-  )
+const removeFileCommand = (path: string): string => `
+if [ -f ${path} ]; then
+  rm -f ${path}
 fi
 `;
 
-export async function runMaintenanceScript({
-  instance,
-  script,
-}: {
-  instance: MorphInstance;
-  script: string;
-}): Promise<{ error: string | null }> {
-  const maintenanceScriptPath = `${CMUX_RUNTIME_DIR}/maintenance-script.sh`;
-  const command = `
-set -euo pipefail
-trap 'rm -f ${maintenanceScriptPath}' EXIT
-${buildScriptFileCommand(maintenanceScriptPath, script)}
-cd ${WORKSPACE_ROOT}
-bash -eu -o pipefail ${maintenanceScriptPath}
-`;
-
+const execAndFormatError = async (
+  instance: MorphInstance,
+  command: string,
+  context: string,
+): Promise<{ error: string | null }> => {
   try {
     const result = await instance.exec(`bash -lc ${singleQuote(command)}`);
-
     if (result.exit_code !== 0) {
       const stderrPreview = previewOutput(result.stderr, 2000);
       const stdoutPreview = previewOutput(result.stdout, 500);
       const messageParts = [
-        `Maintenance script failed with exit code ${result.exit_code}`,
+        `${context} failed with exit code ${result.exit_code}`,
         stderrPreview ? `stderr: ${stderrPreview}` : null,
         stdoutPreview ? `stdout: ${stdoutPreview}` : null,
       ].filter((part): part is string => part !== null);
       return { error: messageParts.join(" | ") };
     }
-
     return { error: null };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    return { error: `Maintenance script execution failed: ${errorMessage}` };
+    return { error: `${context} execution failed: ${errorMessage}` };
   }
-}
+};
 
-export async function startDevScript({
+export const syncMaintenanceScript = async ({
   instance,
   script,
 }: {
   instance: MorphInstance;
-  script: string;
-}): Promise<{ error: string | null }> {
-  const devScriptRunId = randomUUID().replace(/-/g, "");
-  const devScriptDir = `${CMUX_RUNTIME_DIR}/${devScriptRunId}`;
-  const devScriptPath = `${devScriptDir}/dev-script.sh`;
-  const pidFile = `${LOG_DIR}/dev-script.pid`;
-  const logFile = `${LOG_DIR}/dev-script.log`;
+  script: string | null;
+}): Promise<{ error: string | null }> => {
+  const command = script
+    ? `set -euo pipefail\n${buildScriptFileCommand(MAINTENANCE_SCRIPT_PATH, script)}`
+    : `set -euo pipefail\n${removeFileCommand(MAINTENANCE_SCRIPT_PATH)}`;
+  return execAndFormatError(instance, command, "Maintenance script sync");
+};
 
-  const command = `
-set -euo pipefail
-mkdir -p ${LOG_DIR}
-mkdir -p ${devScriptDir}
-${ensurePidStoppedCommand(pidFile)}
-${buildScriptFileCommand(devScriptPath, script)}
-cd ${WORKSPACE_ROOT}
-nohup bash -eu -o pipefail ${devScriptPath} > ${logFile} 2>&1 &
-echo $! > ${pidFile}
-`;
+export const syncDevScript = async ({
+  instance,
+  script,
+}: {
+  instance: MorphInstance;
+  script: string | null;
+}): Promise<{ error: string | null }> => {
+  const command = script
+    ? `set -euo pipefail\n${buildScriptFileCommand(DEV_SCRIPT_PATH, script)}`
+    : `set -euo pipefail\n${removeFileCommand(DEV_SCRIPT_PATH)}`;
+  return execAndFormatError(instance, command, "Dev script sync");
+};
 
-  try {
-    const result = await instance.exec(`bash -lc ${singleQuote(command)}`);
-
-    if (result.exit_code !== 0) {
-      const stderrPreview = previewOutput(result.stderr, 2000);
-      const stdoutPreview = previewOutput(result.stdout, 500);
-      const messageParts = [
-        `Dev script failed to start with exit code ${result.exit_code}`,
-        stderrPreview ? `stderr: ${stderrPreview}` : null,
-        stdoutPreview ? `stdout: ${stdoutPreview}` : null,
-      ].filter((part): part is string => part !== null);
-      return { error: messageParts.join(" | ") };
-    }
-
-    // Check if the process started successfully and is still running
-    const checkCommand = `
-if [ -f ${pidFile} ]; then
-  PID=$(cat ${pidFile} 2>/dev/null || echo "")
-  if [ -n "\$PID" ]; then
-    sleep 0.5
-    if ! kill -0 \$PID 2>/dev/null; then
-      if [ -f ${logFile} ]; then
-        tail -n 50 ${logFile}
-      fi
-      exit 1
-    fi
-  fi
-fi
-`;
-
-    const checkResult = await instance.exec(
-      `bash -c ${singleQuote(checkCommand)}`,
-    );
-
-    if (checkResult.exit_code !== 0) {
-      const logPreview = previewOutput(checkResult.stdout, 2000);
-      return {
-        error: `Dev script failed immediately after start${logPreview ? ` | log: ${logPreview}` : ""}`,
-      };
-    }
-
-    return { error: null };
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return { error: `Dev script execution failed: ${errorMessage}` };
-  }
-}
+export const DEV_SCRIPT_ABSOLUTE_PATH = DEV_SCRIPT_PATH;
+export const MAINTENANCE_SCRIPT_ABSOLUTE_PATH = MAINTENANCE_SCRIPT_PATH;

--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -33,6 +33,6 @@ bind -n PageUp if-shell -F "#{pane_in_mode}" \
   "send-keys -X page-up" \
   "copy-mode -e; send-keys -X page-up"
 
-# Automatically launch dev and maintenance scripts inside the default session
-set-hook -g session-created "run-shell -F '/root/workspace/scripts/tmux/start-core-scripts.sh #{hook_session_name}'"
-set-hook -g client-attached "run-shell -F '/root/workspace/scripts/tmux/start-core-scripts.sh #{hook_session_name}'"
+# Automatically launch dev and maintenance scripts for the default session lifecycle
+set-hook -g session-created "run-shell -F '/root/workspace/scripts/tmux/start-core-scripts.sh #{hook} #{hook_session_name} #{client_session}'"
+set-hook -g client-attached "run-shell -F '/root/workspace/scripts/tmux/start-core-scripts.sh #{hook} #{hook_session_name} #{client_session}'"

--- a/configs/tmux.conf
+++ b/configs/tmux.conf
@@ -33,3 +33,6 @@ bind -n PageUp if-shell -F "#{pane_in_mode}" \
   "send-keys -X page-up" \
   "copy-mode -e; send-keys -X page-up"
 
+# Automatically launch dev and maintenance scripts inside the default session
+set-hook -g session-created "run-shell -F '/root/workspace/scripts/tmux/start-core-scripts.sh #{hook_session_name}'"
+set-hook -g client-attached "run-shell -F '/root/workspace/scripts/tmux/start-core-scripts.sh #{hook_session_name}'"

--- a/scripts/tmux/start-core-scripts.sh
+++ b/scripts/tmux/start-core-scripts.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+STATE_DIR="/var/tmp/cmux-tmux-hooks"
+LOG_FILE="${STATE_DIR}/start-core-scripts.log"
+
+mkdir -p "${STATE_DIR}"
+touch "${LOG_FILE}"
+
+log() {
+  local message="$1"
+  local timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  echo "${timestamp} ${message}" >> "${LOG_FILE}"
+  echo "${message}" >&2
+}
+
 resolve_session_name() {
   local value="$1"
   if [[ -z "${value}" ]]; then
@@ -44,21 +57,9 @@ MAINTENANCE_SCRIPT="${WORKSPACE_DIR}/scripts/maintenance.sh"
 CMUX_RUNTIME_DIR="/var/tmp/cmux-scripts"
 DEV_OVERRIDE_SCRIPT="${CMUX_RUNTIME_DIR}/dev-script.sh"
 MAINTENANCE_OVERRIDE_SCRIPT="${CMUX_RUNTIME_DIR}/maintenance-script.sh"
-STATE_DIR="/var/tmp/cmux-tmux-hooks"
-LOG_FILE="${STATE_DIR}/start-core-scripts.log"
 DEV_WINDOW_NAME="dev"
 MAINTENANCE_WINDOW_NAME="maintenance"
 MAINTENANCE_MARKER="${STATE_DIR}/${SESSION_NAME}-maintenance.launched"
-
-mkdir -p "${STATE_DIR}"
-touch "${LOG_FILE}"
-
-log() {
-  local message="$1"
-  local timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
-  echo "${timestamp} ${message}" >> "${LOG_FILE}"
-  echo "${message}" >&2
-}
 
 list_windows() {
   tmux list-windows -t "${SESSION_NAME}" -F '#{window_name}' 2>/dev/null || true

--- a/scripts/tmux/start-core-scripts.sh
+++ b/scripts/tmux/start-core-scripts.sh
@@ -1,25 +1,64 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SESSION_NAME="${1:-}"
+resolve_session_name() {
+  local value="$1"
+  if [[ -z "${value}" ]]; then
+    echo ""
+    return
+  fi
+
+  if [[ "${value}" =~ ^\$[0-9]+$ ]]; then
+    tmux display-message -p -t "${value}" '#S' 2>/dev/null || echo ""
+    return
+  fi
+
+  echo "${value}"
+}
+
+HOOK_NAME="${1:-}"
+RAW_SESSION_ARG="${2:-}"
+RAW_CLIENT_ARG="${3:-}"
+
+SESSION_NAME="$(resolve_session_name "${RAW_SESSION_ARG}")"
 if [[ -z "${SESSION_NAME}" ]]; then
+  SESSION_NAME="$(resolve_session_name "${RAW_CLIENT_ARG}")"
+fi
+
+log "[cmux] start-core-scripts.sh hook='${HOOK_NAME}' rawSession='${RAW_SESSION_ARG}' rawClient='${RAW_CLIENT_ARG}' resolved='${SESSION_NAME}'"
+
+if [[ -z "${SESSION_NAME}" ]]; then
+  log "[cmux] Unable to resolve session name, skipping"
   exit 0
 fi
 
 TARGET_SESSION="cmux"
 if [[ "${SESSION_NAME}" != "${TARGET_SESSION}" ]]; then
+  log "[cmux] Session '${SESSION_NAME}' did not match target '${TARGET_SESSION}', skipping"
   exit 0
 fi
 
 WORKSPACE_DIR="/root/workspace"
 DEV_SCRIPT="${WORKSPACE_DIR}/scripts/dev.sh"
 MAINTENANCE_SCRIPT="${WORKSPACE_DIR}/scripts/maintenance.sh"
+CMUX_RUNTIME_DIR="/var/tmp/cmux-scripts"
+DEV_OVERRIDE_SCRIPT="${CMUX_RUNTIME_DIR}/dev-script.sh"
+MAINTENANCE_OVERRIDE_SCRIPT="${CMUX_RUNTIME_DIR}/maintenance-script.sh"
 STATE_DIR="/var/tmp/cmux-tmux-hooks"
+LOG_FILE="${STATE_DIR}/start-core-scripts.log"
 DEV_WINDOW_NAME="dev"
 MAINTENANCE_WINDOW_NAME="maintenance"
 MAINTENANCE_MARKER="${STATE_DIR}/${SESSION_NAME}-maintenance.launched"
 
 mkdir -p "${STATE_DIR}"
+touch "${LOG_FILE}"
+
+log() {
+  local message="$1"
+  local timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  echo "${timestamp} ${message}" >> "${LOG_FILE}"
+  echo "${message}" >&2
+}
 
 list_windows() {
   tmux list-windows -t "${SESSION_NAME}" -F '#{window_name}' 2>/dev/null || true
@@ -31,36 +70,59 @@ window_exists() {
 }
 
 maybe_start_dev_script() {
-  if [[ ! -x "${DEV_SCRIPT}" ]]; then
+  if window_exists "${DEV_WINDOW_NAME}"; then
+    log "[cmux] Dev window already exists"
     return
   fi
 
-  if window_exists "${DEV_WINDOW_NAME}"; then
+  local command
+  if [[ -f "${DEV_OVERRIDE_SCRIPT}" ]]; then
+    command="cd ${WORKSPACE_DIR} && bash -eu -o pipefail ${DEV_OVERRIDE_SCRIPT}"
+    log "[cmux] Using override dev script ${DEV_OVERRIDE_SCRIPT}"
+  elif [[ -x "${DEV_SCRIPT}" ]]; then
+    command="cd ${WORKSPACE_DIR} && ./scripts/dev.sh"
+    log "[cmux] Using default dev script ${DEV_SCRIPT}"
+  else
+    log "[cmux] No dev script available"
     return
   fi
 
   tmux new-window -d -t "${SESSION_NAME}" -n "${DEV_WINDOW_NAME}" \
-    "bash -lc 'cd ${WORKSPACE_DIR} && ./scripts/dev.sh'"
+    "bash -lc '${command}'"
+  log "[cmux] Launched dev window"
 }
 
 maybe_start_maintenance_script() {
-  if [[ ! -x "${MAINTENANCE_SCRIPT}" ]]; then
-    return
-  fi
-
   if [[ -f "${MAINTENANCE_MARKER}" ]]; then
+    log "[cmux] Maintenance marker present, skipping"
     return
   fi
 
   if window_exists "${MAINTENANCE_WINDOW_NAME}"; then
+    log "[cmux] Maintenance window already exists"
+    return
+  fi
+
+  local command
+  if [[ -f "${MAINTENANCE_OVERRIDE_SCRIPT}" ]]; then
+    command="cd ${WORKSPACE_DIR} && bash -eu -o pipefail ${MAINTENANCE_OVERRIDE_SCRIPT}"
+    log "[cmux] Using override maintenance script ${MAINTENANCE_OVERRIDE_SCRIPT}"
+  elif [[ -x "${MAINTENANCE_SCRIPT}" ]]; then
+    command="cd ${WORKSPACE_DIR} && ./scripts/maintenance.sh"
+    log "[cmux] Using default maintenance script ${MAINTENANCE_SCRIPT}"
+  else
+    log "[cmux] No maintenance script available"
     return
   fi
 
   tmux new-window -d -t "${SESSION_NAME}" -n "${MAINTENANCE_WINDOW_NAME}" \
-    "bash -lc 'cd ${WORKSPACE_DIR} && ./scripts/maintenance.sh'"
+    "bash -lc '${command}'"
+  log "[cmux] Launched maintenance window"
 
   touch "${MAINTENANCE_MARKER}"
+  log "[cmux] Maintenance marker created at ${MAINTENANCE_MARKER}"
 }
 
 maybe_start_dev_script
 maybe_start_maintenance_script
+log "[cmux] start-core-scripts.sh completed"

--- a/scripts/tmux/start-core-scripts.sh
+++ b/scripts/tmux/start-core-scripts.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSION_NAME="${1:-}"
+if [[ -z "${SESSION_NAME}" ]]; then
+  exit 0
+fi
+
+TARGET_SESSION="cmux"
+if [[ "${SESSION_NAME}" != "${TARGET_SESSION}" ]]; then
+  exit 0
+fi
+
+WORKSPACE_DIR="/root/workspace"
+DEV_SCRIPT="${WORKSPACE_DIR}/scripts/dev.sh"
+MAINTENANCE_SCRIPT="${WORKSPACE_DIR}/scripts/maintenance.sh"
+STATE_DIR="/var/tmp/cmux-tmux-hooks"
+DEV_WINDOW_NAME="dev"
+MAINTENANCE_WINDOW_NAME="maintenance"
+MAINTENANCE_MARKER="${STATE_DIR}/${SESSION_NAME}-maintenance.launched"
+
+mkdir -p "${STATE_DIR}"
+
+list_windows() {
+  tmux list-windows -t "${SESSION_NAME}" -F '#{window_name}' 2>/dev/null || true
+}
+
+window_exists() {
+  local window_name="$1"
+  list_windows | grep -Fx "${window_name}" >/dev/null 2>&1
+}
+
+maybe_start_dev_script() {
+  if [[ ! -x "${DEV_SCRIPT}" ]]; then
+    return
+  fi
+
+  if window_exists "${DEV_WINDOW_NAME}"; then
+    return
+  fi
+
+  tmux new-window -d -t "${SESSION_NAME}" -n "${DEV_WINDOW_NAME}" \
+    "bash -lc 'cd ${WORKSPACE_DIR} && ./scripts/dev.sh'"
+}
+
+maybe_start_maintenance_script() {
+  if [[ ! -x "${MAINTENANCE_SCRIPT}" ]]; then
+    return
+  fi
+
+  if [[ -f "${MAINTENANCE_MARKER}" ]]; then
+    return
+  fi
+
+  if window_exists "${MAINTENANCE_WINDOW_NAME}"; then
+    return
+  fi
+
+  tmux new-window -d -t "${SESSION_NAME}" -n "${MAINTENANCE_WINDOW_NAME}" \
+    "bash -lc 'cd ${WORKSPACE_DIR} && ./scripts/maintenance.sh'"
+
+  touch "${MAINTENANCE_MARKER}"
+}
+
+maybe_start_dev_script
+maybe_start_maintenance_script


### PR DESCRIPTION
currently our dev and maintenance scripts are not run from tmux attach. we want to run it from tmux attach so that when we start the agent we are also running the dev and maintenance script. we should not be altering @startup.sh though. find a way to do it.