### PR TITLE
Add dual-proc exec to mitigate Vercel timeout

### DIFF
--- a/apps/worker/src/execRunner.test.ts
+++ b/apps/worker/src/execRunner.test.ts
@@ -72,4 +72,37 @@ describe("runWorkerExec", () => {
     });
     expect(kill.exitCode).toBe(0);
   });
+
+  it("runs a command detached and returns its pid", async () => {
+    const result = await runWorkerExec({
+      command: "sleep",
+      args: ["5"],
+      detached: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(typeof result.pid).toBe("number");
+
+    if (typeof result.pid === "number") {
+      expect(result.pid).toBeGreaterThan(0);
+
+      let isRunning = true;
+      try {
+        process.kill(result.pid, 0);
+      } catch (_error) {
+        isRunning = false;
+      }
+
+      expect(isRunning).toBe(true);
+
+      try {
+        process.kill(result.pid, "SIGTERM");
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code !== "ESRCH") {
+          throw err;
+        }
+      }
+    }
+  });
 });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -739,6 +739,8 @@ managementIO.on("connection", (socket) => {
         exitCode: result.exitCode,
         stdout: result.stdout.slice(0, 200),
         stderr: result.stderr.slice(0, 200),
+        ...(typeof result.pid === "number" ? { pid: result.pid } : {}),
+        ...(typeof result.signal === "string" ? { signal: result.signal } : {}),
       });
 
       callback({

--- a/packages/shared/src/worker-schemas.ts
+++ b/packages/shared/src/worker-schemas.ts
@@ -172,6 +172,7 @@ export const WorkerExecSchema = z.object({
   cwd: z.string().optional(),
   env: z.record(z.string(), z.string()).optional(),
   timeout: z.number().optional(), // Timeout in milliseconds
+  detached: z.boolean().optional(),
 });
 
 // Execute command result schema
@@ -180,6 +181,7 @@ export const WorkerExecResultSchema = z.object({
   stderr: z.string(),
   exitCode: z.number(),
   signal: z.string().optional(),
+  pid: z.number().optional(),
 });
 
 // Server to Worker Events

--- a/scripts/morph-start-instance.ts
+++ b/scripts/morph-start-instance.ts
@@ -132,21 +132,27 @@ async function workerExec({
   args,
   cwd,
   env,
+  detached,
 }: {
   workerSocket: Socket<WorkerToServerEvents, ServerToWorkerEvents>;
   command: string;
   args: string[];
   cwd: string;
   env: Record<string, string>;
+  detached?: boolean;
 }) {
   return new Promise((resolve, reject) => {
-    workerSocket.emit("worker:exec", { command, args, cwd, env }, (payload) => {
-      if (payload.error) {
-        reject(payload.error);
-      } else {
-        resolve(payload);
+    workerSocket.emit(
+      "worker:exec",
+      { command, args, cwd, env, detached },
+      (payload) => {
+        if (payload.error) {
+          reject(payload.error);
+        } else {
+          resolve(payload);
+        }
       }
-    });
+    );
   });
 }
 
@@ -157,6 +163,7 @@ await workerExec({
   args: ["-c", "SKIP_DOCKER_BUILD=true SKIP_CONVEX=true ./scripts/dev.sh"],
   cwd: "/root/workspace",
   env: {},
+  detached: true,
 });
 // await workerExec({
 //   workerSocket: clientSocket,


### PR DESCRIPTION
we might need 2 exec processes because sometimes there is a vercel timeout which causes dev script to not run sometimes. we need to counter the timeout by having 2 exec processes? you get what i mean