### PR TITLE
Clear instance/morph id on size change

### DIFF
--- a/apps/client/src/components/RepositoryPicker.tsx
+++ b/apps/client/src/components/RepositoryPicker.tsx
@@ -248,6 +248,7 @@ export function RepositoryPicker({
 
   const updateSnapshotSelection = useCallback(
     (nextSnapshotId: MorphSnapshotId) => {
+      const shouldResetInstanceId = nextSnapshotId !== selectedSnapshotId;
       setSelectedSnapshotId(nextSnapshotId);
       void navigate({
         to: "/$teamSlugOrId/environments/new",
@@ -255,7 +256,7 @@ export function RepositoryPicker({
         search: (prev) => ({
           step: prev.step ?? "select",
           selectedRepos: prev.selectedRepos ?? [],
-          instanceId: prev.instanceId,
+          instanceId: shouldResetInstanceId ? undefined : prev.instanceId,
           connectionLogin: prev.connectionLogin,
           repoSearch: prev.repoSearch,
           snapshotId: nextSnapshotId,
@@ -263,7 +264,7 @@ export function RepositoryPicker({
         replace: true,
       });
     },
-    [navigate, teamSlugOrId]
+    [navigate, selectedSnapshotId, teamSlugOrId]
   );
 
   const toggleRepo = useCallback((repo: string) => {


### PR DESCRIPTION
in environments, if we selected base machine size, and press continue, then go back, and then select a diff machine size, we need to clear query params for instance/morph id since we need to make a new instance to reflect the larger size