### PR TITLE
Enable cmd+shift+v paste as plain text

### DIFF
--- a/apps/client/src/components/lexical/LexicalEditor.tsx
+++ b/apps/client/src/components/lexical/LexicalEditor.tsx
@@ -25,6 +25,8 @@ import type { Id } from "@cmux/convex/dataModel";
 import {
   $createParagraphNode,
   $getRoot,
+  $getSelection,
+  $isRangeSelection,
   COMMAND_PRIORITY_HIGH,
   INSERT_LINE_BREAK_COMMAND,
   KEY_DOWN_COMMAND,
@@ -157,9 +159,51 @@ function KeyboardCommandPlugin({ onSubmit }: { onSubmit?: () => void }) {
       COMMAND_PRIORITY_HIGH
     );
 
+    const unregisterPlainPaste = editor.registerCommand(
+      KEY_DOWN_COMMAND,
+      (event: KeyboardEvent) => {
+        const isModifierPressed = event.metaKey || event.ctrlKey;
+        const isShiftV =
+          (event.key === "v" || event.key === "V" || event.code === "KeyV") &&
+          event.shiftKey;
+
+        if (!isModifierPressed || !isShiftV) {
+          return false;
+        }
+
+        if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+          return false;
+        }
+
+        event.preventDefault();
+
+        void navigator.clipboard
+          .readText()
+          .then((text) => {
+            if (!text) {
+              return;
+            }
+
+            editor.update(() => {
+              const selection = $getSelection();
+              if ($isRangeSelection(selection)) {
+                selection.insertRawText(text);
+              }
+            });
+          })
+          .catch((error) => {
+            console.error("Plain paste failed", error);
+          });
+
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+
     return () => {
       unregisterEnter();
       unregisterCtrlJ();
+      unregisterPlainPaste();
     };
   }, [editor, onSubmit]);
 


### PR DESCRIPTION
make cmd+shift+v in dashboard input execute paste without formatting (right now, on mac, only cmd+option+shift+v works)