### PR TITLE
Enable Sing-box proxy for Electron devbox

### DIFF
--- a/apps/client/electron/main/proxy-routing.test.ts
+++ b/apps/client/electron/main/proxy-routing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveMorphDetails,
+  SING_BOX_PROXY_PORT,
+} from "./proxy-routing";
+
+describe("deriveMorphDetails", () => {
+  it("returns nulls for empty input", () => {
+    const result = deriveMorphDetails(null);
+    expect(result.proxyConfig).toBeNull();
+    expect(result.morphId).toBeNull();
+    expect(result.navigationUrl).toBeNull();
+    expect(result.displayUrl).toBeNull();
+  });
+
+  it("passes through non-morph URLs untouched", () => {
+    const url = "https://example.com/foo";
+    const result = deriveMorphDetails(url);
+    expect(result.proxyConfig).toBeNull();
+    expect(result.morphId).toBeNull();
+    expect(result.navigationUrl).toBe(url);
+    expect(result.displayUrl).toBe(url);
+  });
+
+  it("derives proxy routing for morph hosts", () => {
+    const url =
+      "https://port-39380-morphvm-abc123.http.cloud.morph.so/vnc.html?autoconnect=1";
+    const result = deriveMorphDetails(url);
+
+    expect(result.morphId).toBe("abc123");
+    expect(result.navigationUrl).toBe("http://localhost:39380/vnc.html?autoconnect=1");
+    expect(result.displayUrl).toBe("http://localhost:39380/vnc.html?autoconnect=1");
+    expect(result.proxyConfig).not.toBeNull();
+    expect(result.proxyConfig).toMatchObject({
+      scheme: "socks5",
+      host: `port-${SING_BOX_PROXY_PORT}-morphvm-abc123.http.cloud.morph.so`,
+      port: SING_BOX_PROXY_PORT,
+    });
+  });
+});
+

--- a/apps/client/electron/main/proxy-routing.ts
+++ b/apps/client/electron/main/proxy-routing.ts
@@ -1,0 +1,91 @@
+import { URL } from "node:url";
+
+import { extractMorphInstanceInfo } from "@cmux/shared";
+
+export type ProxyConfig = {
+  scheme: "socks5";
+  host: string;
+  port: number;
+  bypassRules: string;
+};
+
+export const DEFAULT_PROXY_BYPASS = "cmux.local,cmux.localhost";
+export const SING_BOX_PROXY_PORT = 39384;
+
+export type ProxyRoutingResult = {
+  proxyConfig: ProxyConfig | null;
+  morphId: string | null;
+  navigationUrl: string | null;
+  displayUrl: string | null;
+};
+
+export function deriveMorphDetails(
+  rawUrl: string | null | undefined,
+): ProxyRoutingResult {
+  if (!rawUrl) {
+    return {
+      proxyConfig: null,
+      morphId: null,
+      navigationUrl: null,
+      displayUrl: null,
+    };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return {
+      proxyConfig: null,
+      morphId: null,
+      navigationUrl: rawUrl,
+      displayUrl: rawUrl,
+    };
+  }
+
+  try {
+    const info = extractMorphInstanceInfo(parsed);
+    if (!info || !info.morphId || info.port === null) {
+      return {
+        proxyConfig: null,
+        morphId: null,
+        navigationUrl: rawUrl,
+        displayUrl: rawUrl,
+      };
+    }
+
+    const morphId = info.morphId;
+    const host = `port-${SING_BOX_PROXY_PORT}-morphvm-${morphId}.http.cloud.morph.so`;
+    const navigation = new URL(parsed.toString());
+    navigation.hostname = "localhost";
+    navigation.port = String(info.port);
+    if (navigation.protocol === "https:") {
+      navigation.protocol = "http:";
+    } else if (navigation.protocol === "wss:") {
+      navigation.protocol = "ws:";
+    }
+
+    const display = new URL(navigation.toString());
+    display.hostname = "localhost";
+
+    return {
+      morphId,
+      navigationUrl: navigation.toString(),
+      displayUrl: display.toString(),
+      proxyConfig: {
+        scheme: "socks5",
+        host,
+        port: SING_BOX_PROXY_PORT,
+        bypassRules: DEFAULT_PROXY_BYPASS,
+      },
+    };
+  } catch {
+    return {
+      proxyConfig: null,
+      morphId: null,
+      navigationUrl: rawUrl,
+      displayUrl: rawUrl,
+    };
+  }
+}
+

