### PR TITLE
Stabilize local docker startup and reconnect

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -38,6 +38,8 @@ const SWITCH_BRANCH_BUN_SCRIPT = rawSwitchBranchScript;
 
 const { getApiEnvironmentsByIdVars } = await getWwwOpenApiModule();
 
+const LOOPBACK_HOST = process.env.CMUX_LOOPBACK_HOST?.trim() || "127.0.0.1";
+
 export interface AgentSpawnResult {
   agentName: string;
   terminalId: string;
@@ -832,7 +834,7 @@ exit $EXIT_CODE
               ? (vscodeInstance as DockerVSCodeInstance).getPorts()?.worker
               : "39377";
 
-          const uploadUrl = `http://localhost:${workerPort}/upload-image`;
+          const uploadUrl = `http://${LOOPBACK_HOST}:${workerPort}/upload-image`;
 
           serverLogger.info(`[AgentSpawner] Uploading image to ${uploadUrl}`);
 

--- a/apps/server/src/scripts/test-agent-spawner.ts
+++ b/apps/server/src/scripts/test-agent-spawner.ts
@@ -95,7 +95,9 @@ async function main() {
         console.log("\n\nChecking if terminal is still running...");
 
         // Check container and tmux status
-        const containerId = result.vscodeUrl?.match(/localhost:(\d+)/)?.[1];
+        const containerId = result.vscodeUrl?.match(
+          /(?:localhost|127\.0\.0\.1):(\d+)/
+        )?.[1];
         if (containerId) {
           try {
             const { execSync } = await import("child_process");


### PR DESCRIPTION
there is some issue with local docker mode. sometimes vscode instances dont start for some reason. we need to make sure that they start.. it might be because of these errors. fix workbench.js:34   ERR CodeExpectedError: WebSocket close with status code 1006    at WebSocket.<anonymous> (workbench.js:3650:22532)
workbench.js:34   ERR [remote-connection][Management   ][90f5c…][reconnect][WebSocket(localhost:32897)] socketFactory.connect() failed or timed out. Error:workbench.js:34   ERR CodeExpectedError: WebSocket close with status code 1006    at WebSocket.<anonymous> (workbench.js:3650:22532)workbench.js:34  INFO [remote-connection][Management   ][90f5c…][reconnect] A temporarily not available error occurred while trying to reconnect, will try again...workbench.js:34  INFO [remote-connection][Management   ][90f5c…][reconnect] waiting for 10 seconds before reconnecting... WebSocket connection to 'ws://localhost:32897/stable-117906114228e557ec421c03807eec59d7736135?reconnectionToken=6857458f-6b63-467c-9767-0fc179d7e299&reconnection=true&skipWebSocketFrames=false' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED WebSocket connection to 'ws://localhost:32897/stable-117906114228e557ec421c03807eec59d7736135?reconnectionToken=6857458f-6b63-467c-9767-0fc179d7e299&reconnection=true&skipWebSocketFrames=false' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED WebSocket connection to 'ws://localhost:32897/stable-117906114228e557ec421c03807eec59d7736135?reconnectionToken=6857458f-6b63-467c-9767-0fc179d7e299&reconnection=true&skipWebSocketFrames=false' failed: Error in connection establishment: net::ERR_CONNECTION_REFU