### PR TITLE
Add loading state for VS Code previews; preload first preview

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -4,8 +4,9 @@ import { api } from "@cmux/convex/api";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import z from "zod";
+import { preloadTaskRunIframes } from "@/lib/preloadTaskRunIframes";
 
 const paramsSchema = z.object({
   taskId: typedZid("tasks"),
@@ -42,26 +43,42 @@ function PreviewPage() {
     return taskRuns?.find((run) => run._id === runId);
   }, [runId, taskRuns]);
 
-  // Find the service URL for the requested port
-  const previewUrl = useMemo(() => {
+  // Find the service for the requested port
+  const service = useMemo(() => {
     if (!selectedRun?.networking) return null;
     const portNum = parseInt(port, 10);
-    const service = selectedRun.networking.find(
-      (s) => s.port === portNum && s.status === "running",
-    );
-    return service?.url;
+    return selectedRun.networking.find((s) => s.port === portNum);
   }, [selectedRun, port]);
+
+  // Preview is ready when service exists, has a URL, and status is "running"
+  const previewUrl = service?.url ?? null;
+  const isPreviewReady = service?.status === "running" && previewUrl !== null;
+  const isPreviewStarting = service?.status === "starting";
 
   const persistKey = useMemo(() => {
     return getTaskRunPreviewPersistKey(runId, port);
   }, [runId, port]);
 
+  // Preload the preview iframe when it becomes ready for the first time
+  const hasPreloadedRef = useRef(false);
+  useEffect(() => {
+    if (isPreviewReady && previewUrl && !hasPreloadedRef.current) {
+      hasPreloadedRef.current = true;
+      void preloadTaskRunIframes([
+        {
+          url: previewUrl,
+          taskRunId: runId,
+        },
+      ]);
+    }
+  }, [isPreviewReady, previewUrl, runId]);
+
   const paneBorderRadius = 6;
 
   return (
     <div className="flex h-full flex-col bg-white dark:bg-neutral-950">
-      <div className="flex-1 min-h-0">
-        {previewUrl ? (
+      <div className="flex-1 min-h-0 relative">
+        {previewUrl && isPreviewReady ? (
           <ElectronPreviewBrowser
             persistKey={persistKey}
             src={previewUrl}
@@ -70,29 +87,53 @@ function PreviewPage() {
         ) : (
           <div className="flex h-full items-center justify-center">
             <div className="text-center">
-              <p className="mb-2 text-sm text-neutral-500 dark:text-neutral-400">
-                {selectedRun
-                  ? `Port ${port} is not available for this run`
-                  : "Loading..."}
-              </p>
-              {selectedRun?.networking && selectedRun.networking.length > 0 && (
-                <div className="mt-4">
-                  <p className="mb-2 text-xs text-neutral-400 dark:text-neutral-500">
-                    Available ports:
-                  </p>
-                  <div className="flex justify-center gap-2">
-                    {selectedRun.networking
-                      .filter((s) => s.status === "running")
-                      .map((service) => (
-                        <span
-                          key={service.port}
-                          className="rounded px-2 py-1 text-xs bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-200"
-                        >
-                          {service.port}
-                        </span>
-                      ))}
+              {isPreviewStarting || (service && !isPreviewReady) ? (
+                <div className="flex flex-col items-center gap-3">
+                  <div className="flex gap-1">
+                    <div
+                      className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                      style={{ animationDelay: "0ms" }}
+                    />
+                    <div
+                      className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                      style={{ animationDelay: "150ms" }}
+                    />
+                    <div
+                      className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                      style={{ animationDelay: "300ms" }}
+                    />
                   </div>
+                  <span className="text-sm text-neutral-500 dark:text-neutral-400">
+                    Starting dev server on port {port}...
+                  </span>
                 </div>
+              ) : (
+                <>
+                  <p className="mb-2 text-sm text-neutral-500 dark:text-neutral-400">
+                    {selectedRun
+                      ? `Port ${port} is not available for this run`
+                      : "Loading..."}
+                  </p>
+                  {selectedRun?.networking && selectedRun.networking.length > 0 && (
+                    <div className="mt-4">
+                      <p className="mb-2 text-xs text-neutral-400 dark:text-neutral-500">
+                        Available ports:
+                      </p>
+                      <div className="flex justify-center gap-2">
+                        {selectedRun.networking
+                          .filter((s) => s.status === "running")
+                          .map((service) => (
+                            <span
+                              key={service.port}
+                              className="rounded px-2 py-1 text-xs bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-200"
+                            >
+                              {service.port}
+                            </span>
+                          ))}
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -4,9 +4,8 @@ import { api } from "@cmux/convex/api";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import z from "zod";
-import { preloadTaskRunIframes } from "@/lib/preloadTaskRunIframes";
 
 const paramsSchema = z.object({
   taskId: typedZid("tasks"),
@@ -58,20 +57,6 @@ function PreviewPage() {
   const persistKey = useMemo(() => {
     return getTaskRunPreviewPersistKey(runId, port);
   }, [runId, port]);
-
-  // Preload the preview iframe when it becomes ready for the first time
-  const hasPreloadedRef = useRef(false);
-  useEffect(() => {
-    if (isPreviewReady && previewUrl && !hasPreloadedRef.current) {
-      hasPreloadedRef.current = true;
-      void preloadTaskRunIframes([
-        {
-          url: previewUrl,
-          taskRunId: runId,
-        },
-      ]);
-    }
-  }, [isPreviewReady, previewUrl, runId]);
 
   const paneBorderRadius = 6;
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -65,7 +65,12 @@ function VSCodeComponent() {
     ? toProxyWorkspaceUrl(taskRun.data.vscode.workspaceUrl)
     : null;
   const persistKey = getTaskRunPersistKey(taskRunId);
-  const hasWorkspace = workspaceUrl !== null;
+
+  // VS Code is ready when:
+  // 1. We have a workspace URL
+  // 2. The vscode status is "running" (not just "starting")
+  const vscodeStatus = taskRun?.data?.vscode?.status;
+  const isVSCodeReady = workspaceUrl !== null && vscodeStatus === "running";
 
   const onLoad = useCallback(() => {
     console.log(`Workspace view loaded for task run ${taskRunId}`);
@@ -94,7 +99,7 @@ function VSCodeComponent() {
               sandbox={TASK_RUN_IFRAME_SANDBOX}
               allow={TASK_RUN_IFRAME_ALLOW}
               retainOnUnmount
-              suspended={!hasWorkspace}
+              suspended={!isVSCodeReady}
               onLoad={onLoad}
               onError={onError}
             />
@@ -105,8 +110,8 @@ function VSCodeComponent() {
             className={clsx(
               "absolute inset-0 flex items-center justify-center transition pointer-events-none",
               {
-                "opacity-100": !hasWorkspace,
-                "opacity-0": hasWorkspace,
+                "opacity-100": !isVSCodeReady,
+                "opacity-0": isVSCodeReady,
               }
             )}
           >


### PR DESCRIPTION
we need a loading state for vscode as well as the previews. dont show previews until dev server is finished (it is async and runs in background so we need some way to figure out when dev script is ready and the previews are ready..) we should also help the user and preload the first load of the preview so it doesn't take too long on the second load.