--- a/apps/client/electron/main/web-contents-view.ts
+++ b/apps/client/electron/main/web-contents-view.ts
@@ -56,13 +56,6 @@ interface ReleaseOptions {
   persist?: boolean;
 }
 
-type ProxyConfig = {
-  scheme: "socks5";
-  host: string;
-  port: number;
-  bypassRules: string;
-};
-
 interface Entry {
   id: number;
   view: Electron.WebContentsView;
@@ -212,81 +205,6 @@ async function applyProxyToSession(
       context,
       error,
     });
-  }
-}
-
-function deriveMorphDetails(
-  rawUrl: string | null | undefined,
-): {
-  proxyConfig: ProxyConfig | null;
-  morphId: string | null;
-  navigationUrl: string | null;
-  displayUrl: string | null;
-} {
-  if (!rawUrl) {
-    return {
-      proxyConfig: null,
-      morphId: null,
-      navigationUrl: null,
-      displayUrl: null,
-    };
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    return {
-      proxyConfig: null,
-      morphId: null,
-      navigationUrl: rawUrl,
-      displayUrl: rawUrl,
-    };
-  }
-
-  try {
-    const info = extractMorphInstanceInfo(parsed);
-    if (!info || !info.morphId || info.port === null) {
-      return {
-        proxyConfig: null,
-        morphId: null,
-        navigationUrl: rawUrl,
-        displayUrl: rawUrl,
-      };
-    }
-
-    const morphId = info.morphId;
-    const host = `port-${SING_BOX_PROXY_PORT}-morphvm-${morphId}.http.cloud.morph.so`;
-    const navigation = new URL(parsed.toString());
-    navigation.hostname = "localhost";
-    navigation.port = String(info.port);
-    if (navigation.protocol === "https:") {
-      navigation.protocol = "http:";
-    } else if (navigation.protocol === "wss:") {
-      navigation.protocol = "ws:";
-    }
-
-    const display = new URL(navigation.toString());
-    display.hostname = "localhost";
-
-    return {
-      morphId,
-      navigationUrl: navigation.toString(),
-      displayUrl: display.toString(),
-      proxyConfig: {
-        scheme: "socks5",
-        host,
-        port: SING_BOX_PROXY_PORT,
-        bypassRules: DEFAULT_PROXY_BYPASS,
-      },
-    };
-  } catch {
-    return {
-      proxyConfig: null,
-      morphId: null,
-      navigationUrl: rawUrl,
-      displayUrl: rawUrl,
-    };
   }
 }
 

--- a/apps/client/electron/main/web-contents-view.ts
+++ b/apps/client/electron/main/web-contents-view.ts
@@ -8,7 +8,9 @@ import {
   type Session,
   type WebContents,
 } from "electron";
+import { createHash, randomUUID } from "node:crypto";
 import { STATUS_CODES } from "node:http";
