### PR TITLE
Enable native right-click context menu in Electron input

### DIFF
--- a/apps/client/electron/preload/index.ts
+++ b/apps/client/electron/preload/index.ts
@@ -121,6 +121,12 @@ const cmuxAPI = {
         Boolean(open)
       ) as Promise<{ ok: boolean }>;
     },
+    showEditContextMenu: (position?: { x?: number; y?: number }) => {
+      return ipcRenderer.invoke("cmux:ui:show-edit-context-menu", {
+        x: typeof position?.x === "number" ? position.x : undefined,
+        y: typeof position?.y === "number" ? position.y : undefined,
+      }) as Promise<{ ok: boolean }>;
+    },
     setPreviewReloadVisible: (visible: boolean) => {
       return ipcRenderer.invoke(
         "cmux:ui:set-preview-reload-visible",

--- a/apps/client/src/types/electron.d.ts
+++ b/apps/client/src/types/electron.d.ts
@@ -101,6 +101,7 @@ interface CmuxAPI {
       frameProcessId: number
     ) => Promise<{ ok: boolean; queued?: boolean }>;
     setCommandPaletteOpen: (open: boolean) => Promise<{ ok: boolean }>;
+    showEditContextMenu: (position?: { x?: number; y?: number }) => Promise<{ ok: boolean }>;
     setPreviewReloadVisible?: (visible: boolean) => Promise<{ ok: boolean }>;
     restoreLastFocus: () => Promise<{ ok: boolean; queued?: boolean }>;
   };


### PR DESCRIPTION
make right click on the dashboard input work. like it should show paste cut copy, etc. like how a standard right click on context menu should show. must use native ui. this is only when we're in electron.