### PR TITLE
sync diff colors across codemirror and monaco

### DIFF
--- a/apps/client/src/lib/codemirror/merge-extensions.ts
+++ b/apps/client/src/lib/codemirror/merge-extensions.ts
@@ -39,6 +39,8 @@ import { dockerFile as dockerfileLanguage } from "@codemirror/legacy-modes/mode/
 import { sass as legacySass } from "@codemirror/legacy-modes/mode/sass";
 import { toml as tomlLanguage } from "@codemirror/legacy-modes/mode/toml";
 
+import { getDiffColorPalette } from "@/lib/diff-colors";
+
 import {
   diffLineNumberMarkers,
   LINE_NUMBER_ADDITION_CLASS,
@@ -81,29 +83,11 @@ const darkHighlightStyle = HighlightStyle.define([
   },
 ]);
 
-const GITHUB_ADDITION_LINE_BG = "#dafbe1";
-const GITHUB_ADDITION_GUTTER_BG = "#b8f0c8";
-const GITHUB_ADDITION_TEXT_BG = "#b8f0c8";
-const GITHUB_DELETION_LINE_BG = "#ffebe9";
-const GITHUB_DELETION_GUTTER_BG = "#ffdcd7";
-const GITHUB_DELETION_TEXT_BG = "#ffdcd7";
-const GITHUB_DARK_ADDITION_LINE = "#2ea04326";
-const GITHUB_DARK_ADDITION_GUTTER = "#3fb9504d";
-const GITHUB_DARK_DELETION_LINE = "#f851491a";
-const GITHUB_DARK_DELETION_GUTTER = "#f851494d";
-const GITHUB_ADDITION_LINE_NUMBER_LIGHT = "#116329";
-const GITHUB_ADDITION_LINE_NUMBER_DARK = "#7ee787";
-const GITHUB_DELETION_LINE_NUMBER_LIGHT = "#a0111f";
-const GITHUB_DELETION_LINE_NUMBER_DARK = "#ff7b72";
-const GITHUB_COLLAPSED_LIGHT_BG = "#E9F4FF";
-const GITHUB_COLLAPSED_LIGHT_TEXT = "#4b5563";
-const GITHUB_COLLAPSED_DARK_BG = "#1f2733";
-const GITHUB_COLLAPSED_DARK_TEXT = "#e5e7eb";
-
 export function createMergeBaseExtensions(
   theme: string | undefined,
 ): Extension[] {
   const isDark = theme === "dark";
+  const palette = getDiffColorPalette(isDark ? "dark" : "light");
   const textColor = isDark ? "#e5e7eb" : "#1f2937";
   const gutterColor = isDark ? "#9ca3af" : "#6b7280";
 
@@ -150,14 +134,10 @@ export function createMergeBaseExtensions(
         fontSize: "11px",
       },
       [`.cm-lineNumbers .cm-gutterElement.${LINE_NUMBER_ADDITION_CLASS}`]: {
-        color: isDark
-          ? GITHUB_ADDITION_LINE_NUMBER_DARK
-          : GITHUB_ADDITION_LINE_NUMBER_LIGHT,
+        color: palette.addition.lineNumberForeground,
       },
       [`.cm-lineNumbers .cm-gutterElement.${LINE_NUMBER_DELETION_CLASS}`]: {
-        color: isDark
-          ? GITHUB_DELETION_LINE_NUMBER_DARK
-          : GITHUB_DELETION_LINE_NUMBER_LIGHT,
+        color: palette.deletion.lineNumberForeground,
       },
       ".cm-activeLine": {
         backgroundColor: isDark
@@ -184,36 +164,24 @@ export function createMergeBaseExtensions(
         borderRight: `1px solid ${isDark ? "#27272a" : "#e5e5e5"}`,
       },
       ".cm-change.cm-change-insert": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_ADDITION_LINE
-          : GITHUB_ADDITION_TEXT_BG,
+        backgroundColor: palette.addition.textBackground,
         textDecoration: "none",
       },
       ".cm-change.cm-change-delete": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_DELETION_LINE
-          : GITHUB_DELETION_TEXT_BG,
+        backgroundColor: palette.deletion.textBackground,
         textDecoration: "none",
       },
       ".cm-mergeView ins.cm-insertedLine": {
         textDecoration: "none",
-        backgroundColor: isDark
-          ? GITHUB_DARK_ADDITION_LINE
-          : GITHUB_ADDITION_TEXT_BG,
+        backgroundColor: palette.addition.textBackground,
       },
       ".cm-mergeView del.cm-deletedLine": {
         textDecoration: "none",
-        backgroundColor: isDark
-          ? GITHUB_DARK_DELETION_LINE
-          : GITHUB_DELETION_TEXT_BG,
+        backgroundColor: palette.deletion.textBackground,
       },
       ".cm-collapsedLines": {
-        backgroundColor: isDark
-          ? GITHUB_COLLAPSED_DARK_BG
-          : GITHUB_COLLAPSED_LIGHT_BG,
-        color: isDark
-          ? GITHUB_COLLAPSED_DARK_TEXT
-          : GITHUB_COLLAPSED_LIGHT_TEXT,
+        backgroundColor: palette.collapsed.background,
+        color: palette.collapsed.foreground,
         padding: "5px 5px 5px 10px",
         cursor: "pointer",
         backgroundImage: "none",
@@ -222,44 +190,28 @@ export function createMergeBaseExtensions(
         backgroundColor: isDark ? "rgba(148, 163, 184, 0.18)" : "#f6f8fa",
       },
       "&.cm-merge-b .cm-changedLine": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_ADDITION_LINE
-          : GITHUB_ADDITION_LINE_BG,
+        backgroundColor: palette.addition.lineBackground,
       },
       "&.cm-merge-a .cm-changedLine": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_DELETION_LINE
