### PR TITLE
Add global shortcut to toggle sidebar

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -91,6 +91,8 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
 
   // Keyboard shortcut to toggle sidebar (Ctrl+Shift+S)
   useEffect(() => {
+    if (isElectron) return;
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if (
         e.ctrlKey &&
@@ -104,6 +106,18 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (!isElectron) return;
+
+    const off = window.cmux.on("shortcut:sidebar-toggle", () => {
+      setIsHidden((prev) => !prev);
+    });
+
+    return () => {
+      if (typeof off === "function") off();
+    };
   }, []);
 
   // Listen for storage events from command bar


### PR DESCRIPTION
wire up global electron keyboard shortcut for sidebar toggle.. we have it currently working in cmux but it doesn't work for vscode. we need the global electron shortcut for ctrl + shift + s to be toggling the sidebar...