### PR TITLE
Run dev after maintenance completes, even on failure

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -291,7 +291,7 @@ const RestartTaskForm = memo(function RestartTaskForm({
             branch={task?.baseBranch ?? undefined}
             environmentId={task?.environmentId ?? undefined}
             persistenceKey={persistenceKey}
-            maxHeight="42px"
+            maxHeight="300px"
             minHeight="30px"
             onEditorReady={(api) => {
               editorApiRef.current = api;


### PR DESCRIPTION
sometimes the dev tmux window doesn't show up. we need to run the dev script strictly after the maintenance script finishes (no matter if the maintenance script finishes or fails early). it needs to wait for the maintenance script first.