### PR TITLE
Add Morph VNC browser under Git Diff

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -9,6 +9,7 @@ import { useArchiveTask } from "@/hooks/useArchiveTask";
 import { useOpenWithActions } from "@/hooks/useOpenWithActions";
 import { isElectron } from "@/lib/electron";
 import { isFakeConvexId } from "@/lib/fakeConvexId";
+import { toMorphVncUrl } from "@/lib/morphWorkspace";
 import type { AnnotatedTaskRun, TaskRunWithChildren } from "@/types/task";
 import { ContextMenu } from "@base-ui-components/react/context-menu";
 import { api } from "@cmux/convex/api";
@@ -773,6 +774,11 @@ function TaskRunDetails({
     environmentError?.maintenanceError || environmentError?.devError
   );
 
+  const workspaceUrl = run.vscode?.workspaceUrl ?? null;
+  const shouldRenderBrowserLink =
+    run.vscode?.provider === "morph" &&
+    Boolean(workspaceUrl && toMorphVncUrl(workspaceUrl));
+
   const environmentErrorIndicator = hasEnvironmentError ? (
     <Tooltip delayDuration={0}>
       <TooltipTrigger asChild>
@@ -827,6 +833,16 @@ function TaskRunDetails({
         label="Git diff"
         indentLevel={indentLevel}
       />
+
+      {shouldRenderBrowserLink ? (
+        <TaskRunDetailLink
+          to="/$teamSlugOrId/task/$taskId/run/$runId/browser"
+          params={{ teamSlugOrId, taskId, runId: run._id }}
+          icon={<Globe className="w-3 h-3 mr-2 text-neutral-400" />}
+          label="Browser"
+          indentLevel={indentLevel}
+        />
+      ) : null}
 
       {shouldRenderPullRequestLink ? (
         <TaskRunDetailLink

--- a/apps/client/src/lib/morphWorkspace.ts
+++ b/apps/client/src/lib/morphWorkspace.ts
@@ -20,7 +20,7 @@ export function parseMorphWorkspaceHostname(
   };
 }
 
-export function buildMorphHostname({
+export function buildMorphProxyHostname({
   morphId,
   port,
   scope = "base",
@@ -32,6 +32,16 @@ export function buildMorphHostname({
   return `cmux-${morphId}-${scope}-${String(port)}.cmux.app`;
 }
 
+export function buildMorphCloudHostname({
+  morphId,
+  port,
+}: {
+  morphId: string;
+  port: string | number;
+}): string {
+  return `port-${String(port)}-morphvm-${morphId}.http.cloud.morph.so`;
+}
+
 export function toMorphPortUrl(
   workspaceUrl: string,
   targetPort: string | number,
@@ -40,6 +50,7 @@ export function toMorphPortUrl(
     protocol?: "http" | "https";
     pathname?: string;
     searchParams?: Record<string, string>;
+    host?: "proxy" | "cloud";
   }
 ): string | null {
   if (!workspaceUrl) {
@@ -60,11 +71,11 @@ export function toMorphPortUrl(
 
   const protocol = options?.protocol ?? "https";
   const scope = options?.scope ?? "base";
-  const target = new URL(`${protocol}://${buildMorphHostname({
-    morphId: info.morphId,
-    port: targetPort,
-    scope,
-  })}`);
+  const hostname =
+    (options?.host ?? "proxy") === "cloud"
+      ? buildMorphCloudHostname({ morphId: info.morphId, port: targetPort })
+      : buildMorphProxyHostname({ morphId: info.morphId, port: targetPort, scope });
+  const target = new URL(`${protocol}://${hostname}`);
 
   if (options?.pathname) {
     target.pathname = options.pathname;
@@ -87,6 +98,7 @@ export function toMorphVncUrl(workspaceUrl: string): string | null {
       resize: "scale",
       scale: "local",
     },
+    host: "cloud",
   });
 }
 

--- a/apps/client/src/lib/morphWorkspace.ts
+++ b/apps/client/src/lib/morphWorkspace.ts
@@ -1,0 +1,109 @@
+const MORPH_HOST_REGEX = /^port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so$/;
+
+export interface MorphWorkspaceInfo {
+  port: string;
+  morphId: string;
+}
+
+export function parseMorphWorkspaceHostname(
+  hostname: string
+): MorphWorkspaceInfo | null {
+  const match = hostname.match(MORPH_HOST_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const [, port, morphId] = match;
+  return {
+    port,
+    morphId,
+  };
+}
+
+export function buildMorphHostname({
+  morphId,
+  port,
+  scope = "base",
+}: {
+  morphId: string;
+  port: string | number;
+  scope?: string;
+}): string {
+  return `cmux-${morphId}-${scope}-${String(port)}.cmux.app`;
+}
+
+export function toMorphPortUrl(
+  workspaceUrl: string,
+  targetPort: string | number,
+  options?: {
+    scope?: string;
+    protocol?: "http" | "https";
+    pathname?: string;
+    searchParams?: Record<string, string>;
+  }
+): string | null {
+  if (!workspaceUrl) {
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(workspaceUrl);
+  } catch {
+    return null;
+  }
+
+  const info = parseMorphWorkspaceHostname(url.hostname);
+  if (!info) {
+    return null;
+  }
+
+  const protocol = options?.protocol ?? "https";
+  const scope = options?.scope ?? "base";
+  const target = new URL(`${protocol}://${buildMorphHostname({
+    morphId: info.morphId,
+    port: targetPort,
+    scope,
+  })}`);
+
+  if (options?.pathname) {
+    target.pathname = options.pathname;
+  }
+
+  if (options?.searchParams) {
+    for (const [key, value] of Object.entries(options.searchParams)) {
+      target.searchParams.set(key, value);
+    }
+  }
+
+  return target.toString();
+}
+
+export function toMorphVncUrl(workspaceUrl: string): string | null {
+  return toMorphPortUrl(workspaceUrl, 39380, {
+    pathname: "/vnc.html",
+    searchParams: {
+      autoconnect: "1",
+      resize: "scale",
+      scale: "local",
+    },
+  });
+}
+
+export function getMorphInstanceIdFromWorkspaceUrl(
+  workspaceUrl: string
+): string | null {
+  if (!workspaceUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(workspaceUrl);
+    const info = parseMorphWorkspaceHostname(url.hostname);
+    return info?.morphId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export { MORPH_HOST_REGEX };

--- a/apps/client/src/lib/persistent-webview-keys.ts
+++ b/apps/client/src/lib/persistent-webview-keys.ts
@@ -1,6 +1,7 @@
 const TASK_RUN_PREFIX = "task-run:";
 const TASK_RUN_PREVIEW_PREFIX = "task-run-preview:";
 const TASK_RUN_PULL_REQUEST_PREFIX = "task-run-pr:";
+const TASK_RUN_BROWSER_PREFIX = "task-run-browser:";
 
 export function getTaskRunPersistKey(taskRunId: string): string {
   return `${TASK_RUN_PREFIX}${taskRunId}`;
@@ -15,4 +16,8 @@ export function getTaskRunPreviewPersistKey(
 
 export function getTaskRunPullRequestPersistKey(taskRunId: string): string {
   return `${TASK_RUN_PULL_REQUEST_PREFIX}${taskRunId}`;
+}
+
+export function getTaskRunBrowserPersistKey(taskRunId: string): string {
+  return `${TASK_RUN_BROWSER_PREFIX}${taskRunId}`;
 }

--- a/apps/client/src/lib/preloadTaskRunIframes.ts
+++ b/apps/client/src/lib/preloadTaskRunIframes.ts
@@ -1,6 +1,9 @@
 import { PERMISSIVE_IFRAME_ALLOW, PERMISSIVE_IFRAME_SANDBOX } from "./iframePermissions";
 import { persistentIframeManager } from "./persistentIframeManager";
-import { getTaskRunPersistKey } from "./persistent-webview-keys";
+import {
+  getTaskRunBrowserPersistKey,
+  getTaskRunPersistKey,
+} from "./persistent-webview-keys";
 
 /**
  * Preload iframes for task runs
@@ -40,6 +43,20 @@ export async function preloadTaskRunIframe(
     allow: TASK_RUN_IFRAME_ALLOW,
     sandbox: TASK_RUN_IFRAME_SANDBOX,
   });
+}
+
+export async function preloadTaskRunBrowserIframe(
+  taskRunId: string,
+  url: string
+): Promise<void> {
+  await persistentIframeManager.preloadIframe(
+    getTaskRunBrowserPersistKey(taskRunId),
+    url,
+    {
+      allow: TASK_RUN_IFRAME_ALLOW,
+      sandbox: TASK_RUN_IFRAME_SANDBOX,
+    }
+  );
 }
 
 /**

--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -1,29 +1,19 @@
+import { buildMorphHostname, parseMorphWorkspaceHostname } from "./morphWorkspace";
+
 export function toProxyWorkspaceUrl(workspaceUrl: string): string {
   if (workspaceUrl.includes("morph.so")) {
-    // convert https://port-39378-morphvm-zqcjcumw.http.cloud.morph.so/?folder=/root/workspace
-    // to https://cmux-zqcjcumw-base-39378.cmux.app/?folder=/root/workspace
-
-    // Parse the URL to extract components
     const url = new URL(workspaceUrl);
-    const hostname = url.hostname;
+    const info = parseMorphWorkspaceHostname(url.hostname);
 
-    // Match format: port-{port}-morphvm-{morphId}.http.cloud.morph.so
-    const match = hostname.match(
-      /^port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so$/
-    );
-
-    if (!match) {
+    if (!info) {
       throw new Error(`Invalid workspace URL: ${workspaceUrl}`);
     }
 
-    const [, port, morphId] = match;
-    const scope = "base"; // Default scope
+    url.hostname = buildMorphHostname({
+      morphId: info.morphId,
+      port: info.port,
+    });
 
-    // Reconstruct as cmux-{morphId}-{scope}-{port}.cmux.app
-    const newHostname = `cmux-${morphId}-${scope}-${port}.cmux.app`;
-
-    // Rebuild the URL with the new hostname
-    url.hostname = newHostname;
     return url.toString();
   }
 

--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -1,4 +1,4 @@
-import { buildMorphHostname, parseMorphWorkspaceHostname } from "./morphWorkspace";
+import { buildMorphProxyHostname, parseMorphWorkspaceHostname } from "./morphWorkspace";
 
 export function toProxyWorkspaceUrl(workspaceUrl: string): string {
   if (workspaceUrl.includes("morph.so")) {
@@ -9,7 +9,7 @@ export function toProxyWorkspaceUrl(workspaceUrl: string): string {
       throw new Error(`Invalid workspace URL: ${workspaceUrl}`);
     }
 
-    url.hostname = buildMorphHostname({
+    url.hostname = buildMorphProxyHostname({
       morphId: info.morphId,
       port: info.port,
     });

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -43,6 +43,7 @@ import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdIndexRouteImport } from '.
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode'
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.pr'
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff'
+import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser'
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdPreviewPortRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port'
 
 const SignInRoute = SignInRouteImport.update({
@@ -231,6 +232,12 @@ const LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute =
     path: '/run/$runId/diff',
     getParentRoute: () => LayoutTeamSlugOrIdTaskTaskIdRoute,
   } as any)
+const LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute =
+  LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRouteImport.update({
+    id: '/run/$runId/browser',
+    path: '/run/$runId/browser',
+    getParentRoute: () => LayoutTeamSlugOrIdTaskTaskIdRoute,
+  } as any)
 const LayoutTeamSlugOrIdTaskTaskIdRunRunIdPreviewPortRoute =
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdPreviewPortRouteImport.update({
     id: '/run/$runId/preview/$port',
@@ -268,6 +275,7 @@ export interface FileRoutesByFullPath {
   '/$teamSlugOrId/task/$taskId/': typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
   '/$teamSlugOrId/prs-only/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOnlyOwnerRepoNumberRoute
   '/$teamSlugOrId/prs/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOwnerRepoNumberRoute
+  '/$teamSlugOrId/task/$taskId/run/$runId/browser': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/diff': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/pr': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/vscode': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -302,6 +310,7 @@ export interface FileRoutesByTo {
   '/$teamSlugOrId/task/$taskId': typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
   '/$teamSlugOrId/prs-only/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOnlyOwnerRepoNumberRoute
   '/$teamSlugOrId/prs/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOwnerRepoNumberRoute
+  '/$teamSlugOrId/task/$taskId/run/$runId/browser': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/diff': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/pr': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/vscode': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -340,6 +349,7 @@ export interface FileRoutesById {
   '/_layout/$teamSlugOrId/task/$taskId/': typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
   '/_layout/$teamSlugOrId/prs-only/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOnlyOwnerRepoNumberRoute
   '/_layout/$teamSlugOrId/prs/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOwnerRepoNumberRoute
+  '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   '/_layout/$teamSlugOrId/task/$taskId/run/$runId/diff': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   '/_layout/$teamSlugOrId/task/$taskId/run/$runId/pr': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   '/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -378,6 +388,7 @@ export interface FileRouteTypes {
     | '/$teamSlugOrId/task/$taskId/'
     | '/$teamSlugOrId/prs-only/$owner/$repo/$number'
     | '/$teamSlugOrId/prs/$owner/$repo/$number'
+    | '/$teamSlugOrId/task/$taskId/run/$runId/browser'
     | '/$teamSlugOrId/task/$taskId/run/$runId/diff'
     | '/$teamSlugOrId/task/$taskId/run/$runId/pr'
     | '/$teamSlugOrId/task/$taskId/run/$runId/vscode'
@@ -412,6 +423,7 @@ export interface FileRouteTypes {
     | '/$teamSlugOrId/task/$taskId'
     | '/$teamSlugOrId/prs-only/$owner/$repo/$number'
     | '/$teamSlugOrId/prs/$owner/$repo/$number'
+    | '/$teamSlugOrId/task/$taskId/run/$runId/browser'
     | '/$teamSlugOrId/task/$taskId/run/$runId/diff'
     | '/$teamSlugOrId/task/$taskId/run/$runId/pr'
     | '/$teamSlugOrId/task/$taskId/run/$runId/vscode'
@@ -449,6 +461,7 @@ export interface FileRouteTypes {
     | '/_layout/$teamSlugOrId/task/$taskId/'
     | '/_layout/$teamSlugOrId/prs-only/$owner/$repo/$number'
     | '/_layout/$teamSlugOrId/prs/$owner/$repo/$number'
+    | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser'
     | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/diff'
     | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/pr'
     | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode'
@@ -709,6 +722,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRouteImport
       parentRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRoute
     }
+    '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser': {
+      id: '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser'
+      path: '/run/$runId/browser'
+      fullPath: '/$teamSlugOrId/task/$taskId/run/$runId/browser'
+      preLoaderRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRouteImport
+      parentRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRoute
+    }
     '/_layout/$teamSlugOrId/task/$taskId/run/$runId/preview/$port': {
       id: '/_layout/$teamSlugOrId/task/$taskId/run/$runId/preview/$port'
       path: '/run/$runId/preview/$port'
@@ -759,6 +779,7 @@ const LayoutTeamSlugOrIdPrsRouteWithChildren =
 
 interface LayoutTeamSlugOrIdTaskTaskIdRouteChildren {
   LayoutTeamSlugOrIdTaskTaskIdIndexRoute: typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
+  LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -770,6 +791,8 @@ const LayoutTeamSlugOrIdTaskTaskIdRouteChildren: LayoutTeamSlugOrIdTaskTaskIdRou
   {
     LayoutTeamSlugOrIdTaskTaskIdIndexRoute:
       LayoutTeamSlugOrIdTaskTaskIdIndexRoute,
+    LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute:
+      LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute,
     LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute:
       LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute,
     LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute:

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
@@ -1,0 +1,134 @@
+import { PersistentWebView } from "@/components/persistent-webview";
+import {
+  TASK_RUN_IFRAME_ALLOW,
+  TASK_RUN_IFRAME_SANDBOX,
+} from "../lib/preloadTaskRunIframes";
+import { getTaskRunBrowserPersistKey } from "@/lib/persistent-webview-keys";
+import { toMorphVncUrl } from "@/lib/morphWorkspace";
+import { api } from "@cmux/convex/api";
+import { typedZid } from "@cmux/shared/utils/typed-zid";
+import { convexQuery } from "@convex-dev/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import clsx from "clsx";
+import { useCallback } from "react";
+import z from "zod";
+
+const paramsSchema = z.object({
+  taskId: typedZid("tasks"),
+  runId: typedZid("taskRuns"),
+});
+
+export const Route = createFileRoute(
+  "/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser"
+)({
+  component: TaskRunBrowser,
+  params: {
+    parse: paramsSchema.parse,
+    stringify: (params) => ({
+      taskId: params.taskId,
+      runId: params.runId,
+    }),
+  },
+  loader: async (opts) => {
+    await opts.context.queryClient.ensureQueryData(
+      convexQuery(api.taskRuns.get, {
+        teamSlugOrId: opts.params.teamSlugOrId,
+        id: opts.params.runId,
+      })
+    );
+  },
+});
+
+function TaskRunBrowser() {
+  const { runId: taskRunId, teamSlugOrId } = Route.useParams();
+  const taskRun = useSuspenseQuery(
+    convexQuery(api.taskRuns.get, {
+      teamSlugOrId,
+      id: taskRunId,
+    })
+  );
+
+  const vscode = taskRun?.data?.vscode;
+  const isMorphProvider = vscode?.provider === "morph";
+  const workspaceUrl = vscode?.workspaceUrl ?? null;
+  const browserUrl = isMorphProvider && workspaceUrl
+    ? toMorphVncUrl(workspaceUrl)
+    : null;
+
+  const persistKey = getTaskRunBrowserPersistKey(taskRunId);
+  const hasBrowser = Boolean(browserUrl);
+
+  const onLoad = useCallback(() => {
+    console.log(`Browser view loaded for task run ${taskRunId}`);
+  }, [taskRunId]);
+
+  const onError = useCallback(
+    (error: Error) => {
+      console.error(`Failed to load browser view for task run ${taskRunId}:`, error);
+    },
+    [taskRunId]
+  );
+
+  return (
+    <div className="pl-1 flex flex-col grow bg-neutral-50 dark:bg-black">
+      <div className="flex flex-col grow min-h-0 border-l border-neutral-200 dark:border-neutral-800">
+        <div className="flex flex-row grow min-h-0 relative">
+          {browserUrl ? (
+            <PersistentWebView
+              persistKey={persistKey}
+              src={browserUrl}
+              className="grow flex relative"
+              sandbox={TASK_RUN_IFRAME_SANDBOX}
+              allow={TASK_RUN_IFRAME_ALLOW}
+              retainOnUnmount
+              suspended={!hasBrowser}
+              onLoad={onLoad}
+              onError={onError}
+            />
+          ) : (
+            <div className="grow" />
+          )}
+
+          <div
+            className={clsx(
+              "absolute inset-0 flex items-center justify-center transition pointer-events-none",
+              {
+                "opacity-100": !hasBrowser,
+                "opacity-0": hasBrowser,
+              }
+            )}
+          >
+            {isMorphProvider ? (
+              <div className="flex flex-col items-center gap-3">
+                <div className="flex gap-1">
+                  <div
+                    className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                    style={{ animationDelay: "0ms" }}
+                  />
+                  <div
+                    className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                    style={{ animationDelay: "150ms" }}
+                  />
+                  <div
+                    className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                    style={{ animationDelay: "300ms" }}
+                  />
+                </div>
+                <span className="text-sm text-neutral-500">
+                  Preparing browser view...
+                </span>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-3 px-6 text-center">
+                <span className="text-sm text-neutral-500">
+                  Browser view is available only for Morph cloud runs.
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
add the vnc thing right below Git Diff and call it Browser, it should render morph port 39380 url + /vnc.html with url query params for auto connect and local scaling. should only apply to cloud/morph instances. do not rely on the vscode ports. we only need morph instance id and we can just auto-infer 39378 and 39380 and render them immediately.