+import { deriveMorphDetails, type ProxyConfig } from "./proxy-routing";
 import type {
   ElectronDevToolsMode,
   ElectronWebContentsEvent,
@@ -54,6 +56,13 @@ interface ReleaseOptions {
   persist?: boolean;
 }
 
+type ProxyConfig = {
+  scheme: "socks5";
+  host: string;
+  port: number;
+  bypassRules: string;
+};
+
 interface Entry {
   id: number;
   view: Electron.WebContentsView;
@@ -65,6 +74,10 @@ interface Entry {
   ownerWebContentsDestroyed: boolean;
   eventChannel: string;
   eventCleanup: Array<() => void>;
+  proxyConfig: ProxyConfig | null;
+  morphId: string | null;
+  displayUrl: string | null;
+  originalUrl: string | null;
 }
 
 const viewEntries = new Map<number, Entry>();
@@ -137,19 +150,163 @@ function sendEventToOwner(
 function buildState(entry: Entry): ElectronWebContentsState | null {
   const contents = entry.view.webContents;
   try {
+    const actualUrl = contents.getURL();
+    const displayUrl = entry.displayUrl ?? actualUrl;
     return {
       id: entry.id,
       webContentsId: contents.id,
-      url: contents.getURL(),
+      url: displayUrl,
       title: contents.getTitle(),
       canGoBack: contents.navigationHistory.canGoBack(),
       canGoForward: contents.navigationHistory.canGoForward(),
       isLoading: contents.isLoading(),
       isDevToolsOpened: contents.isDevToolsOpened(),
+      morphId: entry.morphId,
     };
   } catch {
     return null;
   }
+}
+
+function resolvePartitionId(persistKey: string | undefined): string {
+  if (persistKey && persistKey.trim().length > 0) {
+    const hash = createHash("sha1").update(persistKey.trim()).digest("hex");
+    return `persist:cmux-webview:${hash}`;
+  }
+  return `persist:cmux-webview:${randomUUID()}`;
+}
+
+function proxyConfigsEqual(a: ProxyConfig | null, b: ProxyConfig | null): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return (
+    a.scheme === b.scheme &&
+    a.host === b.host &&
+    a.port === b.port &&
+    a.bypassRules === b.bypassRules
+  );
+}
+
+async function applyProxyToSession(
+  targetSession: Session,
+  proxy: ProxyConfig | null,
+  logger: Logger,
+  context: string,
+): Promise<void> {
+  try {
+    if (!proxy) {
+      await targetSession.setProxy({ mode: "direct" });
+      targetSession.closeAllConnections();
+      return;
+    }
+
+    const proxyRules = `${proxy.scheme}://${proxy.host}:${proxy.port}`;
+    await targetSession.setProxy({
+      mode: "fixed_servers",
+      proxyRules,
+      proxyBypassRules: proxy.bypassRules,
+    });
+    targetSession.closeAllConnections();
+  } catch (error) {
+    logger.warn("Failed to apply proxy configuration", {
+      context,
+      error,
+    });
+  }
+}
+
+function deriveMorphDetails(
+  rawUrl: string | null | undefined,
+): {
+  proxyConfig: ProxyConfig | null;
+  morphId: string | null;
+  navigationUrl: string | null;
+  displayUrl: string | null;
+} {
+  if (!rawUrl) {
+    return {
+      proxyConfig: null,
+      morphId: null,
+      navigationUrl: null,
+      displayUrl: null,
+    };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return {
+      proxyConfig: null,
+      morphId: null,
+      navigationUrl: rawUrl,
+      displayUrl: rawUrl,
+    };
+  }
+
+  try {
+    const info = extractMorphInstanceInfo(parsed);
+    if (!info || !info.morphId || info.port === null) {
+      return {
+        proxyConfig: null,
+        morphId: null,
+        navigationUrl: rawUrl,
+        displayUrl: rawUrl,
+      };
+    }
+
+    const morphId = info.morphId;
+    const host = `port-${SING_BOX_PROXY_PORT}-morphvm-${morphId}.http.cloud.morph.so`;
+    const navigation = new URL(parsed.toString());
+    navigation.hostname = "localhost";
+    navigation.port = String(info.port);
+    if (navigation.protocol === "https:") {
+      navigation.protocol = "http:";
+    } else if (navigation.protocol === "wss:") {
+      navigation.protocol = "ws:";
+    }
+
+    const display = new URL(navigation.toString());
+    display.hostname = "localhost";
+
+    return {
+      morphId,
+      navigationUrl: navigation.toString(),
+      displayUrl: display.toString(),
+      proxyConfig: {
+        scheme: "socks5",
+        host,
+        port: SING_BOX_PROXY_PORT,
+        bypassRules: DEFAULT_PROXY_BYPASS,
+      },
+    };
+  } catch {
+    return {
+      proxyConfig: null,
+      morphId: null,
+      navigationUrl: rawUrl,
+      displayUrl: rawUrl,
+    };
+  }
+}
+
+async function updateEntryProxy(
+  entry: Entry,
+  targetUrl: string | null | undefined,
+  logger: Logger,
+  context: string,
+): Promise<string | null> {
+  const { proxyConfig, morphId, navigationUrl, displayUrl } = deriveMorphDetails(
+    targetUrl,
+  );
+  if (!proxyConfigsEqual(entry.proxyConfig, proxyConfig)) {
+    await applyProxyToSession(entry.view.webContents.session, proxyConfig, logger, context);
+    entry.proxyConfig = proxyConfig;
+  }
+  entry.morphId = morphId;
+  entry.originalUrl = targetUrl ?? null;
+  entry.displayUrl = displayUrl ?? targetUrl ?? null;
+  return navigationUrl ?? targetUrl ?? null;
 }
 
 function sendState(entry: Entry, logger: Logger, reason: string) {
@@ -196,6 +353,10 @@ function setupEventForwarders(entry: Entry, logger: Logger) {
     httpResponseCode: number,
     httpStatusText: string,
   ) => {
+    if (!entry.proxyConfig) {
+      entry.displayUrl = url;
+      entry.originalUrl = url;
+    }
     // Check for HTTP errors (4xx, 5xx)
     if (httpResponseCode >= 400) {
       const statusText = httpStatusText || STATUS_CODES[httpResponseCode];
@@ -221,6 +382,15 @@ function setupEventForwarders(entry: Entry, logger: Logger) {
   });
 
   const onDidNavigateInPage = () => {
+    if (!entry.proxyConfig) {
+      try {
+        const current = entry.view.webContents.getURL();
+        entry.displayUrl = current;
+        entry.originalUrl = current;
+      } catch {
+        // ignore
+      }
+    }
     sendState(entry, logger, "did-navigate-in-page");
   };
   webContents.on("did-navigate-in-page", onDidNavigateInPage);
@@ -642,6 +812,10 @@ export function registerWebContentsViewHandlers({
               applyBorderRadius(candidate.view, options.borderRadius);
             }
 
+            const restoredUrl =
+              options.url ?? candidate.originalUrl ?? candidate.view.webContents.getURL();
+            await updateEntryProxy(candidate, restoredUrl, logger, "reattach");
+
             candidate.ownerWindowId = win.id;
             candidate.ownerWebContentsId = sender.id;
             candidate.ownerWebContentsDestroyed = false;
@@ -694,7 +868,12 @@ export function registerWebContentsViewHandlers({
           destroyConflictingEntries(persistKey, win.id, logger);
         }
 
-        const view = new WebContentsView();
+        const partitionId = resolvePartitionId(persistKey);
+        const view = new WebContentsView({
+          webPreferences: {
+            partition: partitionId,
+          },
+        });
 
         applyChromeCamouflage(view, logger);
 
@@ -724,12 +903,6 @@ export function registerWebContentsViewHandlers({
         }
 
         const finalUrl = options.url ?? "about:blank";
-        void view.webContents.loadURL(finalUrl).catch((error) =>
-          logger.warn("WebContentsView initial load failed", {
-            url: finalUrl,
-            error,
-          }),
-        );
 
         const id = nextViewId++;
         const entry: Entry = {
@@ -743,8 +916,20 @@ export function registerWebContentsViewHandlers({
           ownerWebContentsDestroyed: false,
           eventChannel: eventChannelFor(id),
           eventCleanup: [],
+          proxyConfig: null,
+          morphId: null,
+          displayUrl: null,
+          originalUrl: null,
         };
         viewEntries.set(id, entry);
+        const navigationTarget =
+          (await updateEntryProxy(entry, finalUrl, logger, "create")) ?? finalUrl;
+        void view.webContents.loadURL(navigationTarget).catch((error) =>
+          logger.warn("WebContentsView initial load failed", {
+            url: navigationTarget,
+            error,
+          }),
+        );
         setupEventForwarders(entry, logger);
         sendState(entry, logger, "created");
 
@@ -804,7 +989,7 @@ export function registerWebContentsViewHandlers({
 
   ipcMain.handle(
     "cmux:webcontents:load-url",
-    (event, options: LoadUrlOptions) => {
+    async (event, options: LoadUrlOptions) => {
       const { id, url } = options ?? {};
       if (
         typeof id !== "number" ||
@@ -820,7 +1005,9 @@ export function registerWebContentsViewHandlers({
       }
       entry.ownerSender = event.sender;
       try {
-        void entry.view.webContents.loadURL(url);
+        const navigationTarget =
+          (await updateEntryProxy(entry, url, logger, "load-url")) ?? url;
+        void entry.view.webContents.loadURL(navigationTarget);
         return { ok: true };
       } catch (error) {
         logger.warn("Failed to load URL", { id, url, error });

--- a/apps/client/src/types/electron-webcontents.ts
+++ b/apps/client/src/types/electron-webcontents.ts
@@ -9,6 +9,7 @@ export interface ElectronWebContentsState {
   canGoForward: boolean;
   isLoading: boolean;
   isDevToolsOpened: boolean;
+  morphId?: string | null;
 }
 
 export interface ElectronWebContentsSnapshot {

--- a/configs/sing-box/config.json
+++ b/configs/sing-box/config.json
@@ -1,0 +1,36 @@
+{
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "inbounds": [
+    {
+      "type": "mixed",
+      "tag": "mixed-in",
+      "listen": "0.0.0.0",
+      "listen_port": 39384,
+      "sniff": true,
+      "proxy_protocol": false,
+      "set_system_proxy": false
+    }
+  ],
+  "outbounds": [
+    {
+      "type": "direct",
+      "tag": "direct"
+    },
+    {
+      "type": "block",
+      "tag": "block"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "rules": [
+      {
+        "protocol": ["bittorrent"],
+        "outbound": "block"
+      }
+    ]
+  }
+}

--- a/configs/systemd/cmux-sing-box.service
+++ b/configs/systemd/cmux-sing-box.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Cmux sing-box proxy
+After=network-online.target
+Wants=network-online.target
+Before=cmux-openvscode.service cmux-worker.service cmux-proxy.service cmux-devtools.service cmux-xterm.service
+
+[Service]
+Type=simple
+EnvironmentFile=-/opt/app/app.env
+LogsDirectory=cmux
+ExecStartPre=/bin/mkdir -p /var/log/cmux
+ExecStart=/usr/local/bin/sing-box run -c /etc/sing-box/config.json
+Restart=on-failure
+RestartSec=2
+StandardOutput=append:/var/log/cmux/sing-box.log
+StandardError=append:/var/log/cmux/sing-box.log
+LimitNOFILE=65535
+
+[Install]
+WantedBy=cmux.target

--- a/packages/shared/src/morph-snapshots.ts
+++ b/packages/shared/src/morph-snapshots.ts
@@ -9,7 +9,7 @@ export interface MorphSnapshotPreset {
 
 export const MORPH_SNAPSHOT_PRESETS = [
   {
-    id: "snapshot_vb7uqz8o",
+    id: "snapshot_vwnox2w3",
     label: "Standard workspace",
     cpu: "4 vCPU",
     memory: "16 GB RAM",
@@ -18,7 +18,7 @@ export const MORPH_SNAPSHOT_PRESETS = [
       "Great default for day-to-day work. Balanced CPU, memory, and storage.",
   },
   {
-    id: "snapshot_oa4dps0g",
+    id: "snapshot_lhcrpuia",
     label: "Performance workspace",
     cpu: "6 vCPU",
     memory: "32 GB RAM",
@@ -27,8 +27,7 @@ export const MORPH_SNAPSHOT_PRESETS = [
   },
 ] as const satisfies readonly MorphSnapshotPreset[];
 
-export type MorphSnapshotId =
-  (typeof MORPH_SNAPSHOT_PRESETS)[number]["id"];
+export type MorphSnapshotId = (typeof MORPH_SNAPSHOT_PRESETS)[number]["id"];
 
 export const DEFAULT_MORPH_SNAPSHOT_ID: MorphSnapshotId =
   MORPH_SNAPSHOT_PRESETS[0].id;

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: 'snapshot_vb7uqz8o' | 'snapshot_oa4dps0g';
+    snapshotId?: 'snapshot_vwnox2w3' | 'snapshot_lhcrpuia';
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
Goal: enable Electron WebContentsView to load localhost via the devbox.

Tasks:
1. On the devbox, install a fast Go/Rust proxy (use sing-box preferred).
   - Run as root on port 39384, allow HTTP+SOCKS on one port.
   - Config path: /etc/sing-box/config.json
   - Add systemd unit so it auto-starts.

2. In Dockerfile:
   - Install sing-box and add the config file.
   - Expose port 39384.
   - Start sing-box before the app (use simple entrypoint script or supervisor).
   - Add a healthcheck for port 39384.

3. In ./scripts/snapshot.py:
   - Add proxy setup before launching Electron:
     ```
     session.setProxy({
       mode: "fixed_servers",
       proxyRules: "http=<DEVBOX_HOST>:39384;https=<DEVBOX_HOST>:39384;socks5=<DEVBOX_HOST>:39384",
       proxyBypassRules: "<-loopback>"
     })
     ```
   - Make DEVBOX_HOST configurable via env var.
   - Log effective proxy info.

4. Validate:
   - curl via proxy to http://localhost:3000 works.
   - ws:// connections also work.

Deliverables:
- Full updated Dockerfile and scripts/snapshot.py
- /etc/sing-box/config.json
- systemd unit file
- README.dev.md with setup + verification steps.