### PR TITLE
socketio cors

### DIFF
--- a/apps/server/src/transports/socketio-transport.ts
+++ b/apps/server/src/transports/socketio-transport.ts
@@ -17,6 +17,7 @@ export function createSocketIOTransport(
   const defaultAllowed = new Set([
     "http://localhost:5173",
     "https://cmux.local",
+    "https://www.cmux.sh",
   ]);
   const dynamicAllowed = new Set(
     (allowedOriginsEnv?.split(",") ?? []).map((s) => s.trim()).filter(Boolean)


### PR DESCRIPTION
- **vendor crates 0**
- **dockerfile dry stages**
- **wip**
- **wip**
- **wip**
- **sync github actions**
- **wip**
- **wip**
- **better diff viewer 1**
- **wip**
- **wip**
- **wip**
- **wip**
- **wip**
- **chore(codex-gpt-5-codex-high): currently, on cloud mode, we are not running dev script i...**
- **wip**
- **wip**
- **wip**
- **wip**
- **wip**
- **wip**
- **lol**
- **lol**
- **revert changes in startup.sh**
- **wip**
- **wip**
- **wip**
- **simplify**
- **fix lc review**
- **wip**
- **works**
- **wip**
- **Hide debug Monaco editors when offscreen**
- **Remove debug Monaco visibility logs**
- **Extract debug Monaco samples to lib**
- **Duplicate debug Monaco samples for stress test**
- **wip**
- **wip**
- **wip**
- **chore: remove webcontents layout logger**
- **wip**
- **wip**
- **Improve diff viewer visibility tracking**
- **wip**
- **wip**
- **wip**
- **morph instance manager script**
- **remove unused dep**
- **works**
- **ok**
- **ok**
- **wip**
- **works**
- **better diff viewer 1 monaco bug**
- **ok**
- **Revert "works"**
- **wip**
- **wip**
- **ok**
- **wip**
- **good**
- **chore: release v1.0.62**
- **wip**
- **ok**
- **style**
- **fix gate**
- **fix**
- **ok**
- **fix type issue**
- **chore: bump version to 1.0.63**
- **chore(claude-sonnet-4-5): @ doesn’t work in restart task. we have the functionality...**
- **chore(codex-gpt-5-codex-high): currently restart task doesn't do the right number of age...**
- **wip**
- **chore(codex-gpt-5-codex-high): make docker detect work. for some reason, when i first la...**
- **cmux-proxy port 39379**
- **dev delete script**
- **maintenance script dont poll**
- **fixes**
- **Display active snapshot scripts in environment config UI**
- **ok**
- **ok**
- **ok**
- **dev script tmpdirs**
- **cleanup**
- **feat: enable editing environment scripts inline**
- **chore: release v1.0.64**
- **chore(claude-sonnet-4-5): in electron, for all links (anchors), prevent dragging li...**
- **chore(codex-gpt-5-codex-high): how is the default branch in frontend main page dropdown ...**
- **ok**
- **fix**
- **works**
- **wip**
- **chore(claude-sonnet-4-5): currently a lot of the opencode models have different log...**
- **chore(codex-gpt-5-codex-high): when restarting a task, the follow up button starting... ...**
- **fix test fail**
- **working**
- **Increase Morph sandbox TTL default to one hour**
- **standardize logos**
- **comment out for now**
- **chore(codex-gpt-5-codex-high): if user did not set up the configuration for the model, t...**
- **wip**
- **fix restart task latency**
- **remove persistence across restart task chat**
- **ok**
- **remove useEffect**
- **fix comment issue**
- **rm null stuff**
- **ok**
- **read AGENT_CONFIGS**
- **working state**
- **chore: bump version to 1.0.65**
- **wip**
- **fix convex callback urls**
- **Require explicit task run context when spawning worker terminals**
- **Make snapshot version tooltip open immediately**
- **wip**
- **chore(codex-gpt-5-codex-high): Make the landing page not be book a meeting, put that som...**
- **the one with chrome**
- **good**
- **chrome works good**
- **morph image works**
- **chore: bump version to 1.0.66**
- **wip**
- **rm unknown types and cleanup**
- **task runner cli**
- **edge router strip csp**
- **wip**
- **proxy stuff**
- **persistent iframe webview**
- **wip**
- **chore: release v1.0.67**
- **rm useEffect**
- **fix csp iframe**
- **chore: release v1.0.68**
- **Align empty sidebar states with section headings**
- **taskrunidpage**
- **chore: release v1.0.69**
- **fix index page**
- **chore: release v1.0.70**
- **confident**
- **chore: bump version to 1.0.71**
- **vscode working state**
- **chore: release v1.0.72**
- **wip**
- **docker shell**
- **working**
- **wip**
- **chore(claude-sonnet-4-5): can you remove the waiting list for cloud mode, we can re...**
- **up timeout**
- **remove additional attempts**
- **cleanup**
- **dockerfile dry stages less exec**
- **cleanup**
- **works**
- **browser qol**
- **wip**
- **works**
- **fix webcontentsview 2**
- **chore: bump version to 1.0.73**
- **put back type**
- **introduce mac universal binary**
- **binary**
- **reload preload**
- **chore: bump version to 1.0.74**
- **loading indicator fade**
- **ok**
- **keep TaskStarted**
- **working state**
- **new snapshot**
- **empty commit**
- **try building mac-universal**
- **wip**
- **chore: bump version to 1.0.75**
- **technically working error state handling**
- **no universal for now**
- **one more time**
- **mac intel build**
- **chore: bump version to 1.0.76**
- **ensure gh cli**
- **fix core**
- **wip**
- **good error state**
- **wip**
- **cmdl works**
- **wip**
- **fix chrome focus stuff**
- **wip**
- **Fix WebContentsView focus stealing when alt-tabbing away**
- **working state**
- **working state**
- **wip**
- **wip**
- **wip**
- **wip**
- **chore: release v1.0.77**
- **wip**
- **Fix releases**
- **chore: bump version to 1.0.78**
- **wip**
- **works**
- **ok**
- **wip**
- **wipo**
- **morph nfpm**
- **chore(codex-gpt-5-codex-high): in the landing page, we need add the mac x64 intel downlo...**
- **remove backfill**
- **works**
- **wip**
- **ok**
- **ok**
- **wip**
- **wip**
- **wip**
- **cleanup**
- **morph instance template**
- **fix, always take more update**
- **wip**
- **still should work**
- **wip**
- **ssh**
- **make look good**
- **wip**
- **good**
- **good**
- **looks fine**
- **looks better?**
- **good**
- **deps flag**
- **remove the ors**
- **cleanup code**
- **ok**
- **for now**
- **remove the useless tests**
- **wip**
- **wip**
- **rm as const**
- **working state**
- **beautiful working state**
- **no fluxbox**
- **wip**
- **wip**
- **good**
- **wip**
- **for merge conflict stuff**
- **works**
- **clean the logs**
- **wip**
- **add -x64 suffix to every mac x64 file**
- **download autodetects x64 vs arm64 for mac**
- **chore: bump version to 1.0.79**
- **working state**
- **fix type issues**
- **chore: bump version to 1.0.80**
- **chore(claude-sonnet-4-5): currently, the anthropic key does not work in environment...**
- **instance.exec**
- **wip**
- **ok**
- **Implement reset functionality for environment variables and enhance proxy configuration**
- **chore: bump version to 1.0.81**
- **start cmux proxy**
- **cleanup**
- **works**
- **works for anthropic edge case**
- **ok now**
- **try fix gh cmux-proxy test fail**
- **add -x64 suffic**
- **chore: bump version to 1.0.82**
- **Remove Node and Bun requirement from requirements section**
- **new sandbox**
- **fix**
- **ok**
- **working state**
- **wip**
- **wip**
- **Remove default exposed ports on new environment forms**
- **wip**
- **wip**
- **wip**
- **wip**
- **wip**
- **wip**
- **wip**
- **Refactor LD_PRELOAD library handling in tests to use a dedicated function for building the library if missing. This improves code readability and reduces duplication across multiple test cases.**
- **wip**
- **chore(codex-gpt-5-codex-high): when the cmux app first starts up after autoupdates or fi...**
- **lol**
- **m**
- **semi working state**
- **extensions**
- **wip**
- **Fix invalid sandbox attribute on task run webview**
- **qol**
- **wip**
- **rm unused .github workflows**
- **wip**
- **wip**
- **add log**
- **morph-instance-template-1**
- **wip**
- **works**
- **fix docker multistage build dind**
- **wip**
- **wip**
- **ok**
- **new snapshot**
- **empty**
- **autocommit works for local**
- **wip**
- **fixed**
- **wip**
- **wip**
- **wip**
- **chore: release v1.0.83**
- **ok**
- **lol**
- **release updates**
- **chore: bump version to 1.0.84**
- **might fix**
- **chore: bump version to 1.0.85**
- **no inherit env**
- **use zsh**
- **chore: bump version to 1.0.86**
- **wip**
- **chore: release v1.0.87**
- **chore: release v1.0.88**
- **new snapshot**
- **chore: release v1.0.89**
- **disallow same origin**
- **chore: release v1.0.90**
- **chore(codex-gpt-5-codex-high): sometimes the dev tmux window doesn't show up. we need to...**
- **Revert "disallow same origin"**
- **Increase max height for updated instructions input**
- **op**
- **chore: bump version to 1.0.92**
- **socketio cors**
