### PR TITLE
Guard restart prompts until update is ready

### DIFF
--- a/apps/client/electron/preload/index.d.ts
+++ b/apps/client/electron/preload/index.d.ts
@@ -39,6 +39,7 @@ declare global {
             reason?: string;
             updateAvailable?: boolean;
             version?: string | null;
+            alreadyDownloaded?: boolean;
           }>;
         install: () => Promise<{ ok: boolean; reason?: string }>;
       };

--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -427,7 +427,13 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
             if (!cmux?.autoUpdate?.check) {
               toast.error("Update checks are currently unavailable.");
             } else {
+              // Show loading toast while checking
+              const checkingToastId = toast.loading("Checking for updates...");
+
               const result = await cmux.autoUpdate.check();
+
+              // Dismiss the loading toast
+              toast.dismiss(checkingToastId);
 
               if (!result?.ok) {
                 if (result?.reason === "not-packaged") {
@@ -439,9 +445,18 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
                 const versionLabel = result.version
                   ? ` (${result.version})`
                   : "";
-                toast.success(
-                  `Update available${versionLabel}. Downloading in the background.`,
-                );
+
+                if (result.alreadyDownloaded) {
+                  // Update is already downloaded and ready to install
+                  toast.success(
+                    `Update ready to install${versionLabel}. Restart to apply.`,
+                  );
+                } else {
+                  // Update is available but needs to download
+                  toast.success(
+                    `Update available${versionLabel}. Downloading in the background.`,
+                  );
+                }
               } else {
                 toast.info("You're up to date.");
               }

--- a/apps/client/src/types/electron.d.ts
+++ b/apps/client/src/types/electron.d.ts
@@ -114,6 +114,7 @@ interface CmuxAPI {
         reason?: string;
         updateAvailable?: boolean;
         version?: string | null;
+        alreadyDownloaded?: boolean;
       }>;
     install: () => Promise<{ ok: boolean; reason?: string }>;
   };


### PR DESCRIPTION
we need to figure out why the autoupdates doesn't show when the update is ready. check the logs [MAIN] [2025-10-14T02:13:39.280Z] Setting up auto-updates { appVersion: '1.0.92', platform: 'darwin', arch: 'arm64' }
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.280Z] Configured autoUpdater channel { channel: 'latest-arm64', arch: 'arm64' }
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.280Z] Auto-updater configuration complete {
  autoDownload: true,
  autoInstallOnAppQuit: true,
  allowPrerelease: false,
  channel: 'latest-arm64'
}
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.280Z] Starting initial auto-update check
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.280Z] [updater] Checking for update
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.281Z] Checking for update…
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.281Z] Loading renderer (prod) { host: 'cmux.local' }
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.351Z] did-navigate { url: 'https://cmux.local/index.html' }
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.620Z] Window ready-to-show
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.626Z] did-frame-finish-load {
  isMainFrame: true,
  frameProcessId: 4,
  frameRoutingId: 1,
  frameUrl: 'https://cmux.local/index.html'
}
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.626Z] Renderer finished load
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.751Z] [updater] Found version 1.0.93 (url: cmux-1.0.93-arm64-mac.zip, cmux-1.0.93-arm64.dmg)
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.751Z] Update available 1.0.93
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.751Z] [updater] Downloading update from cmux-1.0.93-arm64-mac.zip, cmux-1.0.93-arm64.dmg
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.755Z] [updater] Checked for macOS Rosetta environment (isRosetta=false)
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.757Z] [updater] Checked 'uname -a': arm64=true
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:39.757Z] Initial checkForUpdatesAndNotify completed {
  updateAvailable: true,
  version: '1.0.93',
  releaseDate: '2025-10-13T13:20:03.002Z',
  fileCount: 2,
  stagingPercentage: null
}
index-CaNPJ_lt.js:71961 signalConvexAuthReady true
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:40.011Z] [updater] Update has already been downloaded to /Users/austinwang/Library/Caches/@cmuxclient-updater/pending/cmux-1.0.93-arm64-mac.zip).
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:40.338Z] Update downloaded; notifying renderer { version: null }
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:40.489Z] [updater] / requested
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:40.491Z] [updater] /2742e7ccb0044e9a35ff22fbde7adcaaba4070d43a462818aeb2e24d81108f40f660caf7fade78fa63afbbade7b8ab5ebc3bdcff11d3ed5a428d1a5cfdfe2889.zip requested
VM119 index.cjs:225 [MAIN] [2025-10-14T02:13:40.491Z] [updater] /2742e7ccb0044e9a35ff22fbde7adcaaba4070d43a462818aeb2e24d81108f40f660caf7fade78fa63afbbade7b8ab5ebc3bdcff11d3ed5a428d1a5cfdfe2889.zip requested by Squirrel.Mac, pipe /Users/austinwang/Library/Caches/@cmuxclient-updater/pending/cmux-1.0.93-arm64-mac.zip
_layout-BflcNv3m.js:3530 [ElectronSocket] No auth token yet; delaying connect
(anonymous) @ _layout-BflcNv3m.js:3530
_layout-BflcNv3m.js:3546 [ElectronSocket] Connecting via IPC (cmux)...
_layout-BflcNv3m.js:3562 [ElectronSocket] Available editors: Object
_layout-BflcNv3m.js:3562 [ElectronSocket] Available editors: Object
index-CaNPJ_lt.js:71961 signalConvexAuthReady true... also if user clicks check for updates and the update is not ready... then it won't work. we should not be showing the restart for updates until it's ready? add a modal checking for updates until we are done with the checking the udpates otherwise it'll just restart the cmux app without actually updating cuz it wasn't ready and the modal showed right after check for updates becuse it is forced to show?