### PR TITLE
Pull main before maintenance and dev scripts

### DIFF
--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -84,6 +84,9 @@ fi`;
 set -eux
 cd ${WORKSPACE_ROOT}
 
+echo "=== Pulling latest changes from main branch ==="
+git checkout main && git pull origin main
+
 echo "=== Maintenance Script Started at \$(date) ==="
 ${maintenanceScript}
 echo "=== Maintenance Script Completed at \$(date) ==="


### PR DESCRIPTION
currently in environments we run the maintenance scripts and dev scripts. we need to be running git pull from the main branch everytime before we start the maintenance and dev script.

we should only pull once before ruing dev and maintenance scripts...or we can just pull in the maintenance script? the dev script should also be pulled if we pull in maintenance because it happens after?