### PR TITLE
Limit patch to page.tsx for PR review

### DIFF
--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { waitUntil } from "@vercel/functions";
 import { ExternalLink, GitPullRequest } from "lucide-react";
+import { type Team } from "@stackframe/stack";
 
 import { PullRequestDiffViewer } from "@/components/pr/pull-request-diff-viewer";
 import {
@@ -32,11 +33,20 @@ type PageProps = {
 
 export const dynamic = "force-dynamic";
 
+async function getFirstTeam(): Promise<Team | null> {
+  const teams = await stackServerApp.listTeams();
+  const firstTeam = teams[0];
+  if (!firstTeam) {
+    return null;
+  }
+  return firstTeam;
+}
+
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const user = await stackServerApp.getUser({ or: "redirect" });
-  const selectedTeam = user.selectedTeam;
+  const selectedTeam = user.selectedTeam || (await getFirstTeam());
   if (!selectedTeam) {
     throw notFound();
   }
@@ -77,7 +87,7 @@ export async function generateMetadata({
 
 export default async function PullRequestPage({ params }: PageProps) {
   const user = await stackServerApp.getUser({ or: "redirect" });
-  const selectedTeam = user.selectedTeam;
+  const selectedTeam = user.selectedTeam || (await getFirstTeam());
   if (!selectedTeam) {
     throw notFound();
   }


### PR DESCRIPTION
From 580aa7268dc9c931ce6cb4f20a94c23d2cef317f Mon Sep 17 00:00:00 2001From: Lawrence Chen <54008264+lawrencecchen@users.noreply.github.com>Date: Sun, 19 Oct 2025 17:22:38 -0700Subject: [PATCH 1/6] curator 1--- apps/www/lib/services/code-review/start-code-review.ts | 10 +--------- 1 file changed, 1 insertion(+), 9 deletions(-)diff --git a/apps/www/lib/services/code-review/start-code-review.ts b/apps/www/lib/services/code-review/start-code-review.tsindex 8a8d41754..7605fe4da 100644--- a/apps/www/lib/services/code-review/start-code-review.ts+++ b/apps/www/lib/services/code-review/start-code-review.ts@@ -1,5 +1,4 @@ import { randomBytes, createHash } from "node:crypto";-import { ConvexHttpClient } from "convex/browser"; import { api } from "@cmux/convex/api"; import type { Id } from "@cmux/convex/dataModel"; @@ -61,12 +60,6 @@ export function getConvexHttpActionBaseUrl(): string | null {   return url.replace(".convex.cloud", ".convex.site").replace(/\/$/, ""); } -function getDeployConvexClient(): ConvexHttpClient {-  const client = new ConvexHttpClient(env.NEXT_PUBLIC_CONVEX_URL);-  client.setAuth(env.CONVEX_DEPLOY_KEY);-  return client;-}- export async function startCodeReviewJob({   accessToken,   callbackBaseUrl,@@ -185,9 +178,8 @@ export async function startCodeReviewJob({         error instanceof Error ? error.message : String(error ?? "Unknown error");       console.error("[code-review] Background review failed", message); -      const deployConvex = getDeployConvexClient();       try {-        await deployConvex.mutation(api.codeReview.failJob, {+        await convex.mutation(api.codeReview.failJob, {           jobId: job.jobId as Id<"automatedCodeReviewJobs">,           errorCode: "pr_review_setup_failed",           errorDetail: message,From 2142cac2a26858e69e5d954479df0a3cd15ca777 Mon Sep 17 00:00:00 2001From: Lawrence Chen <54008264+lawrencecchen@users.noreply.github.com>Date: Sun, 19 Oct 2025 17:31:36 -0700Subject: [PATCH 2/6] wip--- .../pull/[pullNumber]/[...segments]/page.tsx  | 26 +++++++++++++++++++ 1 file changed, 26 insertions(+) create mode 100644 apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsxdiff --git a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsx b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsxnew file mode 100644index 000000000..9c39041cb--- /dev/null+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsx@@ -0,0 +1,26 @@+import { redirect } from "next/navigation";++type PageParams = {+  teamSlugOrId: string;+  repo: string;+  pullNumber: string;+  segments: string[];+};++type PageProps = {+  params: Promise<PageParams>;+};++export const dynamic = "force-dynamic";++export default async function PullRequestCatchallPage({+  params,+}: PageProps): Promise<never> {+  const { teamSlugOrId, repo, pullNumber } = await params;++  redirect(+    `/${encodeURIComponent(teamSlugOrId)}/${encodeURIComponent(+      repo+    )}/pull/${encodeURIComponent(pullNumber)}`+  );+}From 0835971696b663690c5e483cb9fba239f0b44076 Mon Sep 17 00:00:00 2001From: Lawrence Chen <54008264+lawrencecchen@users.noreply.github.com>Date: Sun, 19 Oct 2025 17:37:02 -0700Subject: [PATCH 3/6] Validate pull number before PR catchall redirect--- .../[repo]/pull/[pullNumber]/[...segments]/page.tsx         | 6 +++++- 1 file changed, 5 insertions(+), 1 deletion(-)diff --git a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsx b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsxindex 9c39041cb..74c25a80b 100644--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsx+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/[...segments]/page.tsx@@ -1,4 +1,4 @@-import { redirect } from "next/navigation";+import { notFound, redirect } from "next/navigation";  type PageParams = {   teamSlugOrId: string;@@ -18,6 +18,10 @@ export default async function PullRequestCatchallPage({ }: PageProps): Promise<never> {   const { teamSlugOrId, repo, pullNumber } = await params; +  if (!/^\d+$/.test(pullNumber)) {+    notFound();+  }+   redirect(     `/${encodeURIComponent(teamSlugOrId)}/${encodeURIComponent(       repoFrom 45310a98a22a103e893937eb5a2e332c7d514f72 Mon Sep 17 00:00:00 2001From: Lawrence Chen <54008264+lawrencecchen@users.noreply.github.com>Date: Sun, 19 Oct 2025 17:38:26 -0700Subject: [PATCH 4/6] better desktop auth 0--- apps/client/src/components/sign-in-component.tsx               | 2 +- apps/www/app/[teamSlugOrId]/connect-complete/page.tsx          | 3 +-- .../app/{handler => desktop}/after-sign-in/OpenCmuxClient.tsx  | 0 apps/www/app/{handler => desktop}/after-sign-in/page.tsx       | 0 4 files changed, 2 insertions(+), 3 deletions(-) rename apps/www/app/{handler => desktop}/after-sign-in/OpenCmuxClient.tsx (100%) rename apps/www/app/{handler => desktop}/after-sign-in/page.tsx (100%)diff --git a/apps/client/src/components/sign-in-component.tsx b/apps/client/src/components/sign-in-component.tsxindex e03a6cd06..b0ef8bf34 100644--- a/apps/client/src/components/sign-in-component.tsx+++ b/apps/client/src/components/sign-in-component.tsx@@ -37,7 +37,7 @@ export function SignInComponent() {               </div>               <button                 onClick={() => {-                  const url = `${WWW_ORIGIN}/handler/sign-in/`;+                  const url = `${WWW_ORIGIN}/handler/sign-in?after_auth_return_to=/desktop/after-sign-in`;                   // Open in external browser via Electron handler                   window.open(url, "_blank", "noopener,noreferrer");                 }}diff --git a/apps/www/app/[teamSlugOrId]/connect-complete/page.tsx b/apps/www/app/[teamSlugOrId]/connect-complete/page.tsxindex 091f3ca7c..6b3fedb7b 100644--- a/apps/www/app/[teamSlugOrId]/connect-complete/page.tsx+++ b/apps/www/app/[teamSlugOrId]/connect-complete/page.tsx@@ -1,4 +1,4 @@-import { OpenCmuxClient } from "../../handler/after-sign-in/OpenCmuxClient";+import { OpenCmuxClient } from "../../desktop/after-sign-in/OpenCmuxClient";  export const dynamic = "force-dynamic"; @@ -12,4 +12,3 @@ export default function ConnectCompletePage({   )}`;   return <OpenCmuxClient href={href} />; }-diff --git a/apps/www/app/handler/after-sign-in/OpenCmuxClient.tsx b/apps/www/app/desktop/after-sign-in/OpenCmuxClient.tsxsimilarity index 100%rename from apps/www/app/handler/after-sign-in/OpenCmuxClient.tsxrename to apps/www/app/desktop/after-sign-in/OpenCmuxClient.tsxdiff --git a/apps/www/app/handler/after-sign-in/page.tsx b/apps/www/app/desktop/after-sign-in/page.tsxsimilarity index 100%rename from apps/www/app/handler/after-sign-in/page.tsxrename to apps/www/app/desktop/after-sign-in/page.tsxFrom 3847b39ea5d4b5736d620483ff0c98c5eb522b96 Mon Sep 17 00:00:00 2001From: Lawrence Chen <54008264+lawrencecchen@users.noreply.github.com>Date: Sun, 19 Oct 2025 17:47:04 -0700Subject: [PATCH 5/6] wip--- apps/www/lib/utils/stack.ts | 4 ---- 1 file changed, 4 deletions(-)diff --git a/apps/www/lib/utils/stack.ts b/apps/www/lib/utils/stack.tsindex 1d2b2622a..2cbea20f9 100644--- a/apps/www/lib/utils/stack.ts+++ b/apps/www/lib/utils/stack.ts@@ -7,10 +7,6 @@ export const stackServerApp = new StackServerApp({   publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,   secretServerKey: env.STACK_SECRET_SERVER_KEY,   tokenStore: "nextjs-cookie",-  urls: {-    afterSignIn: "/handler/after-sign-in",-    afterSignUp: "/handler/after-sign-in",-  }, });  export const stackServerAppJs = new StackServerAppJs({From 19ed171a3815ac6d629d1499e173a472f5507a2d Mon Sep 17 00:00:00 2001From: Lawrence Chen <54008264+lawrencecchen@users.noreply.github.com>Date: Sun, 19 Oct 2025 18:20:54 -0700Subject: [PATCH 6/6] wip--- .../[repo]/pull/[pullNumber]/page.tsx         | 20 ++++++++++++------- 1 file changed, 13 insertions(+), 7 deletions(-)diff --git a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsxindex 58ff007fc..63a55d63c 100644--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx@@ -19,6 +19,7 @@ import {   getConvexHttpActionBaseUrl,   startCodeReviewJob, } from "@/lib/services/code-review/start-code-review";+import { type Team } from "@stackframe/stack";  type PageParams = {   teamSlugOrId: string;@@ -32,11 +33,20 @@ type PageProps = {  export const dynamic = "force-dynamic"; +async function getFirstTeam(): Promise<Team | null> {+  const teams = await stackServerApp.listTeams();+  const firstTeam = teams[0];+  if (!firstTeam) {+    return null;+  }+  return firstTeam;+}+ export async function generateMetadata({   params, }: PageProps): Promise<Metadata> {   const user = await stackServerApp.getUser({ or: "redirect" });-  const selectedTeam = user.selectedTeam;+  const selectedTeam = user.selectedTeam || (await getFirstTeam());   if (!selectedTeam) {     throw notFound();   }@@ -54,11 +64,7 @@ export async function generateMetadata({   }    try {-    const pullRequest = await fetchPullRequest(-      githubOwner,-      repo,-      pullNumber-    );+    const pullRequest = await fetchPullRequest(githubOwner, repo, pullNumber);      return {       title: `${pullRequest.title} · #${pullRequest.number} · ${githubOwner}/${repo}`,@@ -77,7 +83,7 @@ export async function generateMetadata({  export default async function PullRequestPage({ params }: PageProps) {   const user = await stackServerApp.getUser({ or: "redirect" });-  const selectedTeam = user.selectedTeam;+  const selectedTeam = user.selectedTeam || (await getFirstTeam());   if (!selectedTeam) {     throw notFound();   }
make a PR that only applies this file apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx and not the rest