### PR TITLE
Enable mouse selection for file mentions

### DIFF
--- a/apps/client/src/components/lexical/MentionPlugin.tsx
+++ b/apps/client/src/components/lexical/MentionPlugin.tsx
@@ -112,7 +112,10 @@ function MentionMenu({
           return (
           <button
             key={file.relativePath}
-            onClick={() => onSelect(file)}
+            onMouseDown={(e) => {
+              e.preventDefault(); // Prevent blur event from firing
+              onSelect(file);
+            }}
             className={clsx(
               "w-full text-left px-2.5 py-1 text-xs flex items-center gap-1.5",
               index === selectedIndex


### PR DESCRIPTION
for the frontpage's chat textarea where we are starting tasks, when I do @ , i am able to search for files to reference but clicking on the selection menu doesn't complete the phrase for me... like i can searhc but i need to use the keyboard and press enter to autopopulate the rest... click the menu does not work. we need to make it work as well