### PR TITLE
Investigate mac dmg detection; fallback to arm64

### DIFF
--- a/apps/www/components/mac-download-link.tsx
+++ b/apps/www/components/mac-download-link.tsx
@@ -111,6 +111,14 @@ const resolveUrl = (
     return candidate;
   }
 
+  if (typeof urls.arm64 === "string" && urls.arm64.trim() !== "") {
+    return urls.arm64;
+  }
+
+  if (typeof urls.x64 === "string" && urls.x64.trim() !== "") {
+    return urls.x64;
+  }
+
   return fallbackUrl;
 };
 


### PR DESCRIPTION
we need to make sure that the button on the landing page download can actually figure out which mac arm 64 or x64 dmg. we do not want to redirect to the git repository if possible. figure out root cause of why sometimes it can't figure it out and instead just redirects to git repository for downloads. honestly if u cant figure it out, just default to arm64 as a fallback for now.