### PR TITLE
Increase vitest timeouts to 2 minutes for morph tests

### DIFF
--- a/apps/www/lib/routes/github.repos.route.test.ts
+++ b/apps/www/lib/routes/github.repos.route.test.ts
@@ -14,12 +14,17 @@ describe("githubReposRouter via SDK", () => {
     expect(res.response.status).toBe(401);
   });
 
-  it("returns repos for authenticated user", async () => {
-    const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
-    const res = await getApiIntegrationsGithubRepos({
-      client: testApiClient,
-      query: { team: "manaflow" },
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
+  it(
+    "returns repos for authenticated user",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
+      const res = await getApiIntegrationsGithubRepos({
+        client: testApiClient,
+        query: { team: "manaflow" },
+        headers: { "x-stack-auth": JSON.stringify(tokens) },
     });
     // Accept 200 (OK), 401 (if token rejected), 500 (server error), or 501 (GitHub app not configured)
     expect([200, 401, 500, 501]).toContain(res.response.status);
@@ -39,7 +44,8 @@ describe("githubReposRouter via SDK", () => {
       expect(body.repos.length).toBeLessThanOrEqual(5);
       // No client-side sorting; server returns sorted by 'updated'.
     }
-  });
+    }
+  );
 
   it("can limit to a single installation when specified", async () => {
     const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();

--- a/apps/www/lib/routes/morph.route.test.ts
+++ b/apps/www/lib/routes/morph.route.test.ts
@@ -5,253 +5,278 @@ import { postApiMorphSetupInstance } from "@cmux/www-openapi-client";
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
 
-describe.skip("morphRouter - live", () => {
-  let createdInstanceId: string | null = null;
+describe(
+  "morphRouter - live",
+  {
+    timeout: 120_000,
+  },
+  () => {
+    let createdInstanceId: string | null = null;
 
-  afterAll(async () => {
-    if (!createdInstanceId) return;
-    try {
-      const inst = await __TEST_INTERNAL_ONLY_MORPH_CLIENT.instances.get({
-        instanceId: createdInstanceId,
-      });
-      await inst.stop();
-    } catch (e) {
-      console.warn("Morph cleanup failed:", e);
-    }
-  });
-  it("rejects unauthenticated requests", async () => {
-    const res = await postApiMorphSetupInstance({
-      client: testApiClient,
-      body: { teamSlugOrId: "manaflow", ttlSeconds: 120 },
-    });
-    expect(res.response.status).toBe(401);
-  });
-
-  it(
-    "creates and then reuses an instance with instanceId",
-    {
-      timeout: 20_000,
-    },
-    async () => {
-      const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
-      // First call: create new instance
-      const first = await postApiMorphSetupInstance({
-        client: testApiClient,
-        headers: { "x-stack-auth": JSON.stringify(tokens) },
-        body: { teamSlugOrId: "manaflow", ttlSeconds: 300 },
-      });
-      // Accept 200 (OK) or 500 (server error due to team/auth issues)
-      expect([200, 500]).toContain(first.response.status);
-      if (first.response.status !== 200) return; // Skip rest if server error
-      const firstBody = first.data as unknown as {
-        instanceId: string;
-        vscodeUrl: string;
-        clonedRepos: string[];
-        removedRepos: string[];
-      };
-      expect(typeof firstBody.instanceId).toBe("string");
-      expect(firstBody.instanceId.length).toBeGreaterThan(0);
-      expect(firstBody.vscodeUrl.includes("/?folder=/root/workspace")).toBe(
-        true
-      );
-      createdInstanceId = firstBody.instanceId;
-
-      // Second call: reuse existing instance by passing instanceId
-      const second = await postApiMorphSetupInstance({
-        client: testApiClient,
-        headers: { "x-stack-auth": JSON.stringify(tokens) },
-        body: {
-          teamSlugOrId: "manaflow",
-          instanceId: firstBody.instanceId,
-          ttlSeconds: 300,
-        },
-      });
-      expect(second.response.status).toBe(200);
-      const secondBody = second.data as unknown as {
-        instanceId: string;
-        vscodeUrl: string;
-        clonedRepos: string[];
-        removedRepos: string[];
-      };
-      expect(secondBody.instanceId).toBe(firstBody.instanceId);
-      expect(secondBody.vscodeUrl.includes("/?folder=/root/workspace")).toBe(
-        true
-      );
-    }
-  );
-
-  it("denies reusing an instance with a different team", async () => {
-    const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
-
-    // Ensure we have an instance to test against
-    if (!createdInstanceId) {
-      const first = await postApiMorphSetupInstance({
-        client: testApiClient,
-        headers: { "x-stack-auth": JSON.stringify(tokens) },
-        body: { teamSlugOrId: "manaflow", ttlSeconds: 300 },
-      });
-      if (first.response.status !== 200) {
-        console.warn("Skipping: failed to create instance for mismatch test");
-        return;
+    afterAll(async () => {
+      if (!createdInstanceId) return;
+      try {
+        const inst = await __TEST_INTERNAL_ONLY_MORPH_CLIENT.instances.get({
+          instanceId: createdInstanceId,
+        });
+        await inst.stop();
+      } catch (e) {
+        console.warn("Morph cleanup failed:", e);
       }
-      const firstBody = first.data as unknown as { instanceId: string };
-      createdInstanceId = firstBody.instanceId;
-    }
-
-    // Use a random team slug/id to simulate another org when only one team exists
-    // This should still be denied (either 403 for mismatch or 404 if team doesn't exist)
-    const otherTeamSlugOrId = `cmux-test-${randomUUID().slice(0, 8)}`;
-
-    const res = await postApiMorphSetupInstance({
-      client: testApiClient,
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
-      body: {
-        teamSlugOrId: otherTeamSlugOrId,
-        instanceId: createdInstanceId!,
-        ttlSeconds: 300,
-      },
     });
-    // Depending on environment, this may be 403 (mismatch), 404 (unknown team), or 500 (env/verification error)
-    expect([403, 404, 500]).toContain(res.response.status);
-  });
 
-  it("clones repos, removes, and re-adds correctly", async () => {
-    const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
-
-    const R1 = "manaflow-ai/manaflow-ai-cmux-testing-repo-1";
-    const R2 = "manaflow-ai/manaflow-ai-cmux-testing-repo-2";
-    const R3 = "manaflow-ai/manaflow-ai-cmux-testing-repo-3";
-    const N1 = "manaflow-ai-cmux-testing-repo-1";
-    const N2 = "manaflow-ai-cmux-testing-repo-2";
-    const N3 = "manaflow-ai-cmux-testing-repo-3";
-
-    // Ensure an instance exists for this sequence
-    if (!createdInstanceId) {
-      const first = await postApiMorphSetupInstance({
-        client: testApiClient,
-        headers: { "x-stack-auth": JSON.stringify(tokens) },
-        body: { teamSlugOrId: "manaflow", ttlSeconds: 900 },
-      });
-      // Accept 200 (OK) or 500 (server error due to team/auth issues)
-      expect([200, 500]).toContain(first.response.status);
-      if (first.response.status !== 200) {
-        throw new Error("Failed to create instance", { cause: first.error });
+    it(
+      "rejects unauthenticated requests",
+      {
+        timeout: 120_000,
+      },
+      async () => {
+        const res = await postApiMorphSetupInstance({
+          client: testApiClient,
+          body: { teamSlugOrId: "manaflow", ttlSeconds: 120 },
+        });
+        expect(res.response.status).toBe(401);
       }
-      if (!first.data) {
-        throw new Error("Failed to create instance", { cause: first.error });
+    );
+
+    it(
+      "creates and then reuses an instance with instanceId",
+      {
+        timeout: 120_000,
+      },
+      async () => {
+        const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
+        // First call: create new instance
+        const first = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: { teamSlugOrId: "manaflow", ttlSeconds: 300 },
+        });
+        // Accept 200 (OK) or 500 (server error due to team/auth issues)
+        expect([200, 500]).toContain(first.response.status);
+        if (first.response.status !== 200) return; // Skip rest if server error
+        const firstBody = first.data as unknown as {
+          instanceId: string;
+          vscodeUrl: string;
+          clonedRepos: string[];
+          removedRepos: string[];
+        };
+        expect(typeof firstBody.instanceId).toBe("string");
+        expect(firstBody.instanceId.length).toBeGreaterThan(0);
+        expect(firstBody.vscodeUrl.includes("/?folder=/root/workspace")).toBe(
+          true
+        );
+        createdInstanceId = firstBody.instanceId;
+
+        // Second call: reuse existing instance by passing instanceId
+        const second = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: {
+            teamSlugOrId: "manaflow",
+            instanceId: firstBody.instanceId,
+            ttlSeconds: 300,
+          },
+        });
+        expect(second.response.status).toBe(200);
+        const secondBody = second.data as unknown as {
+          instanceId: string;
+          vscodeUrl: string;
+          clonedRepos: string[];
+          removedRepos: string[];
+        };
+        expect(secondBody.instanceId).toBe(firstBody.instanceId);
+        expect(secondBody.vscodeUrl.includes("/?folder=/root/workspace")).toBe(
+          true
+        );
       }
-      createdInstanceId = first.data.instanceId;
-    }
+    );
 
-    // Step A: clone R1 + R2
-    const a = await postApiMorphSetupInstance({
-      client: testApiClient,
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
-      body: {
-        teamSlugOrId: "manaflow",
-        instanceId: createdInstanceId,
-        selectedRepos: [R1, R2],
-        ttlSeconds: 900,
+    it(
+      "denies reusing an instance with a different team",
+      {
+        timeout: 120_000,
       },
-    });
-    expect(a.response.status).toBe(200);
-    const aBody = a.data;
-    if (!aBody) {
-      throw new Error("Failed to create instance", { cause: a.error });
-    }
-    // Should have at least cloned these repos; removedRepos may contain pre-existing folders
-    expect(aBody.clonedRepos).toEqual(expect.arrayContaining([R1, R2]));
+      async () => {
+        const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
 
-    // Verify in-VM that R1 and R2 exist with correct remotes
-    const instA = await __TEST_INTERNAL_ONLY_MORPH_CLIENT.instances.get({
-      instanceId: createdInstanceId,
-    });
-    const r1Check = await instA.exec(
-      `bash -lc "test -d /root/workspace/${N1}/.git && git -C /root/workspace/${N1} remote get-url origin"`
-    );
-    const r2Check = await instA.exec(
-      `bash -lc "test -d /root/workspace/${N2}/.git && git -C /root/workspace/${N2} remote get-url origin"`
-    );
-    expect(r1Check.exit_code).toBe(0);
-    expect(r2Check.exit_code).toBe(0);
-    expect(r1Check.stdout).toContain(R1);
-    expect(r2Check.stdout).toContain(R2);
+        // Ensure we have an instance to test against
+        if (!createdInstanceId) {
+          const first = await postApiMorphSetupInstance({
+            client: testApiClient,
+            headers: { "x-stack-auth": JSON.stringify(tokens) },
+            body: { teamSlugOrId: "manaflow", ttlSeconds: 300 },
+          });
+          if (first.response.status !== 200) {
+            console.warn("Skipping: failed to create instance for mismatch test");
+            return;
+          }
+          const firstBody = first.data as unknown as { instanceId: string };
+          createdInstanceId = firstBody.instanceId;
+        }
 
-    // Step B: add R3 (should only clone the new one, not remove R1/R2)
-    const b = await postApiMorphSetupInstance({
-      client: testApiClient,
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
-      body: {
-        teamSlugOrId: "manaflow",
-        instanceId: createdInstanceId,
-        selectedRepos: [R1, R2, R3],
-        ttlSeconds: 900,
+        // Use a random team slug/id to simulate another org when only one team exists
+        // This should still be denied (either 403 for mismatch or 404 if team doesn't exist)
+        const otherTeamSlugOrId = `cmux-test-${randomUUID().slice(0, 8)}`;
+
+        const res = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: {
+            teamSlugOrId: otherTeamSlugOrId,
+            instanceId: createdInstanceId!,
+            ttlSeconds: 300,
+          },
+        });
+        // Depending on environment, this may be 403 (mismatch), 404 (unknown team), or 500 (env/verification error)
+        expect([403, 404, 500]).toContain(res.response.status);
+      }
+    );
+
+    it(
+      "clones repos, removes, and re-adds correctly",
+      {
+        timeout: 120_000,
       },
-    });
-    expect(b.response.status).toBe(200);
-    const bBody = b.data;
-    if (!bBody) {
-      throw new Error("Failed to create instance", { cause: b.error });
-    }
-    expect(bBody.clonedRepos).toEqual(expect.arrayContaining([R3]));
-    // Must NOT remove R1 or R2 here
-    expect(bBody.removedRepos).not.toEqual(expect.arrayContaining([N1, N2]));
+      async () => {
+        const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
 
-    // Step C: remove R2 (should list R2 as removed, not R1/R3)
-    const c = await postApiMorphSetupInstance({
-      client: testApiClient,
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
-      body: {
-        teamSlugOrId: "manaflow",
-        instanceId: createdInstanceId,
-        selectedRepos: [R1, R3],
-        ttlSeconds: 900,
-      },
-    });
-    expect(c.response.status).toBe(200);
-    const cBody = c.data;
-    if (!cBody) {
-      throw new Error("Failed to create instance", { cause: c.error });
-    }
-    expect(cBody.removedRepos).toEqual(expect.arrayContaining([N2]));
-    expect(cBody.removedRepos).not.toEqual(expect.arrayContaining([N1, N3]));
+        const R1 = "manaflow-ai/manaflow-ai-cmux-testing-repo-1";
+        const R2 = "manaflow-ai/manaflow-ai-cmux-testing-repo-2";
+        const R3 = "manaflow-ai/manaflow-ai-cmux-testing-repo-3";
+        const N1 = "manaflow-ai-cmux-testing-repo-1";
+        const N2 = "manaflow-ai-cmux-testing-repo-2";
+        const N3 = "manaflow-ai-cmux-testing-repo-3";
 
-    // Verify in-VM that R2 was removed and R1/R3 remain with correct remotes
-    const instC = await __TEST_INTERNAL_ONLY_MORPH_CLIENT.instances.get({
-      instanceId: createdInstanceId,
-    });
-    const r2Gone = await instC.exec(
-      `bash -lc "test ! -d /root/workspace/${N2}"`
-    );
-    expect(r2Gone.exit_code).toBe(0);
-    const r1Still = await instC.exec(
-      `bash -lc "test -d /root/workspace/${N1}/.git && git -C /root/workspace/${N1} remote get-url origin"`
-    );
-    const r3Still = await instC.exec(
-      `bash -lc "test -d /root/workspace/${N3}/.git && git -C /root/workspace/${N3} remote get-url origin"`
-    );
-    expect(r1Still.exit_code).toBe(0);
-    expect(r3Still.exit_code).toBe(0);
-    expect(r1Still.stdout).toContain(R1);
-    expect(r3Still.stdout).toContain(R3);
+        // Ensure an instance exists for this sequence
+        if (!createdInstanceId) {
+          const first = await postApiMorphSetupInstance({
+            client: testApiClient,
+            headers: { "x-stack-auth": JSON.stringify(tokens) },
+            body: { teamSlugOrId: "manaflow", ttlSeconds: 900 },
+          });
+          // Accept 200 (OK) or 500 (server error due to team/auth issues)
+          expect([200, 500]).toContain(first.response.status);
+          if (first.response.status !== 200) {
+            throw new Error("Failed to create instance", { cause: first.error });
+          }
+          if (!first.data) {
+            throw new Error("Failed to create instance", { cause: first.error });
+          }
+          createdInstanceId = first.data.instanceId;
+        }
 
-    // Step D: add R2 back (should clone R2 again, not remove others)
-    const d = await postApiMorphSetupInstance({
-      client: testApiClient,
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
-      body: {
-        teamSlugOrId: "manaflow",
-        instanceId: createdInstanceId,
-        selectedRepos: [R1, R2, R3],
-        ttlSeconds: 900,
-      },
-    });
-    expect(d.response.status).toBe(200);
-    const dBody = d.data;
-    if (!dBody) {
-      throw new Error("Failed to create instance", { cause: d.error });
-    }
-    expect(dBody.clonedRepos).toEqual(expect.arrayContaining([R2]));
-    expect(dBody.removedRepos).not.toEqual(expect.arrayContaining([N1, N3]));
-  }, 300_000);
-});
+        // Step A: clone R1 + R2
+        const a = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: {
+            teamSlugOrId: "manaflow",
+            instanceId: createdInstanceId,
+            selectedRepos: [R1, R2],
+            ttlSeconds: 900,
+          },
+        });
+        expect(a.response.status).toBe(200);
+        const aBody = a.data;
+        if (!aBody) {
+          throw new Error("Failed to create instance", { cause: a.error });
+        }
+        // Should have at least cloned these repos; removedRepos may contain pre-existing folders
+        expect(aBody.clonedRepos).toEqual(expect.arrayContaining([R1, R2]));
+
+        // Verify in-VM that R1 and R2 exist with correct remotes
+        const instA = await __TEST_INTERNAL_ONLY_MORPH_CLIENT.instances.get({
+          instanceId: createdInstanceId,
+        });
+        const r1Check = await instA.exec(
+          `bash -lc "test -d /root/workspace/${N1}/.git && git -C /root/workspace/${N1} remote get-url origin"`
+        );
+        const r2Check = await instA.exec(
+          `bash -lc "test -d /root/workspace/${N2}/.git && git -C /root/workspace/${N2} remote get-url origin"`
+        );
+        expect(r1Check.exit_code).toBe(0);
+        expect(r2Check.exit_code).toBe(0);
+        expect(r1Check.stdout).toContain(R1);
+        expect(r2Check.stdout).toContain(R2);
+
+        // Step B: add R3 (should only clone the new one, not remove R1/R2)
+        const b = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: {
+            teamSlugOrId: "manaflow",
+            instanceId: createdInstanceId,
+            selectedRepos: [R1, R2, R3],
+            ttlSeconds: 900,
+          },
+        });
+        expect(b.response.status).toBe(200);
+        const bBody = b.data;
+        if (!bBody) {
+          throw new Error("Failed to create instance", { cause: b.error });
+        }
+        expect(bBody.clonedRepos).toEqual(expect.arrayContaining([R3]));
+        // Must NOT remove R1 or R2 here
+        expect(bBody.removedRepos).not.toEqual(expect.arrayContaining([N1, N2]));
+
+        // Step C: remove R2 (should list R2 as removed, not R1/R3)
+        const c = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: {
+            teamSlugOrId: "manaflow",
+            instanceId: createdInstanceId,
+            selectedRepos: [R1, R3],
+            ttlSeconds: 900,
+          },
+        });
+        expect(c.response.status).toBe(200);
+        const cBody = c.data;
+        if (!cBody) {
+          throw new Error("Failed to create instance", { cause: c.error });
+        }
+        expect(cBody.removedRepos).toEqual(expect.arrayContaining([N2]));
+        expect(cBody.removedRepos).not.toEqual(expect.arrayContaining([N1, N3]));
+
+        // Verify in-VM that R2 was removed and R1/R3 remain with correct remotes
+        const instC = await __TEST_INTERNAL_ONLY_MORPH_CLIENT.instances.get({
+          instanceId: createdInstanceId,
+        });
+        const r2Gone = await instC.exec(
+          `bash -lc "test ! -d /root/workspace/${N2}"`
+        );
+        expect(r2Gone.exit_code).toBe(0);
+        const r1Still = await instC.exec(
+          `bash -lc "test -d /root/workspace/${N1}/.git && git -C /root/workspace/${N1} remote get-url origin"`
+        );
+        const r3Still = await instC.exec(
+          `bash -lc "test -d /root/workspace/${N3}/.git && git -C /root/workspace/${N3} remote get-url origin"`
+        );
+        expect(r1Still.exit_code).toBe(0);
+        expect(r3Still.exit_code).toBe(0);
+        expect(r1Still.stdout).toContain(R1);
+        expect(r3Still.stdout).toContain(R3);
+
+        // Step D: add R2 back (should clone R2 again, not remove others)
+        const d = await postApiMorphSetupInstance({
+          client: testApiClient,
+          headers: { "x-stack-auth": JSON.stringify(tokens) },
+          body: {
+            teamSlugOrId: "manaflow",
+            instanceId: createdInstanceId,
+            selectedRepos: [R1, R2, R3],
+            ttlSeconds: 900,
+          },
+        });
+        expect(d.response.status).toBe(200);
+        const dBody = d.data;
+        if (!dBody) {
+          throw new Error("Failed to create instance", { cause: d.error });
+        }
+        expect(dBody.clonedRepos).toEqual(expect.arrayContaining([R2]));
+        expect(dBody.removedRepos).not.toEqual(expect.arrayContaining([N1, N3]));
+      }
+    );
+  }
+);

