### PR TITLE
Always use settings.json Anthropic API key

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -265,7 +265,7 @@ export async function spawnAgent(
     let unsetEnvVars: string[] = [];
 
     // Fetch API keys from Convex BEFORE calling agent.environment()
-    // so we can pass the Anthropic API key to the environment context
+    // so agents can access them in their environment configuration
     const apiKeys = await getConvex().query(api.apiKeys.getAllForAgents, {
       teamSlugOrId,
     });
@@ -276,10 +276,7 @@ export async function spawnAgent(
         taskRunId: taskRunId,
         prompt: processedTaskDescription,
         taskRunJwt,
-        // Pass the Anthropic API key so it can be written to settings.json
-        // This ensures Claude Code always uses the key from cmux settings,
-        // bypassing any ANTHROPIC_API_KEY environment variables in the repo
-        anthropicApiKey: apiKeys.ANTHROPIC_API_KEY,
+        apiKeys,
       });
       envVars = {
         ...envVars,

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -4,10 +4,6 @@ import { checkClaudeRequirements } from "./check-requirements";
 import { startClaudeCompletionDetector } from "./completion-detector";
 import { getClaudeEnvironment } from "./environment";
 
-const CLAUDE_LIFECYCLE_DIR = "/root/lifecycle/claude";
-const CLAUDE_SECRETS_DIR = `${CLAUDE_LIFECYCLE_DIR}/secrets`;
-const CLAUDE_API_KEY_PATH = `${CLAUDE_SECRETS_DIR}/.anthropic_key`;
-
 export const CLAUDE_SONNET_4_CONFIG: AgentConfig = {
   name: "claude/sonnet-4",
   command: "bunx",
@@ -22,20 +18,8 @@ export const CLAUDE_SONNET_4_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (keys) => {
-    const key = keys[ANTHROPIC_API_KEY.envVar];
-    if (!key) return {};
-    const { Buffer } = await import("node:buffer");
-    return {
-      files: [
-        {
-          destinationPath: CLAUDE_API_KEY_PATH,
-          contentBase64: Buffer.from(key).toString("base64"),
-          mode: "600",
-        },
-      ],
-      startupCommands: [`mkdir -p ${CLAUDE_SECRETS_DIR}`],
-    };
+  applyApiKeys: async (_keys) => {
+    return {};
   },
   completionDetector: startClaudeCompletionDetector,
 };
@@ -54,20 +38,8 @@ export const CLAUDE_OPUS_4_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (keys) => {
-    const key = keys[ANTHROPIC_API_KEY.envVar];
-    if (!key) return {};
-    const { Buffer } = await import("node:buffer");
-    return {
-      files: [
-        {
-          destinationPath: CLAUDE_API_KEY_PATH,
-          contentBase64: Buffer.from(key).toString("base64"),
-          mode: "600",
-        },
-      ],
-      startupCommands: [`mkdir -p ${CLAUDE_SECRETS_DIR}`],
-    };
+  applyApiKeys: async (_keys) => {
+    return {};
   },
   completionDetector: startClaudeCompletionDetector,
 };
@@ -86,20 +58,8 @@ export const CLAUDE_OPUS_4_1_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (keys) => {
-    const key = keys[ANTHROPIC_API_KEY.envVar];
-    if (!key) return {};
-    const { Buffer } = await import("node:buffer");
-    return {
-      files: [
-        {
-          destinationPath: CLAUDE_API_KEY_PATH,
-          contentBase64: Buffer.from(key).toString("base64"),
-          mode: "600",
-        },
-      ],
-      startupCommands: [`mkdir -p ${CLAUDE_SECRETS_DIR}`],
-    };
+  applyApiKeys: async (_keys) => {
+    return {};
   },
   completionDetector: startClaudeCompletionDetector,
 };
@@ -118,20 +78,8 @@ export const CLAUDE_SONNET_4_5_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (keys) => {
-    const key = keys[ANTHROPIC_API_KEY.envVar];
-    if (!key) return {};
-    const { Buffer } = await import("node:buffer");
-    return {
-      files: [
-        {
-          destinationPath: CLAUDE_API_KEY_PATH,
-          contentBase64: Buffer.from(key).toString("base64"),
-          mode: "600",
-        },
-      ],
-      startupCommands: [`mkdir -p ${CLAUDE_SECRETS_DIR}`],
-    };
+  applyApiKeys: async (_keys) => {
+    return {};
   },
   completionDetector: startClaudeCompletionDetector,
 };

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -2,7 +2,14 @@ import type { AgentConfig } from "../../agentConfig";
 import { ANTHROPIC_API_KEY } from "../../apiKeys";
 import { checkClaudeRequirements } from "./check-requirements";
 import { startClaudeCompletionDetector } from "./completion-detector";
-import { getClaudeEnvironment } from "./environment";
+import {
+  CLAUDE_KEY_ENV_VARS_TO_UNSET,
+  getClaudeEnvironment,
+} from "./environment";
+
+const applyClaudeApiKeys: NonNullable<AgentConfig["applyApiKeys"]> = async () => ({
+  unsetEnv: [...CLAUDE_KEY_ENV_VARS_TO_UNSET],
+});
 
 export const CLAUDE_SONNET_4_CONFIG: AgentConfig = {
   name: "claude/sonnet-4",
@@ -18,9 +25,7 @@ export const CLAUDE_SONNET_4_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (_keys) => {
-    return {};
-  },
+  applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
 
@@ -38,9 +43,7 @@ export const CLAUDE_OPUS_4_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (_keys) => {
-    return {};
-  },
+  applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
 
@@ -58,9 +61,7 @@ export const CLAUDE_OPUS_4_1_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (_keys) => {
-    return {};
-  },
+  applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
 
@@ -78,8 +79,6 @@ export const CLAUDE_SONNET_4_5_CONFIG: AgentConfig = {
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
   apiKeys: [ANTHROPIC_API_KEY],
-  applyApiKeys: async (_keys) => {
-    return {};
-  },
+  applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -158,6 +158,10 @@ exit 0`;
 
   // Create settings.json with hooks configuration
   const settingsConfig: Record<string, unknown> = {
+    // Use the Anthropic API key from cmux settings.json instead of env vars
+    // This ensures Claude Code always uses the key from cmux, bypassing any
+    // ANTHROPIC_API_KEY environment variables in the repo
+    ...(ctx.anthropicApiKey ? { anthropicApiKey: ctx.anthropicApiKey } : {}),
     // Configure helper to avoid env-var based prompting
     apiKeyHelper: claudeApiKeyHelperPath,
     hooks: {

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -5,10 +5,9 @@ import type {
 
 export const CLAUDE_KEY_ENV_VARS_TO_UNSET = [
   "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_CUSTOM_HEADERS",
   "CLAUDE_API_KEY",
-  "CLAUDE_CODE_API_KEY",
-  "ANTHROPIC_API_KEY_PATH",
-  "ANTHROPIC_API_KEY_FILE",
 ];
 
 export async function getClaudeEnvironment(

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -209,5 +209,10 @@ echo ${ctx.taskRunJwt}`;
     "echo '[CMUX] Settings directory in ~/.claude:' && ls -la /root/.claude/",
   );
 
-  return { files, env, startupCommands };
+  return {
+    files,
+    env,
+    startupCommands,
+    unsetEnv: ["ANTHROPIC_API_KEY"],
+  };
 }

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -161,7 +161,9 @@ exit 0`;
     // Use the Anthropic API key from cmux settings.json instead of env vars
     // This ensures Claude Code always uses the key from cmux, bypassing any
     // ANTHROPIC_API_KEY environment variables in the repo
-    ...(ctx.anthropicApiKey ? { anthropicApiKey: ctx.anthropicApiKey } : {}),
+    ...(ctx.apiKeys?.ANTHROPIC_API_KEY
+      ? { anthropicApiKey: ctx.apiKeys.ANTHROPIC_API_KEY }
+      : {}),
     // Configure helper to avoid env-var based prompting
     apiKeyHelper: claudeApiKeyHelperPath,
     hooks: {

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -3,6 +3,14 @@ import type {
   EnvironmentResult,
 } from "../common/environment-result";
 
+export const CLAUDE_KEY_ENV_VARS_TO_UNSET = [
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_API_KEY",
+  "CLAUDE_CODE_API_KEY",
+  "ANTHROPIC_API_KEY_PATH",
+  "ANTHROPIC_API_KEY_FILE",
+];
+
 export async function getClaudeEnvironment(
   ctx: EnvironmentContext,
 ): Promise<EnvironmentResult> {
@@ -215,6 +223,6 @@ echo ${ctx.taskRunJwt}`;
     files,
     env,
     startupCommands,
-    unsetEnv: ["ANTHROPIC_API_KEY"],
+    unsetEnv: [...CLAUDE_KEY_ENV_VARS_TO_UNSET],
   };
 }