-          : GITHUB_DELETION_LINE_BG,
+        backgroundColor: palette.deletion.lineBackground,
       },
       "&.cm-merge-b .cm-inlineChangedLine": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_ADDITION_LINE
-          : GITHUB_ADDITION_LINE_BG,
+        backgroundColor: palette.addition.lineBackground,
       },
       "&.cm-merge-a .cm-inlineChangedLine": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_DELETION_LINE
-          : GITHUB_DELETION_LINE_BG,
+        backgroundColor: palette.deletion.lineBackground,
       },
       "& .cm-deletedChunk": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_DELETION_LINE
-          : GITHUB_DELETION_LINE_BG,
+        backgroundColor: palette.deletion.lineBackground,
       },
       "& .cm-insertedChunk": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_ADDITION_LINE
-          : GITHUB_ADDITION_LINE_BG,
+        backgroundColor: palette.addition.lineBackground,
       },
       "&.cm-merge-b .cm-gutterElement.cm-changedLineGutter": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_ADDITION_GUTTER
-          : GITHUB_ADDITION_GUTTER_BG,
+        backgroundColor: palette.addition.gutterBackground,
       },
       "&.cm-merge-a .cm-gutterElement.cm-changedLineGutter": {
-        backgroundColor: isDark
-          ? GITHUB_DARK_DELETION_GUTTER
-          : GITHUB_DELETION_GUTTER_BG,
+        backgroundColor: palette.deletion.gutterBackground,
       },
       "&.cm-merge-b .cm-changedText": {
         background: "none",

--- a/apps/client/src/lib/diff-colors.ts
+++ b/apps/client/src/lib/diff-colors.ts
@@ -21,7 +21,7 @@ export const diffColors: Record<"light" | "dark", DiffColorPalette> = {
     addition: {
       lineBackground: "#dafbe1",
       gutterBackground: "#b8f0c8",
-      textBackground: "#b8f0c8",
+      textBackground: "#dafbe1",
       lineNumberForeground: "#116329",
     },
     deletion: {

--- a/apps/client/src/lib/diff-colors.ts
+++ b/apps/client/src/lib/diff-colors.ts
@@ -1,0 +1,60 @@
+export type DiffTone = {
+  lineBackground: string;
+  gutterBackground: string;
+  textBackground: string;
+  lineNumberForeground: string;
+};
+
+export type DiffCollapsedPalette = {
+  background: string;
+  foreground: string;
+};
+
+export type DiffColorPalette = {
+  addition: DiffTone;
+  deletion: DiffTone;
+  collapsed: DiffCollapsedPalette;
+};
+
+export const diffColors: Record<"light" | "dark", DiffColorPalette> = {
+  light: {
+    addition: {
+      lineBackground: "#dafbe1",
+      gutterBackground: "#b8f0c8",
+      textBackground: "#b8f0c8",
+      lineNumberForeground: "#116329",
+    },
+    deletion: {
+      lineBackground: "#ffebe9",
+      gutterBackground: "#ffdcd7",
+      textBackground: "#ffdcd7",
+      lineNumberForeground: "#a0111f",
+    },
+    collapsed: {
+      background: "#E9F4FF",
+      foreground: "#4b5563",
+    },
+  },
+  dark: {
+    addition: {
+      lineBackground: "#2ea04326",
+      gutterBackground: "#3fb9504d",
+      textBackground: "#2ea04326",
+      lineNumberForeground: "#7ee787",
+    },
+    deletion: {
+      lineBackground: "#f851491a",
+      gutterBackground: "#f851494d",
+      textBackground: "#f851491a",
+      lineNumberForeground: "#ff7b72",
+    },
+    collapsed: {
+      background: "#1f2733",
+      foreground: "#e5e7eb",
+    },
+  },
+};
+
+export function getDiffColorPalette(theme: "light" | "dark") {
+  return diffColors[theme];
+}

--- a/apps/client/src/lib/diff-colors.ts
+++ b/apps/client/src/lib/diff-colors.ts
@@ -27,7 +27,7 @@ export const diffColors: Record<"light" | "dark", DiffColorPalette> = {
     deletion: {
       lineBackground: "#ffebe9",
       gutterBackground: "#ffdcd7",
-      textBackground: "#ffdcd7",
+      textBackground: "#ffebe9",
       lineNumberForeground: "#a0111f",
     },
     collapsed: {

--- a/apps/client/src/lib/monaco-environment.ts
+++ b/apps/client/src/lib/monaco-environment.ts
@@ -4,6 +4,8 @@ import * as monaco from "monaco-editor";
 import "monaco-editor/esm/vs/editor/editor.all";
 import "monaco-editor/esm/vs/editor/browser/services/hoverService/hoverService";
 
+import { getDiffColorPalette } from "@/lib/diff-colors";
+
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
@@ -35,13 +37,32 @@ loader.config({
 });
 
 function defineThemes(instance: typeof monaco) {
+  const lightPalette = getDiffColorPalette("light");
+  const darkPalette = getDiffColorPalette("dark");
+
   instance.editor.defineTheme("cmux-light", {
     base: "vs",
     inherit: true,
     rules: [],
     colors: {
-      "diffEditor.unchangedRegionBackground": "#f4f4f5",
-      "diffEditor.unchangedRegionForeground": "#52525b",
+      "diffEditor.insertedTextBackground": lightPalette.addition.textBackground,
+      "diffEditor.removedTextBackground": lightPalette.deletion.textBackground,
+      "diffEditor.insertedTextBorder": lightPalette.addition.textBackground,
+      "diffEditor.removedTextBorder": lightPalette.deletion.textBackground,
+      "diffEditor.insertedLineBackground": lightPalette.addition.lineBackground,
+      "diffEditor.removedLineBackground": lightPalette.deletion.lineBackground,
+      "diffEditorGutter.insertedLineBackground": lightPalette.addition.gutterBackground,
+      "diffEditorGutter.removedLineBackground": lightPalette.deletion.gutterBackground,
+      "editorGutter.addedBackground": lightPalette.addition.gutterBackground,
+      "editorGutter.deletedBackground": lightPalette.deletion.gutterBackground,
+      "editorGutter.addedForeground": lightPalette.addition.lineNumberForeground,
+      "editorGutter.deletedForeground": lightPalette.deletion.lineNumberForeground,
+      "minimapGutter.addedBackground": lightPalette.addition.gutterBackground,
+      "minimapGutter.deletedBackground": lightPalette.deletion.gutterBackground,
+      "diffEditorOverview.insertedForeground": lightPalette.addition.gutterBackground,
+      "diffEditorOverview.removedForeground": lightPalette.deletion.gutterBackground,
+      "diffEditor.unchangedRegionBackground": lightPalette.collapsed.background,
+      "diffEditor.unchangedRegionForeground": lightPalette.collapsed.foreground,
       "diffEditor.unchangedRegionShadow": "#0f172a33",
     },
   });
@@ -51,8 +72,24 @@ function defineThemes(instance: typeof monaco) {
     inherit: true,
     rules: [],
     colors: {
-      "diffEditor.unchangedRegionBackground": "#27272a",
-      "diffEditor.unchangedRegionForeground": "#e5e5e5",
+      "diffEditor.insertedTextBackground": darkPalette.addition.textBackground,
+      "diffEditor.removedTextBackground": darkPalette.deletion.textBackground,
+      "diffEditor.insertedTextBorder": darkPalette.addition.textBackground,
+      "diffEditor.removedTextBorder": darkPalette.deletion.textBackground,
+      "diffEditor.insertedLineBackground": darkPalette.addition.lineBackground,
+      "diffEditor.removedLineBackground": darkPalette.deletion.lineBackground,
+      "diffEditorGutter.insertedLineBackground": darkPalette.addition.gutterBackground,
+      "diffEditorGutter.removedLineBackground": darkPalette.deletion.gutterBackground,
+      "editorGutter.addedBackground": darkPalette.addition.gutterBackground,
+      "editorGutter.deletedBackground": darkPalette.deletion.gutterBackground,
+      "editorGutter.addedForeground": darkPalette.addition.lineNumberForeground,
+      "editorGutter.deletedForeground": darkPalette.deletion.lineNumberForeground,
+      "minimapGutter.addedBackground": darkPalette.addition.gutterBackground,
+      "minimapGutter.deletedBackground": darkPalette.deletion.gutterBackground,
+      "diffEditorOverview.insertedForeground": darkPalette.addition.gutterBackground,
+      "diffEditorOverview.removedForeground": darkPalette.deletion.gutterBackground,
+      "diffEditor.unchangedRegionBackground": darkPalette.collapsed.background,
+      "diffEditor.unchangedRegionForeground": darkPalette.collapsed.foreground,
       "diffEditor.unchangedRegionShadow": "#00000080",
     },
   });


### PR DESCRIPTION
find out the colors we use for the codemirror diff editor and apply the colors to the monaco one as well (like the shades of green/red in both light/dark mode)