### PR TITLE
Add iframe resume hook and use env origin

### DIFF
--- a/apps/client/src/components/persistent-iframe.tsx
+++ b/apps/client/src/components/persistent-iframe.tsx
@@ -9,6 +9,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { usePersistentIframe } from "../hooks/usePersistentIframe";
+import { useIframePreflightStream } from "../hooks/useIframePreflightStream";
 import { cn } from "@/lib/utils";
 
 export type PersistentIframeStatus = "loading" | "loaded" | "error";
@@ -36,57 +37,6 @@ interface PersistentIframeProps {
 }
 
 type ScrollTarget = HTMLElement | Window;
-
-interface IframePreflightResult {
-  ok: boolean;
-  status: number | null;
-  method: "HEAD" | "GET" | null;
-  error?: string;
-}
-
-function parseIframePreflightResult(
-  raw: unknown,
-): IframePreflightResult | null {
-  if (typeof raw !== "object" || raw === null) {
-    return null;
-  }
-
-  const record = raw as Record<string, unknown>;
-  const { ok, status, method, error } = record;
-
-  if (typeof ok !== "boolean") {
-    return null;
-  }
-
-  let normalizedStatus: number | null;
-  if (status === null) {
-    normalizedStatus = null;
-  } else if (typeof status === "number" && Number.isInteger(status) && status >= 0) {
-    normalizedStatus = status;
-  } else {
-    return null;
-  }
-
-  let normalizedMethod: "HEAD" | "GET" | null;
-  if (method === null) {
-    normalizedMethod = null;
-  } else if (method === "HEAD" || method === "GET") {
-    normalizedMethod = method;
-  } else {
-    return null;
-  }
-
-  if (error !== undefined && typeof error !== "string") {
-    return null;
-  }
-
-  return {
-    ok,
-    status: normalizedStatus,
-    method: normalizedMethod,
-    error,
-  };
-}
 
 function getScrollableParents(element: HTMLElement): ScrollTarget[] {
   const parents: ScrollTarget[] = [];
@@ -137,7 +87,6 @@ export function PersistentIframe({
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const [, forceRender] = useState(0);
   const loadTimeoutRef = useRef<number | null>(null);
-  const preflightAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setStatus("loading");
@@ -201,6 +150,15 @@ export function PersistentIframe({
     status,
   ]);
 
+  // Use the streaming preflight hook
+  const preflightState = useIframePreflightStream({
+    url: src,
+    enabled: preflight && Boolean(src),
+    onError: (error) => {
+      handleError(new Error(error));
+    },
+  });
+
   const { containerRef } = usePersistentIframe({
     key: persistKey,
     url: src,
@@ -218,94 +176,6 @@ export function PersistentIframe({
   useEffect(() => {
     onStatusChange?.(effectiveStatus);
   }, [effectiveStatus, onStatusChange]);
-
-  useEffect(() => {
-    if (!preflight) {
-      return;
-    }
-    if (!src) {
-      return;
-    }
-    if (typeof window === "undefined" || typeof fetch === "undefined") {
-      return;
-    }
-
-    preflightAbortRef.current?.abort();
-    const controller = new AbortController();
-    preflightAbortRef.current = controller;
-
-    const runPreflight = async () => {
-      try {
-        const searchParams = new URLSearchParams({ url: src });
-        const response = await fetch(
-          `/api/iframe/preflight?${searchParams.toString()}`,
-          {
-            method: "GET",
-            cache: "no-store",
-            credentials: "include",
-            signal: controller.signal,
-          },
-        );
-
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        if (!response.ok) {
-          handleError(
-            new Error(
-              `Preflight request failed (status ${response.status}) for iframe "${persistKey}"`,
-            ),
-          );
-          return;
-        }
-
-        const payload = parseIframePreflightResult(await response.json());
-
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        if (!payload) {
-          handleError(
-            new Error(
-              `Preflight returned an unexpected response for iframe "${persistKey}"`,
-            ),
-          );
-          return;
-        }
-
-        if (!payload.ok) {
-          const statusText =
-            payload.status !== null ? `status ${payload.status}` : "an error";
-          handleError(
-            new Error(
-              payload.error ??
-                `Preflight failed (${statusText}) for iframe "${persistKey}"`,
-            ),
-          );
-        }
-      } catch (error) {
-        if (controller.signal.aborted) {
-          return;
-        }
-        handleError(
-          error instanceof Error
-            ? error
-            : new Error(`Preflight failed for iframe "${persistKey}"`),
-        );
-      }
-    };
-
-    void runPreflight();
-
-    return () => {
-      controller.abort();
-      if (preflightAbortRef.current === controller) {
-        preflightAbortRef.current = null;
-      }
-    };
-  }, [handleError, persistKey, preflight, src]);
 
   const showLoadingOverlay = effectiveStatus === "loading" && loadingFallback;
   const showErrorOverlay = effectiveStatus === "error" && errorFallback;

--- a/apps/client/src/hooks/useIframePreflightStream.ts
+++ b/apps/client/src/hooks/useIframePreflightStream.ts
@@ -1,0 +1,227 @@
+import { useEffect, useRef, useState } from "react";
+import { WWW_ORIGIN } from "@/lib/wwwOrigin";
+
+export type IframePreflightState =
+  | { status: "idle" }
+  | { status: "loading"; message?: string }
+  | { status: "resuming"; message?: string }
+  | { status: "ready"; message?: string }
+  | { status: "error"; message: string }
+  | { status: "instance_not_found"; message?: string };
+
+interface UseIframePreflightStreamOptions {
+  url: string;
+  enabled?: boolean;
+  onReady?: () => void;
+  onError?: (error: string) => void;
+}
+
+interface StreamEvent {
+  type: "loading" | "resuming" | "ready" | "error" | "instance_not_found";
+  message?: string;
+}
+
+export function useIframePreflightStream({
+  url,
+  enabled = true,
+  onReady,
+  onError,
+}: UseIframePreflightStreamOptions): IframePreflightState {
+  const [state, setState] = useState<IframePreflightState>({ status: "idle" });
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const lastUrlRef = useRef<string>("");
+  const lastStateRef = useRef<IframePreflightState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!enabled || !url) {
+      setState({ status: "idle" });
+      return;
+    }
+
+    // If the URL hasn't changed, don't restart
+    if (url === lastUrlRef.current && state.status !== "idle") {
+      return;
+    }
+
+    lastUrlRef.current = url;
+
+    // Cancel any ongoing request
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setState({ status: "loading", message: "Initializing..." });
+
+    const runPreflight = async () => {
+      try {
+        const searchParams = new URLSearchParams({ url });
+        const response = await fetch(
+          `${WWW_ORIGIN}/api/iframe/preflight-stream?${searchParams.toString()}`,
+          {
+            method: "GET",
+            cache: "no-store",
+            credentials: "include",
+            signal: controller.signal,
+          },
+        );
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        if (!response.ok) {
+          setState({
+            status: "error",
+            message: `Preflight request failed (status ${response.status})`,
+          });
+          onError?.(
+            `Preflight request failed (status ${response.status})`,
+          );
+          return;
+        }
+
+        if (!response.body) {
+          setState({
+            status: "error",
+            message: "Response body is null",
+          });
+          onError?.("Response body is null");
+          return;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+
+          if (controller.signal.aborted) {
+            reader.cancel();
+            return;
+          }
+
+          if (done) {
+            break;
+          }
+
+          // Decode the chunk and add to buffer
+          buffer += decoder.decode(value, { stream: true });
+
+          // Process complete SSE messages
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || ""; // Keep incomplete line in buffer
+
+          for (const line of lines) {
+            if (controller.signal.aborted) {
+              return;
+            }
+
+            // SSE format: "data: <json>"
+            if (line.startsWith("data: ")) {
+              const data = line.slice(6); // Remove "data: " prefix
+              try {
+                const event = JSON.parse(data) as StreamEvent;
+
+                switch (event.type) {
+                  case "loading":
+                    {
+                      const newState = {
+                        status: "loading" as const,
+                        message: event.message,
+                      };
+                      setState(newState);
+                      lastStateRef.current = newState;
+                    }
+                    break;
+                  case "resuming":
+                    {
+                      const newState = {
+                        status: "resuming" as const,
+                        message: event.message,
+                      };
+                      setState(newState);
+                      lastStateRef.current = newState;
+                    }
+                    break;
+                  case "ready":
+                    {
+                      const newState = {
+                        status: "ready" as const,
+                        message: event.message,
+                      };
+                      setState(newState);
+                      lastStateRef.current = newState;
+                      onReady?.();
+                    }
+                    return; // Stop processing
+                  case "error":
+                    {
+                      const newState = {
+                        status: "error" as const,
+                        message: event.message || "Unknown error occurred",
+                      };
+                      setState(newState);
+                      lastStateRef.current = newState;
+                      onError?.(event.message || "Unknown error occurred");
+                    }
+                    return; // Stop processing
+                  case "instance_not_found":
+                    {
+                      const newState = {
+                        status: "instance_not_found" as const,
+                        message: event.message,
+                      };
+                      setState(newState);
+                      lastStateRef.current = newState;
+                      onError?.(
+                        event.message || "Instance not found",
+                      );
+                    }
+                    return; // Stop processing
+                }
+              } catch (parseError) {
+                console.error("Failed to parse SSE event:", parseError);
+              }
+            }
+          }
+        }
+
+        // If we reach here without a terminal state, consider it an error
+        const currentStatus = lastStateRef.current.status;
+        if (currentStatus === "loading" || currentStatus === "resuming") {
+          const newState = {
+            status: "error" as const,
+            message: "Stream ended unexpectedly",
+          };
+          setState(newState);
+          lastStateRef.current = newState;
+          onError?.("Stream ended unexpectedly");
+        }
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error occurred";
+        setState({
+          status: "error",
+          message: errorMessage,
+        });
+        onError?.(errorMessage);
+      }
+    };
+
+    void runPreflight();
+
+    return () => {
+      controller.abort();
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = null;
+      }
+    };
+  }, [enabled, url, onReady, onError]);
+
+  return state;
+}

--- a/apps/www/lib/routes/iframe-preflight.route.ts
+++ b/apps/www/lib/routes/iframe-preflight.route.ts
@@ -1,5 +1,8 @@
 import { getAccessTokenFromRequest } from "@/lib/utils/auth";
+import { env } from "@/lib/utils/www-env";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { streamSSE } from "hono/streaming";
+import { MorphCloudClient } from "morphcloud";
 
 const ALLOWED_HOST_SUFFIXES = [
   ".cmux.sh",
@@ -23,6 +26,32 @@ const ALLOWED_EXACT_HOSTS = new Set<string>([
 ]);
 
 const DEV_ONLY_HOSTS = new Set<string>(["localhost", "127.0.0.1", "::1"]);
+
+const MORPH_HOST_REGEX = /^port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so$/;
+
+interface MorphUrlComponents {
+  morphInstanceId: string;
+  port: number;
+}
+
+function parseMorphUrl(url: URL): MorphUrlComponents | null {
+  const match = url.hostname.match(MORPH_HOST_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const [, portString, morphId] = match;
+  const port = Number.parseInt(portString, 10);
+
+  if (Number.isNaN(port)) {
+    return null;
+  }
+
+  return {
+    morphInstanceId: `morphvm_${morphId}`,
+    port,
+  };
+}
 
 function isAllowedHost(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
@@ -220,5 +249,281 @@ iframePreflightRouter.openapi(
             : "Unknown error during preflight.",
       });
     }
+  },
+);
+
+// Streaming version that handles instance resuming for Morph URLs
+iframePreflightRouter.openapi(
+  createRoute({
+    method: "get",
+    path: "/iframe/preflight-stream",
+    tags: ["Iframe"],
+    summary: "Stream iframe preflight status with instance resume support.",
+    request: {
+      query: QuerySchema,
+    },
+    responses: {
+      200: {
+        description:
+          "Server-sent events stream of preflight status updates, including instance resume attempts.",
+        content: {
+          "text/event-stream": {
+            schema: z.object({
+              type: z.enum([
+                "loading",
+                "resuming",
+                "ready",
+                "error",
+                "instance_not_found",
+              ]),
+              message: z.string().optional(),
+            }),
+          },
+        },
+      },
+      401: {
+        description: "Request is missing valid authentication.",
+      },
+      400: {
+        description: "The provided URL was not valid.",
+      },
+      403: {
+        description: "The target host is not permitted.",
+      },
+    },
+  }),
+  async (c) => {
+    const accessToken = await getAccessTokenFromRequest(c.req.raw);
+    if (!accessToken) {
+      return c.json(
+        {
+          ok: false,
+          status: null,
+          method: null,
+          error: "Unauthorized",
+        },
+        401,
+      );
+    }
+
+    const { url } = c.req.valid("query");
+    const target = new URL(url);
+
+    if (target.protocol !== "https:" && target.protocol !== "http:") {
+      return c.json(
+        {
+          ok: false,
+          status: null,
+          method: null,
+          error: "Only HTTP(S) URLs are supported.",
+        },
+        400,
+      );
+    }
+
+    if (target.username || target.password) {
+      return c.json(
+        {
+          ok: false,
+          status: null,
+          method: null,
+          error: "Authentication credentials in URL are not supported.",
+        },
+        400,
+      );
+    }
+
+    if (!isAllowedHost(target.hostname)) {
+      return c.json(
+        {
+          ok: false,
+          status: null,
+          method: null,
+          error: `Requests to ${target.hostname} are not permitted.`,
+        },
+        403,
+      );
+    }
+
+    return streamSSE(c, async (stream) => {
+      const sendEvent = async (type: string, message?: string) => {
+        await stream.writeSSE({
+          data: JSON.stringify({ type, message }),
+          event: "message",
+        });
+      };
+
+      try {
+        await sendEvent("loading", "Checking iframe target...");
+
+        // Check if this is a Morph URL
+        const morphComponents = parseMorphUrl(target);
+
+        if (morphComponents) {
+          // This is a Morph URL - attempt to resume the instance
+          await sendEvent("resuming", "Resuming instance...");
+
+          try {
+            const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
+            const instance = await client.instances.get({
+              instanceId: morphComponents.morphInstanceId,
+            });
+
+            // Check the instance state
+            const state = (instance as unknown as { state?: string }).state;
+
+            if (state === "paused") {
+              // Instance is paused, resume it with retries
+              const maxRetries = 3;
+              let attempt = 0;
+              let resumed = false;
+
+              while (attempt < maxRetries && !resumed) {
+                attempt++;
+                try {
+                  await sendEvent(
+                    "resuming",
+                    `Resuming instance (attempt ${attempt}/${maxRetries})...`,
+                  );
+                  await instance.resume();
+
+                  // Wait a moment for the instance to be ready
+                  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+                  // Verify the instance is running
+                  const updatedInstance = await client.instances.get({
+                    instanceId: morphComponents.morphInstanceId,
+                  });
+                  const updatedState = (
+                    updatedInstance as unknown as { state?: string }
+                  ).state;
+
+                  if (updatedState === "running") {
+                    resumed = true;
+                    await sendEvent(
+                      "resuming",
+                      "Instance resumed successfully, waiting for services...",
+                    );
+                  }
+                } catch (error) {
+                  if (attempt >= maxRetries) {
+                    await sendEvent(
+                      "error",
+                      `Failed to resume instance after ${maxRetries} attempts: ${error instanceof Error ? error.message : "Unknown error"}`,
+                    );
+                    return;
+                  }
+                  // Wait before retrying
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                }
+              }
+
+              if (!resumed) {
+                await sendEvent(
+                  "error",
+                  "Failed to resume instance after multiple attempts",
+                );
+                return;
+              }
+            }
+
+            // Instance is running or was successfully resumed
+            // Now probe the target URL
+            await sendEvent("resuming", "Probing iframe target...");
+
+            const probe = async (method: "HEAD" | "GET") => {
+              const response = await fetch(target, {
+                method,
+                redirect: "manual",
+              });
+              await response.body?.cancel().catch(() => undefined);
+              return response;
+            };
+
+            // Try HEAD request first
+            const headResponse = await probe("HEAD");
+
+            if (headResponse.ok) {
+              await sendEvent("ready", "Iframe target is ready");
+              return;
+            }
+
+            // If HEAD fails with 405, try GET
+            if (headResponse.status === 405) {
+              const getResponse = await probe("GET");
+              if (getResponse.ok) {
+                await sendEvent("ready", "Iframe target is ready");
+                return;
+              }
+              await sendEvent(
+                "error",
+                `Target responded with status ${getResponse.status}`,
+              );
+              return;
+            }
+
+            await sendEvent(
+              "error",
+              `Target responded with status ${headResponse.status}`,
+            );
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              error.message.includes("not found")
+            ) {
+              await sendEvent(
+                "instance_not_found",
+                "Instance not found or no longer exists",
+              );
+            } else {
+              await sendEvent(
+                "error",
+                `Failed to interact with instance: ${error instanceof Error ? error.message : "Unknown error"}`,
+              );
+            }
+          }
+        } else {
+          // Not a Morph URL - just do a simple probe
+          const probe = async (method: "HEAD" | "GET") => {
+            const response = await fetch(target, {
+              method,
+              redirect: "manual",
+            });
+            await response.body?.cancel().catch(() => undefined);
+            return response;
+          };
+
+          const headResponse = await probe("HEAD");
+
+          if (headResponse.ok) {
+            await sendEvent("ready", "Iframe target is ready");
+            return;
+          }
+
+          if (headResponse.status === 405) {
+            const getResponse = await probe("GET");
+            if (getResponse.ok) {
+              await sendEvent("ready", "Iframe target is ready");
+              return;
+            }
+            await sendEvent(
+              "error",
+              `Request failed with status ${getResponse.status}`,
+            );
+            return;
+          }
+
+          await sendEvent(
+            "error",
+            `Request failed with status ${headResponse.status}`,
+          );
+        }
+      } catch (error) {
+        await sendEvent(
+          "error",
+          error instanceof Error ? error.message : "Unknown error occurred",
+        );
+      }
+    });
   },
 );


### PR DESCRIPTION
apps/www/lib/routes/iframe-preflight.route.ts find the frontend iframe stuff that calls this. if the iframe is linking to a morph page or a proxy leading to a morph page, we need to try to recreate the instanceid and call resume:import { MorphCloudClient } from 'morphcloud';const client = new MorphCloudClient();async function pauseInstance() {  const instance_id = "morphvm_abc123"; // Replace with a valid instance ID  const instance = await client.instances.get({ instance_id: instance_id });  await instance.pause();  console.log(`Instance '${instance_id}' paused.`);}pauseInstance();make a custom hook that will hold state. different states we need to handle:loading -> resuming iframe -> iframe readyloading -> resuming iframe -> failed to resume, even after retriesloading -> couldn't find instanceuse hono stream helper. react hook needs to consume the stream and set the states properly.also, we're talking to the wrong backend endpoint:```tsconst response = await fetch(  `/api/iframe/preflight?${searchParams.toString()}`,  {    method: "GET",    cache: "no-store",    credentials: "include",    signal: controller.signal,  },);```We need to talk to env.NEXT_PUBLIC_WWW_ORIGIN instead.