### PR TITLE
Sort crowned taskruns to top in sidebar

### DIFF
--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -154,7 +154,12 @@ async function fetchTaskRunsForTask(
   });
 
   const sortRuns = (items: TaskRunWithChildren[]) => {
-    items.sort((a, b) => a.createdAt - b.createdAt);
+    items.sort((a, b) => {
+      // Sort crowned runs first, then by creation time
+      if (a.isCrowned && !b.isCrowned) return -1;
+      if (!a.isCrowned && b.isCrowned) return 1;
+      return a.createdAt - b.createdAt;
+    });
     items.forEach((item) => sortRuns(item.children));
   };
   sortRuns(rootRuns);


### PR DESCRIPTION
if a taskrun is crowned, it needs to be sorted to the top in the sidebar (in relation to all the other taskruns in the task collapsable list)