### PR TITLE
Fallback to first team when user has no selected team

### DIFF
--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
@@ -19,6 +19,7 @@ import {
   getConvexHttpActionBaseUrl,
   startCodeReviewJob,
 } from "@/lib/services/code-review/start-code-review";
+import { type Team } from "@stackframe/stack";
 
 type PageParams = {
   teamSlugOrId: string;
@@ -32,11 +33,20 @@ type PageProps = {
 
 export const dynamic = "force-dynamic";
 
+async function getFirstTeam(): Promise<Team | null> {
+  const teams = await stackServerApp.listTeams();
+  const firstTeam = teams[0];
+  if (!firstTeam) {
+    return null;
+  }
+  return firstTeam;
+}
+
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const user = await stackServerApp.getUser({ or: "redirect" });
-  const selectedTeam = user.selectedTeam;
+  const selectedTeam = user.selectedTeam || (await getFirstTeam());
   if (!selectedTeam) {
     throw notFound();
   }
@@ -54,11 +64,7 @@ export async function generateMetadata({
   }
 
   try {
-    const pullRequest = await fetchPullRequest(
-      githubOwner,
-      repo,
-      pullNumber
-    );
+    const pullRequest = await fetchPullRequest(githubOwner, repo, pullNumber);
 
     return {
       title: `${pullRequest.title} · #${pullRequest.number} · ${githubOwner}/${repo}`,
@@ -77,7 +83,7 @@ export async function generateMetadata({
 
 export default async function PullRequestPage({ params }: PageProps) {
   const user = await stackServerApp.getUser({ or: "redirect" });
-  const selectedTeam = user.selectedTeam;
+  const selectedTeam = user.selectedTeam || (await getFirstTeam());
   if (!selectedTeam) {
     throw notFound();
   }
@@ -97,7 +103,7 @@ export default async function PullRequestPage({ params }: PageProps) {
   const pullRequestFilesPromise = fetchPullRequestFiles(
     githubOwner,
     repo,
-    pullNumber
+    pullNumber,
   );
 
   scheduleCodeReviewStart({
@@ -202,10 +208,10 @@ function scheduleCodeReviewStart({
             repo,
             pullNumber,
           },
-          error
+          error,
         );
       }
-    })()
+    })(),
   );
 }
 
@@ -258,10 +264,10 @@ function PullRequestHeaderContent({
 }) {
   const statusBadge = getStatusBadge(pullRequest);
   const createdAtLabel = formatRelativeTimeFromNow(
-    new Date(pullRequest.created_at)
+    new Date(pullRequest.created_at),
   );
   const updatedAtLabel = formatRelativeTimeFromNow(
-    new Date(pullRequest.updated_at)
+    new Date(pullRequest.updated_at),
   );
   const authorLogin = pullRequest.user?.login ?? null;
 
@@ -349,7 +355,7 @@ function PullRequestStatusBadge({
     <span
       className={cn(
         "rounded-md px-2 py-0.5 font-semibold uppercase tracking-wide",
-        className
+        className,
       )}
     >
       {label}
@@ -510,7 +516,7 @@ function summarizeFiles(files: GithubPullRequestFile[]): {
       acc.deletions += file.deletions;
       return acc;
     },
-    { fileCount: 0, additions: 0, deletions: 0 }
+    { fileCount: 0, additions: 0, deletions: 0 },
   );
 }
 


### PR DESCRIPTION
This PR applies the changes to fallback to the first team when a user has no selected team in the PR review page. This ensures that users can still access PR reviews even if they haven't explicitly selected a team.