### PR TITLE
Hide previews until dev script finishes, even if it fails

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -43,8 +43,13 @@ function PreviewPage() {
   }, [runId, taskRuns]);
 
   // Find the service URL for the requested port
+  // Only show previews with "running" status after the dev script has finished
   const previewUrl = useMemo(() => {
     if (!selectedRun?.networking) return null;
+
+    // If dev script hasn't finished yet, don't show any previews
+    if (!selectedRun.devScriptFinished) return null;
+
     const portNum = parseInt(port, 10);
     const service = selectedRun.networking.find(
       (s) => s.port === portNum && s.status === "running",
@@ -71,11 +76,13 @@ function PreviewPage() {
           <div className="flex h-full items-center justify-center">
             <div className="text-center">
               <p className="mb-2 text-sm text-neutral-500 dark:text-neutral-400">
-                {selectedRun
-                  ? `Port ${port} is not available for this run`
-                  : "Loading..."}
+                {!selectedRun
+                  ? "Loading..."
+                  : !selectedRun.devScriptFinished
+                    ? "Waiting for dev script to finish..."
+                    : `Port ${port} is not available for this run`}
               </p>
-              {selectedRun?.networking && selectedRun.networking.length > 0 && (
+              {selectedRun?.networking && selectedRun.networking.length > 0 && selectedRun.devScriptFinished && (
                 <div className="mt-4">
                   <p className="mb-2 text-xs text-neutral-400 dark:text-neutral-500">
                     Available ports:

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -318,13 +318,14 @@ sandboxesRouter.openapi(
             devScript: devScript || undefined,
             identifiers: scriptIdentifiers ?? undefined,
           });
-          if (taskRunConvexId && (result.maintenanceError || result.devError)) {
+          if (taskRunConvexId) {
             try {
               await convex.mutation(api.taskRuns.updateEnvironmentError, {
                 teamSlugOrId: body.teamSlugOrId,
                 id: taskRunConvexId,
                 maintenanceError: result.maintenanceError ?? undefined,
                 devError: result.devError ?? undefined,
+                devScriptFinished: true,
               });
             } catch (mutationError) {
               console.error(

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -243,6 +243,7 @@ const convexSchema = defineSchema({
         })
       )
     ),
+    devScriptFinished: v.optional(v.boolean()), // Whether the dev script has finished (even if it failed)
   })
     .index("by_task", ["taskId", "createdAt"])
     .index("by_parent", ["parentRunId"])

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -1108,6 +1108,7 @@ export const updateEnvironmentError = authMutation({
     id: v.id("taskRuns"),
     maintenanceError: v.optional(v.string()),
     devError: v.optional(v.string()),
+    devScriptFinished: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
@@ -1139,10 +1140,16 @@ export const updateEnvironmentError = authMutation({
       devError?: string;
     };
 
-    await ctx.db.patch(args.id, {
+    const updates: Partial<Doc<"taskRuns">> = {
       environmentError,
       updatedAt: Date.now(),
-    });
+    };
+
+    if (args.devScriptFinished !== undefined) {
+      updates.devScriptFinished = args.devScriptFinished;
+    }
+
+    await ctx.db.patch(args.id, updates);
   },
 });
 


### PR DESCRIPTION
we should only show the previews after the dev script is finishes (even if it fails early)... hide them until the dev script is finished.