### PR TITLE
Remove Node and Bun requirement from homepage requirements

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -605,9 +605,6 @@ export default async function LandingPage() {
               Docker installed
             </div>
             <div className="bg-neutral-900 border border-neutral-800 rounded-lg px-6 py-3">
-              Node.js 20+ or Bun 1.1.25+
-            </div>
-            <div className="bg-neutral-900 border border-neutral-800 rounded-lg px-6 py-3">
               macOS or Linux
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the Node.js and Bun requirement chip from the homepage requirements section

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e81de69c0c83338590677980e9b0e0