### PR TITLE
Add VNC browser component for Morph

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -33,6 +33,7 @@ import {
   GitPullRequestClosed,
   GitPullRequestDraft,
   Globe,
+  Monitor,
   Loader2,
   XCircle,
 } from "lucide-react";
@@ -561,6 +562,7 @@ function TaskRunTreeInner({
   });
 
   const shouldRenderDiffLink = true;
+  const shouldRenderBrowserLink = run.vscode?.provider === "morph";
   const shouldRenderPullRequestLink = Boolean(
     (run.pullRequestUrl && run.pullRequestUrl !== "pending") ||
     run.pullRequests?.some((pr) => pr.url)
@@ -576,6 +578,7 @@ function TaskRunTreeInner({
     hasChildren ||
     hasActiveVSCode ||
     shouldRenderDiffLink ||
+    shouldRenderBrowserLink ||
     shouldRenderPullRequestLink ||
     shouldRenderPreviewLink;
 
@@ -678,14 +681,15 @@ function TaskRunTreeInner({
         run={run}
         level={level}
         taskId={taskId}
-        teamSlugOrId={teamSlugOrId}
-        isExpanded={isExpanded}
-        hasActiveVSCode={hasActiveVSCode}
-        hasChildren={hasChildren}
-        shouldRenderPullRequestLink={shouldRenderPullRequestLink}
-        previewServices={previewServices}
-        environmentError={run.environmentError}
-      />
+      teamSlugOrId={teamSlugOrId}
+      isExpanded={isExpanded}
+      hasActiveVSCode={hasActiveVSCode}
+      hasChildren={hasChildren}
+      shouldRenderBrowserLink={shouldRenderBrowserLink}
+      shouldRenderPullRequestLink={shouldRenderPullRequestLink}
+      previewServices={previewServices}
+      environmentError={run.environmentError}
+    />
     </Fragment>
   );
 }
@@ -744,6 +748,7 @@ interface TaskRunDetailsProps {
   isExpanded: boolean;
   hasActiveVSCode: boolean;
   hasChildren: boolean;
+  shouldRenderBrowserLink: boolean;
   shouldRenderPullRequestLink: boolean;
   previewServices: PreviewService[];
   environmentError?: {
@@ -760,6 +765,7 @@ function TaskRunDetails({
   isExpanded,
   hasActiveVSCode,
   hasChildren,
+  shouldRenderBrowserLink,
   shouldRenderPullRequestLink,
   previewServices,
   environmentError,
@@ -823,16 +829,26 @@ function TaskRunDetails({
       <TaskRunDetailLink
         to="/$teamSlugOrId/task/$taskId/run/$runId/diff"
         params={{ teamSlugOrId, taskId, runId: run._id }}
-        icon={<GitCompare className="w-3 h-3 mr-2 text-neutral-400" />}
-        label="Git diff"
+      icon={<GitCompare className="w-3 h-3 mr-2 text-neutral-400" />}
+      label="Git diff"
+      indentLevel={indentLevel}
+    />
+
+    {shouldRenderBrowserLink ? (
+      <TaskRunDetailLink
+        to="/$teamSlugOrId/task/$taskId/run/$runId/browser"
+        params={{ teamSlugOrId, taskId, runId: run._id }}
+        icon={<Monitor className="w-3 h-3 mr-2 text-neutral-400" />}
+        label="Browser"
         indentLevel={indentLevel}
       />
+    ) : null}
 
-      {shouldRenderPullRequestLink ? (
-        <TaskRunDetailLink
-          to="/$teamSlugOrId/task/$taskId/run/$runId/pr"
-          params={{ teamSlugOrId, taskId, runId: run._id }}
-          icon={<GitPullRequest className="w-3 h-3 mr-2 text-neutral-400" />}
+    {shouldRenderPullRequestLink ? (
+      <TaskRunDetailLink
+        to="/$teamSlugOrId/task/$taskId/run/$runId/pr"
+        params={{ teamSlugOrId, taskId, runId: run._id }}
+        icon={<GitPullRequest className="w-3 h-3 mr-2 text-neutral-400" />}
           label="Pull Request"
           indentLevel={indentLevel}
         />

--- a/apps/client/src/lib/persistent-webview-keys.ts
+++ b/apps/client/src/lib/persistent-webview-keys.ts
@@ -1,6 +1,7 @@
 const TASK_RUN_PREFIX = "task-run:";
 const TASK_RUN_PREVIEW_PREFIX = "task-run-preview:";
 const TASK_RUN_PULL_REQUEST_PREFIX = "task-run-pr:";
+const TASK_RUN_BROWSER_PREFIX = "task-run-browser:";
 
 export function getTaskRunPersistKey(taskRunId: string): string {
   return `${TASK_RUN_PREFIX}${taskRunId}`;
@@ -15,4 +16,8 @@ export function getTaskRunPreviewPersistKey(
 
 export function getTaskRunPullRequestPersistKey(taskRunId: string): string {
   return `${TASK_RUN_PULL_REQUEST_PREFIX}${taskRunId}`;
+}
+
+export function getTaskRunBrowserPersistKey(taskRunId: string): string {
+  return `${TASK_RUN_BROWSER_PREFIX}${taskRunId}`;
 }

--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -1,31 +1,70 @@
-export function toProxyWorkspaceUrl(workspaceUrl: string): string {
-  if (workspaceUrl.includes("morph.so")) {
-    // convert https://port-39378-morphvm-zqcjcumw.http.cloud.morph.so/?folder=/root/workspace
-    // to https://cmux-zqcjcumw-base-39378.cmux.app/?folder=/root/workspace
+const MORPH_HOST_REGEX = /^port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so$/;
 
-    // Parse the URL to extract components
-    const url = new URL(workspaceUrl);
-    const hostname = url.hostname;
+interface MorphUrlComponents {
+  url: URL;
+  morphId: string;
+  port: number;
+}
 
-    // Match format: port-{port}-morphvm-{morphId}.http.cloud.morph.so
-    const match = hostname.match(
-      /^port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so$/
-    );
-
-    if (!match) {
-      throw new Error(`Invalid workspace URL: ${workspaceUrl}`);
-    }
-
-    const [, port, morphId] = match;
-    const scope = "base"; // Default scope
-
-    // Reconstruct as cmux-{morphId}-{scope}-{port}.cmux.app
-    const newHostname = `cmux-${morphId}-${scope}-${port}.cmux.app`;
-
-    // Rebuild the URL with the new hostname
-    url.hostname = newHostname;
-    return url.toString();
+function parseMorphUrl(input: string): MorphUrlComponents | null {
+  if (!input.includes("morph.so")) {
+    return null;
   }
 
-  return workspaceUrl;
+  try {
+    const url = new URL(input);
+    const match = url.hostname.match(MORPH_HOST_REGEX);
+
+    if (!match) {
+      return null;
+    }
+
+    const [, portString, morphId] = match;
+    const port = Number.parseInt(portString, 10);
+
+    if (Number.isNaN(port)) {
+      return null;
+    }
+
+    return {
+      url,
+      morphId,
+      port,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function toProxyWorkspaceUrl(workspaceUrl: string): string {
+  const components = parseMorphUrl(workspaceUrl);
+
+  if (!components) {
+    return workspaceUrl;
+  }
+
+  const scope = "base"; // Default scope
+  const proxiedUrl = new URL(components.url.toString());
+  proxiedUrl.hostname = `cmux-${components.morphId}-${scope}-${components.port}.cmux.app`;
+  return proxiedUrl.toString();
+}
+
+export function toMorphVncUrl(sourceUrl: string): string | null {
+  const components = parseMorphUrl(sourceUrl);
+
+  if (!components) {
+    return null;
+  }
+
+  const vncUrl = new URL(components.url.toString());
+  vncUrl.hostname = `port-39380-morphvm-${components.morphId}.http.cloud.morph.so`;
+  vncUrl.pathname = "/vnc.html";
+
+  const searchParams = new URLSearchParams();
+  searchParams.set("autoconnect", "1");
+  searchParams.set("resize", "scale");
+  vncUrl.search = `?${searchParams.toString()}`;
+  vncUrl.hash = "";
+
+  return vncUrl.toString();
 }

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -43,6 +43,7 @@ import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdIndexRouteImport } from '.
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode'
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.pr'
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff'
+import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser'
 import { Route as LayoutTeamSlugOrIdTaskTaskIdRunRunIdPreviewPortRouteImport } from './routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port'
 
 const SignInRoute = SignInRouteImport.update({
@@ -231,6 +232,12 @@ const LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute =
     path: '/run/$runId/diff',
     getParentRoute: () => LayoutTeamSlugOrIdTaskTaskIdRoute,
   } as any)
+const LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute =
+  LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRouteImport.update({
+    id: '/run/$runId/browser',
+    path: '/run/$runId/browser',
+    getParentRoute: () => LayoutTeamSlugOrIdTaskTaskIdRoute,
+  } as any)
 const LayoutTeamSlugOrIdTaskTaskIdRunRunIdPreviewPortRoute =
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdPreviewPortRouteImport.update({
     id: '/run/$runId/preview/$port',
@@ -268,6 +275,7 @@ export interface FileRoutesByFullPath {
   '/$teamSlugOrId/task/$taskId/': typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
   '/$teamSlugOrId/prs-only/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOnlyOwnerRepoNumberRoute
   '/$teamSlugOrId/prs/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOwnerRepoNumberRoute
+  '/$teamSlugOrId/task/$taskId/run/$runId/browser': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/diff': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/pr': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/vscode': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -302,6 +310,7 @@ export interface FileRoutesByTo {
   '/$teamSlugOrId/task/$taskId': typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
   '/$teamSlugOrId/prs-only/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOnlyOwnerRepoNumberRoute
   '/$teamSlugOrId/prs/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOwnerRepoNumberRoute
+  '/$teamSlugOrId/task/$taskId/run/$runId/browser': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/diff': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/pr': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   '/$teamSlugOrId/task/$taskId/run/$runId/vscode': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -340,6 +349,7 @@ export interface FileRoutesById {
   '/_layout/$teamSlugOrId/task/$taskId/': typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
   '/_layout/$teamSlugOrId/prs-only/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOnlyOwnerRepoNumberRoute
   '/_layout/$teamSlugOrId/prs/$owner/$repo/$number': typeof LayoutTeamSlugOrIdPrsOwnerRepoNumberRoute
+  '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   '/_layout/$teamSlugOrId/task/$taskId/run/$runId/diff': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   '/_layout/$teamSlugOrId/task/$taskId/run/$runId/pr': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   '/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode': typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -378,6 +388,7 @@ export interface FileRouteTypes {
     | '/$teamSlugOrId/task/$taskId/'
     | '/$teamSlugOrId/prs-only/$owner/$repo/$number'
     | '/$teamSlugOrId/prs/$owner/$repo/$number'
+    | '/$teamSlugOrId/task/$taskId/run/$runId/browser'
     | '/$teamSlugOrId/task/$taskId/run/$runId/diff'
     | '/$teamSlugOrId/task/$taskId/run/$runId/pr'
     | '/$teamSlugOrId/task/$taskId/run/$runId/vscode'
@@ -412,6 +423,7 @@ export interface FileRouteTypes {
     | '/$teamSlugOrId/task/$taskId'
     | '/$teamSlugOrId/prs-only/$owner/$repo/$number'
     | '/$teamSlugOrId/prs/$owner/$repo/$number'
+    | '/$teamSlugOrId/task/$taskId/run/$runId/browser'
     | '/$teamSlugOrId/task/$taskId/run/$runId/diff'
     | '/$teamSlugOrId/task/$taskId/run/$runId/pr'
     | '/$teamSlugOrId/task/$taskId/run/$runId/vscode'
@@ -449,6 +461,7 @@ export interface FileRouteTypes {
     | '/_layout/$teamSlugOrId/task/$taskId/'
     | '/_layout/$teamSlugOrId/prs-only/$owner/$repo/$number'
     | '/_layout/$teamSlugOrId/prs/$owner/$repo/$number'
+    | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser'
     | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/diff'
     | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/pr'
     | '/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode'
@@ -709,6 +722,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRouteImport
       parentRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRoute
     }
+    '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser': {
+      id: '/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser'
+      path: '/run/$runId/browser'
+      fullPath: '/$teamSlugOrId/task/$taskId/run/$runId/browser'
+      preLoaderRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRouteImport
+      parentRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRoute
+    }
     '/_layout/$teamSlugOrId/task/$taskId/run/$runId/preview/$port': {
       id: '/_layout/$teamSlugOrId/task/$taskId/run/$runId/preview/$port'
       path: '/run/$runId/preview/$port'
@@ -759,6 +779,7 @@ const LayoutTeamSlugOrIdPrsRouteWithChildren =
 
 interface LayoutTeamSlugOrIdTaskTaskIdRouteChildren {
   LayoutTeamSlugOrIdTaskTaskIdIndexRoute: typeof LayoutTeamSlugOrIdTaskTaskIdIndexRoute
+  LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute
   LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute: typeof LayoutTeamSlugOrIdTaskTaskIdRunRunIdVscodeRoute
@@ -770,6 +791,8 @@ const LayoutTeamSlugOrIdTaskTaskIdRouteChildren: LayoutTeamSlugOrIdTaskTaskIdRou
   {
     LayoutTeamSlugOrIdTaskTaskIdIndexRoute:
       LayoutTeamSlugOrIdTaskTaskIdIndexRoute,
+    LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute:
+      LayoutTeamSlugOrIdTaskTaskIdRunRunIdBrowserRoute,
     LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute:
       LayoutTeamSlugOrIdTaskTaskIdRunRunIdDiffRoute,
     LayoutTeamSlugOrIdTaskTaskIdRunRunIdPrRoute:

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
@@ -1,0 +1,144 @@
+import { PersistentWebView } from "@/components/persistent-webview";
+import { getTaskRunBrowserPersistKey } from "@/lib/persistent-webview-keys";
+import {
+  TASK_RUN_IFRAME_ALLOW,
+  TASK_RUN_IFRAME_SANDBOX,
+} from "@/lib/preloadTaskRunIframes";
+import { toMorphVncUrl } from "@/lib/toProxyWorkspaceUrl";
+import { api } from "@cmux/convex/api";
+import { typedZid } from "@cmux/shared/utils/typed-zid";
+import { convexQuery } from "@convex-dev/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import clsx from "clsx";
+import { useCallback, useMemo } from "react";
+import z from "zod";
+
+const paramsSchema = z.object({
+  taskId: typedZid("tasks"),
+  runId: typedZid("taskRuns"),
+});
+
+export const Route = createFileRoute(
+  "/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser"
+)({
+  component: BrowserComponent,
+  params: {
+    parse: paramsSchema.parse,
+    stringify: (params) => ({
+      taskId: params.taskId,
+      runId: params.runId,
+    }),
+  },
+  loader: async (opts) => {
+    await opts.context.queryClient.ensureQueryData(
+      convexQuery(api.taskRuns.get, {
+        teamSlugOrId: opts.params.teamSlugOrId,
+        id: opts.params.runId,
+      })
+    );
+  },
+});
+
+function BrowserComponent() {
+  const { runId: taskRunId, teamSlugOrId } = Route.useParams();
+  const taskRun = useSuspenseQuery(
+    convexQuery(api.taskRuns.get, {
+      teamSlugOrId,
+      id: taskRunId,
+    })
+  );
+
+  const vscodeInfo = taskRun?.data?.vscode;
+  const rawMorphUrl = vscodeInfo?.url ?? vscodeInfo?.workspaceUrl ?? null;
+  const vncUrl = useMemo(() => {
+    if (!rawMorphUrl) {
+      return null;
+    }
+    return toMorphVncUrl(rawMorphUrl);
+  }, [rawMorphUrl]);
+
+  const persistKey = getTaskRunBrowserPersistKey(taskRunId);
+  const hasBrowserView = Boolean(vncUrl);
+  const isMorphProvider = vscodeInfo?.provider === "morph";
+  const showLoader = isMorphProvider && !hasBrowserView;
+
+  const overlayMessage = useMemo(() => {
+    if (!isMorphProvider) {
+      return "Browser is only available for Morph-based runs.";
+    }
+    if (!hasBrowserView) {
+      return "Waiting for Morph workspace to expose the browser...";
+    }
+    return "Launching browser...";
+  }, [hasBrowserView, isMorphProvider]);
+
+  const onLoad = useCallback(() => {
+    console.log(`Browser view loaded for task run ${taskRunId}`);
+  }, [taskRunId]);
+
+  const onError = useCallback(
+    (error: Error) => {
+      console.error(
+        `Failed to load browser view for task run ${taskRunId}:`,
+        error
+      );
+    },
+    [taskRunId]
+  );
+
+  return (
+    <div className="pl-1 flex flex-col grow bg-neutral-50 dark:bg-black">
+      <div className="flex flex-col grow min-h-0 border-l border-neutral-200 dark:border-neutral-800">
+        <div className="flex flex-row grow min-h-0 relative">
+          {vncUrl ? (
+            <PersistentWebView
+              persistKey={persistKey}
+              src={vncUrl}
+              className="grow flex relative"
+              iframeClassName="select-none"
+              sandbox={TASK_RUN_IFRAME_SANDBOX}
+              allow={TASK_RUN_IFRAME_ALLOW}
+              retainOnUnmount
+              onLoad={onLoad}
+              onError={onError}
+            />
+          ) : (
+            <div className="grow" />
+          )}
+          <div
+            className={clsx(
+              "absolute inset-0 flex items-center justify-center transition pointer-events-none",
+              {
+                "opacity-100": !hasBrowserView,
+                "opacity-0": hasBrowserView,
+              }
+            )}
+          >
+            <div className="flex flex-col items-center gap-3 text-center px-4">
+              {showLoader ? (
+                <div className="flex gap-1">
+                  <div
+                    className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                    style={{ animationDelay: "0ms" }}
+                  />
+                  <div
+                    className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                    style={{ animationDelay: "150ms" }}
+                  />
+                  <div
+                    className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                    style={{ animationDelay: "300ms" }}
+                  />
+                </div>
+              ) : null}
+              <span className="text-sm text-neutral-500 dark:text-neutral-400">
+                {overlayMessage}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
add the vnc thing right below Git Diff and call it Browser, it should render morph port 39380 url + /vnc.html with url query params for auto connect and local scaling. should only apply to cloud/morph instances. do not rely on the vscode ports. we only need morph instance id and we can just auto-infer 39378 and 39380 and render them immediately. do not use proxy url, just use the morph.so url (might have to rebuild it with morph id if necessary, but use your best judgment)actually, do we even need to use vnc.html in an iframe? can't we just make a react comopnent and connect to the right port?