### PR TITLE
Fix task run webview sandbox configuration

### DIFF
--- a/apps/client/src/lib/preloadTaskRunIframes.ts
+++ b/apps/client/src/lib/preloadTaskRunIframes.ts
@@ -6,6 +6,12 @@ import { getTaskRunPersistKey } from "./persistent-webview-keys";
  * @param taskRunIds - Array of task run IDs to preload
  * @returns Promise that resolves when all iframes are loaded
  */
+export const TASK_RUN_IFRAME_ALLOW =
+  "clipboard-read; clipboard-write; usb; serial; hid; cross-origin-isolated; autoplay; camera; microphone; geolocation; payment; fullscreen";
+
+export const TASK_RUN_IFRAME_SANDBOX =
+  "allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation";
+
 export async function preloadTaskRunIframes(
   data: { url: string; taskRunId: string }[]
 ): Promise<void> {
@@ -14,10 +20,8 @@ export async function preloadTaskRunIframes(
     return {
       key,
       url,
-      allow:
-        "clipboard-read; clipboard-write; usb; serial; hid; cross-origin-isolated; autoplay; camera; microphone; geolocation; payment; fullscreen",
-      sandbox:
-        "allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation",
+      allow: TASK_RUN_IFRAME_ALLOW,
+      sandbox: TASK_RUN_IFRAME_SANDBOX,
     };
   });
 
@@ -34,10 +38,8 @@ export async function preloadTaskRunIframe(
   url: string
 ): Promise<void> {
   await persistentIframeManager.preloadIframe(getTaskRunPersistKey(taskRunId), url, {
-    allow:
-      "clipboard-read; clipboard-write; usb; serial; hid; cross-origin-isolated; autoplay; camera; microphone; geolocation; payment; fullscreen",
-    sandbox:
-      "allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation",
+    allow: TASK_RUN_IFRAME_ALLOW,
+    sandbox: TASK_RUN_IFRAME_SANDBOX,
   });
 }
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
@@ -8,7 +8,11 @@ import { useCallback } from "react";
 import { PersistentWebView } from "@/components/persistent-webview";
 import { getTaskRunPersistKey } from "@/lib/persistent-webview-keys";
 import { toProxyWorkspaceUrl } from "@/lib/toProxyWorkspaceUrl";
-import { preloadTaskRunIframes } from "../lib/preloadTaskRunIframes";
+import {
+  TASK_RUN_IFRAME_ALLOW,
+  TASK_RUN_IFRAME_SANDBOX,
+  preloadTaskRunIframes,
+} from "../lib/preloadTaskRunIframes";
 
 export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/"
@@ -77,8 +81,8 @@ function TaskRunComponent() {
               src={workspaceUrl}
               className="grow flex relative"
               iframeClassName="select-none"
-              allow="*"
-              sandbox="*"
+              allow={TASK_RUN_IFRAME_ALLOW}
+              sandbox={TASK_RUN_IFRAME_SANDBOX}
               retainOnUnmount
               suspended={!hasWorkspace}
               onLoad={onLoad}


### PR DESCRIPTION
## Summary
- export shared constants for task run iframe permissions
- apply those permissions when rendering the task run persistent webview so the sandbox attribute uses valid flags

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68e8c0816c608333aa7d4d1be904bf5e