### PR TITLE
Remove default exposed ports from new environment forms

### DIFF
--- a/apps/client/src/components/EnvironmentConfiguration.tsx
+++ b/apps/client/src/components/EnvironmentConfiguration.tsx
@@ -48,7 +48,7 @@ export function EnvironmentConfiguration({
   initialEnvName = "",
   initialMaintenanceScript = "",
   initialDevScript = "",
-  initialExposedPorts = "3000, 8080",
+  initialExposedPorts = "",
   initialEnvVars,
 }: {
   selectedRepos: string[];

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
@@ -147,7 +147,7 @@ function NewSnapshotVersionPage() {
             initialExposedPorts={
               environment.exposedPorts && environment.exposedPorts.length > 0
                 ? environment.exposedPorts.join(", ")
-                : "3000, 8080"
+                : ""
             }
             initialEnvVars={initialEnvVars}
           />


### PR DESCRIPTION
## Summary
- remove the hard-coded default exposed port list from the environment configuration form so new environments start empty
- clear the fallback exposed port list when cloning environments that have no ports configured

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e842a15adc8333907a6bcbeec5ccfa