### PR TITLE
Fix iframe sandbox configuration in task run view

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
@@ -77,8 +77,8 @@ function TaskRunComponent() {
               src={workspaceUrl}
               className="grow flex relative"
               iframeClassName="select-none"
-              allow="*"
-              sandbox="*"
+              sandbox="allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation allow-top-navigation-by-user-activation"
+              allow="accelerometer; camera; encrypted-media; fullscreen; geolocation; gyroscope; magnetometer; microphone; midi; payment; usb; xr-spatial-tracking"
               retainOnUnmount
               suspended={!hasWorkspace}
               onLoad={onLoad}


### PR DESCRIPTION
## Summary
- replace the wildcard iframe sandbox configuration in the task run view with the explicit permissions we use elsewhere
- ensure the iframe allow list matches the VS Code view so the sandbox loads without browser errors

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e8c0816c608333aa7d4d1be904bf5e