### PR TITLE
Pull main before maintenance and dev

### DIFF
--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -84,6 +84,19 @@ fi`;
 set -eux
 cd ${WORKSPACE_ROOT}
 
+echo "=== Pulling latest changes from git repos ==="
+set +e
+for dir in */; do
+  if [ -d "\$dir/.git" ]; then
+    echo "Pulling in \$dir"
+    cd "\$dir"
+    git pull origin main
+    cd ..
+  fi
+done
+set -e
+echo "=== Git pull completed ==="
+
 echo "=== Maintenance Script Started at \$(date) ==="
 ${maintenanceScript}
 echo "=== Maintenance Script Completed at \$(date) ==="


### PR DESCRIPTION
currently in environments we run the maintenance scripts and dev scripts. we need to be running git pull from the main branch everytime before we start the maintenance and dev script.

we should only pull once before ruing dev and maintenance scripts...or we can just pull in the maintenance script? the dev script should also be pulled if we pull in maintenance because it happens after?

this won't actually work because sometimes the repos are inside the WORKSPACE_ROOT there are folders. and we need to make sure we git pull from the repo.... like we need to cd cmux sometimes or cd landing or cd [repo] first...