--- a/apps/www/lib/routes/sandboxes.route.test.ts
+++ b/apps/www/lib/routes/sandboxes.route.test.ts
@@ -8,12 +8,17 @@ const ENVIRONMENT_ID =
   process.env.DEBUG_ENVIRONMENT_ID ?? "mn7bxgkya730p3hqzj2dzatzhh7s8c52";
 
 describe("sandboxesRouter integration", () => {
-  it("rejects providing a snapshotId not owned by the team", async () => {
-    const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
-    const res = await postApiSandboxesStart({
-      client: testApiClient,
-      headers: { "x-stack-auth": JSON.stringify(tokens) },
-      body: {
+  it(
+    "rejects providing a snapshotId not owned by the team",
+    {
+      timeout: 120_000,
+    },
+    async () => {
+      const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();
+      const res = await postApiSandboxesStart({
+        client: testApiClient,
+        headers: { "x-stack-auth": JSON.stringify(tokens) },
+        body: {
         teamSlugOrId: "manaflow",
         snapshotId: "snapshot_does_not_exist_for_team_test",
         ttlSeconds: 60,
@@ -21,12 +26,13 @@ describe("sandboxesRouter integration", () => {
     });
 
     expect([403, 500]).toContain(res.response.status);
-  });
+    }
+  );
 
   it(
     "starts sandbox for configured environment",
     {
-      timeout: 45000,
+      timeout: 120_000,
     },
     async () => {
       const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();


### PR DESCRIPTION
stdout | lib/routes/github.repos.route.test.ts > githubReposRouter via SDK > supports paging and still limits to 5     --> GET /api/integrations/github/repos?team=manaflow&page=1 200 196ms          stdout | lib/routes/github.repos.route.test.ts > githubReposRouter via SDK > supports paging and still limits to 5     Request path: /api/integrations/github/repos     Request url: http://localhost/api/integrations/github/repos?team=manaflow&page=2     <-- GET /api/integrations/github/repos?team=manaflow&page=2          stdout | lib/routes/github.repos.route.test.ts > githubReposRouter via SDK > supports paging and still limits to 5     --> GET /api/integrations/github/repos?team=manaflow&page=2 200 117ms           ❯ lib/routes/github.repos.route.test.ts (4 tests | 1 failed) 7957ms        ✓ githubReposRouter via SDK > rejects unauthenticated requests 163ms        × githubReposRouter via SDK > returns repos for authenticated user 5070ms          → Test timed out in 5000ms.     If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".        ✓ githubReposRouter via SDK > can limit to a single installation when specified  1781ms        ✓ githubReposRouter via SDK > supports paging and still limits to 5  935ms     stdout | lib/routes/sandboxes.route.test.ts > sandboxesRouter integration > starts sandbox for configured environment     [sandboxes.start] Starting hydration with Bun script          stdout | lib/routes/sandboxes.route.test.ts > sandboxesRouter integration > starts sandbox for configured environment     [sandboxes.start] hydration stdout:     2025-10-16T00:56:49.942Z [hydrate-repo] Starting hydration for workspace: /root/workspace     2025-10-16T00:56:49.943Z [hydrate-repo] Ensuring workspace exists at /root/workspace     2025-10-16T00:56:49.943Z [hydrate-repo] DEBUG: Executing: mkdir -p "/root/workspace"     2025-10-16T00:56:49.954Z [hydrate-repo] Hydrating multiple repositories     2025-10-16T00:56:49.955Z [hydrate-repo] Checking for subdirectory git repositories     2025-10-16T00:56:49.964Z [hydrate-repo] Pulling updates in /root/workspace/cmux     2025-10-16T00:56:49.964Z [hydrate-repo] DEBUG: Executing: git pull --ff-only     2025-10-16T00:56:51.729Z [hydrate-repo] Pulling updates in /root/workspace/cmux-testing     2025-10-16T00:56:51.729Z [hydrate-repo] DEBUG: Executing: git pull --ff-only     2025-10-16T00:56:52.508Z [hydrate-repo] Pulling updates in /root/workspace/rawdognew     2025-10-16T00:56:52.508Z [hydrate-repo] DEBUG: Executing: git pull --ff-only     2025-10-16T00:56:53.313Z [hydrate-repo] Hydration completed successfully          [sandboxes.start] hydration exit code: 0          stdout | lib/routes/sandboxes.route.test.ts > sandboxesRouter integration > starts sandbox for configured environment     --> POST /api/sandboxes/start 200 9s          stdout | lib/routes/sandboxes.route.test.ts > sandboxesRouter integration > starts sandbox for configured environment     res {       instanceId: 'morphvm_18wsyg1r',       vscodeUrl: 'https://port-39378-morphvm-18wsyg1r.http.cloud.morph.so',       workerUrl: 'https://port-39377-morphvm-18wsyg1r.http.cloud.morph.so',       provider: 'morph'     }          stdout | lib/routes/sandboxes.route.test.ts > sandboxesRouter integration > starts sandbox for configured environment     envctlVersion { stdout: 'envctl 0.0.8\n', stderr: '', exit_code: 0 }           ❯ lib/routes/sandboxes.route.test.ts (2 tests | 1 failed) 15132ms        × sandboxesRouter integration > rejects providing a snapshotId not owned by the team 5027ms          → Test timed out in 5000ms.     If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".        ✓ sandboxesRouter integration > starts sandbox for configured environment  10102ms     stdout | lib/routes/github.prs.open.route.test.ts > githubPrsOpenRouter via SDK > rejects unauthenticated requests     Request path: /api/integrations/github/prs/open     Request url: http://localhost/api/integrations/github/prs/open     <-- POST /api/integrations/github/prs/open          stdout | lib/routes/github.prs.open.route.test.ts > githubPrsOpenRouter via SDK > rejects unauthenticated requests     --> POST /api/integrations/github/prs/open 401 41ms           ✓ lib/routes/github.prs.open.route.test.ts (1 test) 154ms          ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯           FAIL  lib/routes/github.repos.route.test.ts > githubReposRouter via SDK > returns repos for authenticated user     Error: Test timed out in 5000ms.     If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".      ❯ lib/routes/github.repos.route.test.ts:17:3          15|   });          16|           17|   it("returns repos for authenticated user", async () => {            |   ^          18|     const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();          19|     const res = await getApiIntegrationsGithubRepos({          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯           FAIL  lib/routes/sandboxes.route.test.ts > sandboxesRouter integration > rejects providing a snapshotId not owned by the team     Error: Test timed out in 5000ms.     If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".      ❯ lib/routes/sandboxes.route.test.ts:11:3           9|           10| describe("sandboxesRouter integration", () => {          11|   it("rejects providing a snapshotId not owned by the team", async () …            |   ^          12|     const tokens = await __TEST_INTERNAL_ONLY_GET_STACK_TOKENS();          13|     const res = await postApiSandboxesStart({          ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯                Test Files  2 failed | 5 passed | 1 skipped (8)           Tests  2 failed | 31 passed | 4 skipped (37)        Start at  00:56:11        Duration  50.84s (transform 8.14s, setup 0ms, collect 94.99s, tests 23.39s, environment 17ms, prepare 3.74s)     increase timeouts for these tests. also increase timeouts for the morph.route.ts and re-enable it again. for anything that touches morph, we should set timeout to 2 mins.make sure for vitest we use the second arg, like the modern approach