### PR TITLE
Refresh auth token every 25 minutes

### DIFF
--- a/apps/client/src/contexts/convex/authJsonQueryOptions.ts
+++ b/apps/client/src/contexts/convex/authJsonQueryOptions.ts
@@ -8,8 +8,8 @@ export interface StackUserLike {
   getAuthJson: () => Promise<{ accessToken: string | null }>;
 }
 
-// Refresh every 30 minutes by default
-export const defaultAuthJsonRefreshInterval = 30 * 60 * 1000;
+// Refresh every 25 minutes by default to avoid stack session expiry
+export const defaultAuthJsonRefreshInterval = 25 * 60 * 1000;
 
 export function authJsonQueryOptions() {
   return queryOptions<AuthJson>({

--- a/apps/client/src/contexts/convex/authJsonQueryOptions.ts
+++ b/apps/client/src/contexts/convex/authJsonQueryOptions.ts
@@ -8,8 +8,8 @@ export interface StackUserLike {
   getAuthJson: () => Promise<{ accessToken: string | null }>;
 }
 
-// Refresh every 25 minutes by default to avoid stack session expiry
-export const defaultAuthJsonRefreshInterval = 25 * 60 * 1000;
+// Refresh every 5 minutes to beat the ~10 minute Stack access token expiry window
+export const defaultAuthJsonRefreshInterval = 5 * 60 * 1000;
 
 export function authJsonQueryOptions() {
   return queryOptions<AuthJson>({

--- a/apps/client/src/contexts/convex/authJsonQueryOptions.ts
+++ b/apps/client/src/contexts/convex/authJsonQueryOptions.ts
@@ -8,8 +8,8 @@ export interface StackUserLike {
   getAuthJson: () => Promise<{ accessToken: string | null }>;
 }
 
-// Refresh every 5 minutes to beat the ~10 minute Stack access token expiry window
-export const defaultAuthJsonRefreshInterval = 5 * 60 * 1000;
+// Refresh every 9 minutes to beat the ~10 minute Stack access token expiry window
+export const defaultAuthJsonRefreshInterval = 9 * 60 * 1000;
 
 export function authJsonQueryOptions() {
   return queryOptions<AuthJson>({


### PR DESCRIPTION
sometimes the stack auth token doesn't refresh after 30 minutes and it times out. we need to refresh the auth token every 25 minutes so that when a user is on cmux for a long time it doesn't give the error that auth token expired and cannot start a new tasks.