### PR TITLE
Fix loading z-index; extract zindex.css; update VS Code error

### DIFF
--- a/apps/client/src/components/persistent-iframe.tsx
+++ b/apps/client/src/components/persistent-iframe.tsx
@@ -296,7 +296,7 @@ export function PersistentIframe({
       overlay.style.top = "0";
       overlay.style.left = "0";
       overlay.style.pointerEvents = "none";
-      overlay.style.zIndex = "var(--z-global-blocking, 2147483647)";
+      overlay.style.zIndex = "var(--z-overlay, 9999)";
       overlay.style.visibility = "hidden";
       overlayRef.current = overlay;
       document.body.appendChild(overlay);

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -185,28 +185,6 @@
 
   --sidebar-ring: oklch(0.708 0 0);
 
-  /* Z-Index Tokens (centralized, descriptive) */
-  --z-base: 0; /* default content */
-  --z-low: 10; /* subtle indicators, pills */
-  --z-dropdown: 20; /* small dropdowns/menus attached to buttons */
-  --z-sticky-low: 40; /* sticky bars below modals */
-  --z-sticky: 50; /* sticky headers, lightweight modals */
-  --z-modal: var(--z-sticky); /* generic modal surfaces sharing 50 */
-
-  --z-overlay-behind: 9998; /* behind primary overlays */
-  --z-overlay: 9999; /* generic overlay/fab layers */
-  --z-context-menu: 10000; /* context menus */
-  --z-popover: 10001; /* anchored popovers/sheets */
-  --z-popover-hover: 10010; /* hover states within popovers */
-  --z-tooltip: 10020; /* tooltips above popovers */
-
-  --z-floating-high: 999999; /* transient floating UIs */
-  --z-global-blocking: 99999999; /* full-app blocking overlays (auth/boot) */
-  /* Keep resize handle above overlays but below popovers/menus */
-  --z-sidebar-resize-handle: 10000; /* resize handle */
-
-  /* Highest in app: CommandBar must win over everything */
-  --z-commandbar: 100000000;
 }
 
 .dark {

--- a/apps/client/src/lib/persistentIframeManager.ts
+++ b/apps/client/src/lib/persistentIframeManager.ts
@@ -111,7 +111,7 @@ class PersistentIframeManager {
         width: 0;
         height: 0;
         pointer-events: none;
-        z-index: var(--z-overlay);
+        z-index: var(--z-iframe, 9998);
       `;
       document.body.appendChild(this.container);
     };

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { App } from "./app";
 
 import "./antd-overrides.css";
+import "./zindex.css";
 import "./index.css";
 
 // Global error logging to help diagnose loader stalls

--- a/apps/client/src/zindex.css
+++ b/apps/client/src/zindex.css
@@ -1,0 +1,24 @@
+:root {
+  /* Z-Index Tokens (centralized, descriptive) */
+  --z-base: 0; /* default content */
+  --z-low: 10; /* subtle indicators, pills */
+  --z-dropdown: 20; /* small dropdowns/menus attached to buttons */
+  --z-sticky-low: 40; /* sticky bars below modals */
+  --z-sticky: 50; /* sticky headers, lightweight modals */
+  --z-modal: var(--z-sticky); /* generic modal surfaces sharing 50 */
+
+  --z-overlay-behind: 9998; /* behind primary overlays */
+  --z-overlay: 9999; /* general overlays; sits below context menus/tooltips */
+  --z-context-menu: 10000; /* context menus */
+  --z-popover: 10001; /* anchored popovers/sheets */
+  --z-popover-hover: 10010; /* hover states within popovers */
+  --z-tooltip: 10020; /* tooltips above popovers */
+
+  --z-floating-high: 999999; /* transient floating UIs */
+  --z-global-blocking: 99999999; /* full-app blocking overlays (auth/boot) */
+  /* Keep resize handle above overlays but below popovers/menus */
+  --z-sidebar-resize-handle: 10000; /* resize handle */
+
+  /* Highest in app: CommandBar must win over everything */
+  --z-commandbar: 100000000;
+}

--- a/apps/client/src/zindex.css
+++ b/apps/client/src/zindex.css
@@ -7,7 +7,8 @@
   --z-sticky: 50; /* sticky headers, lightweight modals */
   --z-modal: var(--z-sticky); /* generic modal surfaces sharing 50 */
 
-  --z-overlay-behind: 9998; /* behind primary overlays */
+  --z-iframe: 9997; /* persistent iframes; just below overlays */
+  --z-overlay-behind: 9997; /* behind primary overlays */
   --z-overlay: 9999; /* general overlays; sits below context menus/tooltips */
   --z-context-menu: 10000; /* context menus */
   --z-popover: 10001; /* anchored popovers/sheets */
@@ -17,7 +18,7 @@
   --z-floating-high: 999999; /* transient floating UIs */
   --z-global-blocking: 99999999; /* full-app blocking overlays (auth/boot) */
   /* Keep resize handle above overlays but below popovers/menus */
-  --z-sidebar-resize-handle: 10000; /* resize handle */
+  --z-sidebar-resize-handle: 9998; /* resize handle */
 
   /* Highest in app: CommandBar must win over everything */
   --z-commandbar: 100000000;

--- a/apps/preview-proxy/src/App.tsx
+++ b/apps/preview-proxy/src/App.tsx
@@ -1,6 +1,7 @@
 import { APITester } from "./APITester";
 import { useEffect } from "react";
 import { initCmuxComments } from "./cmux-comments/cmux-comments";
+import "./zindex.css";
 import "./index.css";
 
 import logo from "./logo.svg";

--- a/apps/preview-proxy/src/zindex.css
+++ b/apps/preview-proxy/src/zindex.css
@@ -1,0 +1,20 @@
+:root {
+  --z-base: 0;
+  --z-low: 10;
+  --z-dropdown: 20;
+  --z-sticky-low: 40;
+  --z-sticky: 50;
+  --z-modal: var(--z-sticky);
+
+  --z-overlay-behind: 9998;
+  --z-overlay: 9999;
+  --z-context-menu: 10000;
+  --z-popover: 10001;
+  --z-popover-hover: 10010;
+  --z-tooltip: 10020;
+
+  --z-floating-high: 999999;
+  --z-global-blocking: 99999999;
+  --z-sidebar-resize-handle: 10000;
+  --z-commandbar: 100000000;
+}

--- a/apps/preview-proxy/src/zindex.css
+++ b/apps/preview-proxy/src/zindex.css
@@ -6,6 +6,7 @@
   --z-sticky: 50;
   --z-modal: var(--z-sticky);
 
+  --z-iframe: 9998;
   --z-overlay-behind: 9998;
   --z-overlay: 9999;
   --z-context-menu: 10000;


### PR DESCRIPTION
the "We couldn't launch VS Code Refresh the page or try rerunning the task. " and for all loading state persistent thing z index is too high. it needs to be below popovers like tooltips and right click context menus. while we're at it, extract z index css variables into its own css file maybe like zindex.css and make sure to import it where the main index.css is imported. then make sure to choose or create a z index that makes sense (below the tooltip but above all iframes)