--- a/packages/shared/src/providers/common/environment-result.ts
+++ b/packages/shared/src/providers/common/environment-result.ts
@@ -4,6 +4,7 @@ export interface EnvironmentResult {
   files: AuthFile[];
   env: Record<string, string>;
   startupCommands?: string[];
+  unsetEnv?: string[];
 }
 
 export type EnvironmentContext = {

--- a/packages/shared/src/providers/common/environment-result.ts
+++ b/packages/shared/src/providers/common/environment-result.ts
@@ -10,4 +10,5 @@ export type EnvironmentContext = {
   taskRunId: string;
   prompt: string;
   taskRunJwt: string;
+  anthropicApiKey?: string;
 };

--- a/packages/shared/src/providers/common/environment-result.ts
+++ b/packages/shared/src/providers/common/environment-result.ts
@@ -11,5 +11,5 @@ export type EnvironmentContext = {
   taskRunId: string;
   prompt: string;
   taskRunJwt: string;
-  anthropicApiKey?: string;
+  apiKeys?: Record<string, string>;
 };


### PR DESCRIPTION
currently, the anthropic key does not work in environments because there sometimes exists an ANTHROPIC_API_KEY of some sort inside the existing repo. this causes a conflict because it causes the user to need to figure out which anthropic api key to use. this is an extra step that requires manual user intervention. we want to automatically just use the key set in settings.json no matter what. how can we fix this and circumvent this manual question and checkpoint so it all runs smoothly without the need of user intervention.