### PR TITLE
Add latest-release setting with new convex table

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -82,6 +82,7 @@ let pendingProtocolUrl: string | null = null;
 let mainWindow: BrowserWindow | null = null;
 let previewReloadMenuItem: MenuItem | null = null;
 let previewReloadMenuVisible = false;
+let allowPrereleasePreference = false;
 
 function getTimestamp(): string {
   return new Date().toISOString();
@@ -394,6 +395,63 @@ function registerAutoUpdateIpcHandlers(): void {
     }
   });
 
+  ipcMain.handle(
+    "cmux:auto-update:set-allow-prerelease",
+    async (_event, payload) => {
+      const allow =
+        typeof payload === "object" && payload !== null
+          ? "allowPrerelease" in payload
+            ? Boolean(
+                (payload as { allowPrerelease?: unknown }).allowPrerelease
+              )
+            : Boolean(payload)
+          : Boolean(payload);
+
+      const previous = allowPrereleasePreference;
+      allowPrereleasePreference = allow;
+      autoUpdater.allowPrerelease = allow;
+
+      mainLog("Renderer updated allowPrerelease preference", {
+        previous,
+        next: allow,
+        packaged: app.isPackaged,
+      });
+
+      if (!app.isPackaged) {
+        return {
+          ok: true as const,
+          allowPrerelease: allow,
+          checkTriggered: false as const,
+        };
+      }
+
+      if (previous === allow) {
+        return {
+          ok: true as const,
+          allowPrerelease: allow,
+          checkTriggered: false as const,
+        };
+      }
+
+      try {
+        const result = await autoUpdater.checkForUpdates();
+        logUpdateCheckResult("Renderer setAllowPrerelease", result);
+        return {
+          ok: true as const,
+          allowPrerelease: allow,
+          checkTriggered: true as const,
+        };
+      } catch (error) {
+        mainWarn(
+          "Renderer setAllowPrerelease checkForUpdates failed",
+          error
+        );
+        const err = error instanceof Error ? error : new Error(String(error));
+        throw err;
+      }
+    }
+  );
+
   ipcMain.handle("cmux:auto-update:install", async () => {
     if (!app.isPackaged) {
       mainLog(
@@ -466,7 +524,7 @@ function setupAutoUpdates(): void {
 
     autoUpdater.autoDownload = true;
     autoUpdater.autoInstallOnAppQuit = true;
-    autoUpdater.allowPrerelease = false;
+    autoUpdater.allowPrerelease = allowPrereleasePreference;
 
     if (process.platform === "darwin") {
       const suffix = process.arch === "arm64" ? "arm64" : "x64";
@@ -485,6 +543,7 @@ function setupAutoUpdates(): void {
       autoInstallOnAppQuit: autoUpdater.autoInstallOnAppQuit,
       allowPrerelease: autoUpdater.allowPrerelease,
       channel: autoUpdater.channel ?? null,
+      preference: allowPrereleasePreference,
     });
   } catch (e) {
     mainWarn("Failed to initialize autoUpdater", e);

--- a/apps/client/electron/preload/index.ts
+++ b/apps/client/electron/preload/index.ts
@@ -154,6 +154,14 @@ const cmuxAPI = {
         updateAvailable?: boolean;
         version?: string | null;
       }>,
+    setAllowPrerelease: (allow: boolean) =>
+      ipcRenderer.invoke("cmux:auto-update:set-allow-prerelease", {
+        allowPrerelease: Boolean(allow),
+      }) as Promise<{
+        ok: boolean;
+        allowPrerelease: boolean;
+        checkTriggered?: boolean;
+      }>,
     install: () =>
       ipcRenderer.invoke("cmux:auto-update:install") as Promise<{
         ok: boolean;

--- a/apps/client/src/types/electron.d.ts
+++ b/apps/client/src/types/electron.d.ts
@@ -115,6 +115,14 @@ interface CmuxAPI {
         updateAvailable?: boolean;
         version?: string | null;
       }>;
+    setAllowPrerelease: (
+      allow: boolean
+    ) =>
+      Promise<{
+        ok: boolean;
+        allowPrerelease: boolean;
+        checkTriggered?: boolean;
+      }>;
     install: () => Promise<{ ok: boolean; reason?: string }>;
   };
 }

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as github_webhook from "../github_webhook.js";
 import type * as github_workflows from "../github_workflows.js";
 import type * as http from "../http.js";
 import type * as migrations from "../migrations.js";
+import type * as releasePreferences from "../releasePreferences.js";
 import type * as stack from "../stack.js";
 import type * as stack_webhook from "../stack_webhook.js";
 import type * as stack_webhook_actions from "../stack_webhook_actions.js";
@@ -84,6 +85,7 @@ declare const fullApi: ApiFromModules<{
   github_workflows: typeof github_workflows;
   http: typeof http;
   migrations: typeof migrations;
+  releasePreferences: typeof releasePreferences;
   stack: typeof stack;
   stack_webhook: typeof stack_webhook;
   stack_webhook_actions: typeof stack_webhook_actions;

--- a/packages/convex/convex/releasePreferences.ts
+++ b/packages/convex/convex/releasePreferences.ts
@@ -1,0 +1,92 @@
+import { v } from "convex/values";
+import { resolveTeamIdLoose } from "../_shared/team";
+import { internalQuery } from "./_generated/server";
+import { authMutation, authQuery } from "./users/utils";
+
+const DEFAULT_SETTINGS = {
+  alwaysUseLatestRelease: false,
+};
+
+export const get = authQuery({
+  args: { teamSlugOrId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const settings = await ctx.db
+      .query("releasePreferences")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", teamId).eq("userId", userId)
+      )
+      .first();
+
+    if (!settings) {
+      const now = Date.now();
+      return {
+        ...DEFAULT_SETTINGS,
+        _id: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+    }
+
+    return {
+      ...DEFAULT_SETTINGS,
+      ...settings,
+    };
+  },
+});
+
+export const update = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    alwaysUseLatestRelease: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const existing = await ctx.db
+      .query("releasePreferences")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", teamId).eq("userId", userId)
+      )
+      .first();
+
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        alwaysUseLatestRelease: args.alwaysUseLatestRelease,
+        userId,
+        teamId,
+        updatedAt: now,
+      });
+      return;
+    }
+
+    await ctx.db.insert("releasePreferences", {
+      alwaysUseLatestRelease: args.alwaysUseLatestRelease,
+      createdAt: now,
+      updatedAt: now,
+      userId,
+      teamId,
+    });
+  },
+});
+
+export const getByTeamAndUserInternal = internalQuery({
+  args: { teamId: v.string(), userId: v.string() },
+  handler: async (ctx, args) => {
+    const settings = await ctx.db
+      .query("releasePreferences")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", args.teamId).eq("userId", args.userId)
+      )
+      .first();
+
+    return {
+      alwaysUseLatestRelease:
+        settings?.alwaysUseLatestRelease ??
+        DEFAULT_SETTINGS.alwaysUseLatestRelease,
+    };
+  },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -409,6 +409,13 @@ const convexSchema = defineSchema({
     userId: v.string(),
     teamId: v.string(),
   }).index("by_team_user", ["teamId", "userId"]),
+  releasePreferences: defineTable({
+    alwaysUseLatestRelease: v.boolean(), // Track latest GitHub release, including prereleases
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    userId: v.string(),
+    teamId: v.string(),
+  }).index("by_team_user", ["teamId", "userId"]),
   crownEvaluations: defineTable({
     taskId: v.id("tasks"),
     evaluatedAt: v.number(),

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: 'snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8';
+    snapshotId?: string | ('snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
i want to add to settings an option to always be on the latest release (as shown on github releases), even if it isn't officially released yet. this should be stored in a new convex table so it is persisted.