### PR TITLE
Show dev script terminal in preview with toggle

### DIFF
--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -4,6 +4,7 @@ import {
   Inspect,
   Loader2,
   RefreshCw,
+  Terminal,
 } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -27,6 +28,8 @@ interface ElectronPreviewBrowserProps {
   persistKey: string;
   src: string;
   borderRadius?: number;
+  terminalVisible?: boolean;
+  onToggleTerminal?: () => void;
 }
 
 interface NativeViewHandle {
@@ -93,6 +96,8 @@ function useLoadingProgress(isLoading: boolean) {
 export function ElectronPreviewBrowser({
   persistKey,
   src,
+  terminalVisible = false,
+  onToggleTerminal,
 }: ElectronPreviewBrowserProps) {
   const [viewHandle, setViewHandle] = useState<NativeViewHandle | null>(null);
   const [addressValue, setAddressValue] = useState(src);
@@ -731,6 +736,28 @@ export function ElectronPreviewBrowser({
               disabled={!viewHandle}
             />
             <div className="flex items-center gap-1">
+              {onToggleTerminal && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={clsx(
+                        "size-7 rounded-full p-0 text-neutral-600 hover:text-neutral-800 disabled:opacity-30 disabled:hover:text-neutral-400 dark:text-neutral-500 dark:hover:text-neutral-100 dark:disabled:hover:text-neutral-500",
+                        terminalVisible && "text-primary hover:text-primary",
+                      )}
+                      onClick={onToggleTerminal}
+                      aria-label={terminalVisible ? "Hide Terminal" : "Show Terminal"}
+                    >
+                      <Terminal className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" align="end">
+                    {terminalVisible ? "Hide Terminal" : "Show Terminal"}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button

--- a/apps/client/src/components/electron-preview-browser.tsx
+++ b/apps/client/src/components/electron-preview-browser.tsx
@@ -30,6 +30,7 @@ interface ElectronPreviewBrowserProps {
   borderRadius?: number;
   terminalVisible?: boolean;
   onToggleTerminal?: () => void;
+  renderBelowAddressBar?: () => React.ReactNode;
 }
 
 interface NativeViewHandle {
@@ -98,6 +99,7 @@ export function ElectronPreviewBrowser({
   src,
   terminalVisible = false,
   onToggleTerminal,
+  renderBelowAddressBar,
 }: ElectronPreviewBrowserProps) {
   const [viewHandle, setViewHandle] = useState<NativeViewHandle | null>(null);
   const [addressValue, setAddressValue] = useState(src);
@@ -792,8 +794,8 @@ export function ElectronPreviewBrowser({
           </div>
         </form>
       </div>
-      <div className="flex-1 overflow-hidden bg-white dark:bg-neutral-950 pl-[pxpx] border-l">
-        <div className="relative h-full w-full">
+      <div className="flex-1 min-h-0 flex">
+        <div className="flex-1 overflow-hidden bg-white dark:bg-neutral-950 border-l">
           <PersistentWebView
             persistKey={persistKey}
             src={src}
@@ -805,6 +807,7 @@ export function ElectronPreviewBrowser({
             forceWebContentsViewIfElectron
           />
         </div>
+        {renderBelowAddressBar?.()}
       </div>
     </div>
   );

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -67,11 +67,12 @@ export const Route = createFileRoute(
     }
 
     try {
+      // Attach to cmux session
       const created = await createTerminalTab({
         baseUrl,
         request: {
           cmd: "tmux",
-          args: ["attach", "-t", "cmux:dev"],
+          args: ["attach", "-t", "cmux"],
         },
       });
 
@@ -85,7 +86,7 @@ export const Route = createFileRoute(
         return [...current, created.id];
       });
     } catch (error) {
-      console.error("Failed to auto-create dev script terminal", error);
+      console.error("Failed to auto-create tmux terminal", error);
     }
   },
 });
@@ -136,21 +137,22 @@ function PreviewPage() {
 
   const activeTerminalId = terminalTabsQuery.data?.[0] ?? null;
 
-  // Terminal state
-  const [isTerminalVisible, setIsTerminalVisible] = useState(() => {
-    // Default: closed, but will open if there's an error
-    return false;
-  });
+  // Terminal state - default open if preview URL is not available
+  const [isTerminalVisible, setIsTerminalVisible] = useState(() => !previewUrl);
+
+  // Update terminal visibility when preview URL changes
+  useEffect(() => {
+    if (!previewUrl) {
+      setIsTerminalVisible(true);
+    }
+  }, [previewUrl]);
 
   const [terminalWidth, setTerminalWidth] = useState(400);
   const isResizingRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleConnectionStateChange = useCallback((state: TerminalConnectionState) => {
-    // Auto-expand terminal on error
-    if (state === "error") {
-      setIsTerminalVisible(true);
-    }
+  const handleConnectionStateChange = useCallback((_state: TerminalConnectionState) => {
+    // Terminal connection state changes don't affect visibility
   }, []);
 
   const toggleTerminal = useCallback(() => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -66,28 +66,31 @@ export const Route = createFileRoute(
       return;
     }
 
-    try {
-      // Attach to cmux session
-      const created = await createTerminalTab({
-        baseUrl,
-        request: {
-          cmd: "tmux",
-          args: ["attach", "-t", "cmux"],
-        },
-      });
+    // Create terminal in background without blocking
+    (async () => {
+      try {
+        // Attach to cmux session
+        const created = await createTerminalTab({
+          baseUrl,
+          request: {
+            cmd: "tmux",
+            args: ["attach", "-t", "cmux"],
+          },
+        });
 
-      queryClient.setQueryData<TerminalTabId[]>(tabsQueryKey, (current) => {
-        if (!current || current.length === 0) {
-          return [created.id];
-        }
-        if (current.includes(created.id)) {
-          return current;
-        }
-        return [...current, created.id];
-      });
-    } catch (error) {
-      console.error("Failed to auto-create tmux terminal", error);
-    }
+        queryClient.setQueryData<TerminalTabId[]>(tabsQueryKey, (current) => {
+          if (!current || current.length === 0) {
+            return [created.id];
+          }
+          if (current.includes(created.id)) {
+            return current;
+          }
+          return [...current, created.id];
+        });
+      } catch (error) {
+        console.error("Failed to auto-create tmux terminal", error);
+      }
+    })();
   },
 });
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$port.tsx
@@ -4,9 +4,9 @@ import { api } from "@cmux/convex/api";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { useMemo, useState, useCallback, useEffect, useRef } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import z from "zod";
-import { TaskRunTerminalSession, type TerminalConnectionState } from "@/components/task-run-terminal-session";
+import { TaskRunTerminalSession } from "@/components/task-run-terminal-session";
 import { toMorphXtermBaseUrl } from "@/lib/toProxyWorkspaceUrl";
 import { createTerminalTab, terminalTabsQueryKey, terminalTabsQueryOptions, type TerminalTabId } from "@/queries/terminals";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -154,18 +154,14 @@ function PreviewPage() {
   const isResizingRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleConnectionStateChange = useCallback((_state: TerminalConnectionState) => {
-    // Terminal connection state changes don't affect visibility
-  }, []);
-
-  const toggleTerminal = useCallback(() => {
+  const toggleTerminal = () => {
     setIsTerminalVisible((prev) => !prev);
-  }, []);
+  };
 
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+  const handleResizeStart = (e: React.MouseEvent) => {
     e.preventDefault();
     isResizingRef.current = true;
-  }, []);
+  };
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
@@ -221,7 +217,6 @@ function PreviewPage() {
                       baseUrl={baseUrl}
                       terminalId={activeTerminalId}
                       isActive={true}
-                      onConnectionStateChange={handleConnectionStateChange}
                     />
                   </div>
                 </div>

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
@@ -371,112 +371,131 @@ function TaskRunTerminals() {
   }, []);
 
   const renderTerminalArea = () => {
+    const wrapperClassName =
+      "flex flex-col grow min-h-0 px-4 py-4 md:px-6 md:py-5";
+    const cardClassName =
+      "flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-neutral-200/80 bg-neutral-100/70 shadow-sm dark:border-neutral-800 dark:bg-neutral-900/40";
+
     if (!isMorphProvider) {
-      return renderMessage(
-        "Terminals are only available for Morph-based runs."
+      return (
+        <div className={wrapperClassName}>
+          <div className={cardClassName}>
+            {renderMessage("Terminals are only available for Morph-based runs.")}
+          </div>
+        </div>
       );
     }
 
     if (!xtermBaseUrl) {
-      return renderMessage(
-        "Waiting for Morph workspace to expose the terminal backend..."
+      return (
+        <div className={wrapperClassName}>
+          <div className={cardClassName}>
+            {renderMessage(
+              "Waiting for Morph workspace to expose the terminal backend..."
+            )}
+          </div>
+        </div>
       );
     }
 
+    const resolvedBaseUrl = xtermBaseUrl;
+
     return (
-      <div className="flex flex-col grow min-h-0">
-        <div className="flex items-center justify-between gap-3 border-b border-neutral-200 bg-neutral-100/70 px-3 dark:border-neutral-800 dark:bg-neutral-900/40">
-          <div className="flex items-center overflow-x-auto py-0.5">
-            {terminalIds.length > 0 ? (
-              terminalIds.map((id, index) => {
-                const state = connectionStates[id] ?? "connecting";
-                const isActive = activeTerminalId === id;
-                const isDeletingThis =
-                  isDeletingTerminal && deletingTerminalId === id;
-                return (
-                  <div key={id} className="relative pr-2">
-                    <button
-                      type="button"
-                      onClick={() => setActiveTerminalId(id)}
-                      className={clsx(
-                        "flex items-center gap-2 rounded-md pl-3 pr-8 py-1.5 text-xs font-medium transition-colors",
-                        isActive
-                          ? "bg-neutral-900 text-neutral-50 dark:bg-neutral-100 dark:text-neutral-900"
-                          : "bg-transparent text-neutral-600 hover:bg-neutral-200/70 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800/60 dark:hover:text-neutral-100"
-                      )}
-                      title={id}
-                    >
-                      <span
+      <div className={wrapperClassName}>
+        <div className={cardClassName}>
+          <div className="flex items-center justify-between gap-3 border-b border-neutral-200 bg-neutral-100/80 px-4 py-2.5 dark:border-neutral-800 dark:bg-neutral-900/50">
+            <div className="flex items-center overflow-x-auto py-0.5">
+              {terminalIds.length > 0 ? (
+                terminalIds.map((id, index) => {
+                  const state = connectionStates[id] ?? "connecting";
+                  const isActive = activeTerminalId === id;
+                  const isDeletingThis =
+                    isDeletingTerminal && deletingTerminalId === id;
+                  return (
+                    <div key={id} className="relative pr-2">
+                      <button
+                        type="button"
+                        onClick={() => setActiveTerminalId(id)}
                         className={clsx(
-                          "h-2 w-2 rounded-full",
-                          CONNECTION_STATE_COLORS[state]
+                          "flex items-center gap-2 rounded-md pl-3 pr-8 py-1.5 text-xs font-medium transition-colors",
+                          isActive
+                            ? "bg-neutral-900 text-neutral-50 dark:bg-neutral-100 dark:text-neutral-900"
+                            : "bg-transparent text-neutral-600 hover:bg-neutral-200/70 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800/60 dark:hover:text-neutral-100"
                         )}
-                      />
-                      <span className="whitespace-nowrap">
-                        Terminal {index + 1}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        event.preventDefault();
-                        if (isDeletingThis || !hasTerminalBackend) {
-                          return;
-                        }
-                        deleteTerminalMutation.mutate(id);
-                      }}
-                      disabled={isDeletingThis}
-                      className={clsx(
-                        "absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-                        isActive
-                          ? "text-neutral-100 hover:text-neutral-50 hover:bg-neutral-900/80 dark:text-neutral-700 dark:hover:text-neutral-900 dark:hover:bg-neutral-200"
-                          : "text-neutral-500 hover:text-neutral-900 hover:bg-neutral-300 dark:text-neutral-400 dark:hover:text-neutral-100 dark:hover:bg-neutral-700"
-                      )}
-                      aria-label={`Close terminal ${index + 1}`}
-                      title="Close terminal"
-                    >
-                      {isDeletingThis ? (
-                        <span className="text-[10px] font-medium leading-none">
-                          …
+                        title={id}
+                      >
+                        <span
+                          className={clsx(
+                            "h-2 w-2 rounded-full",
+                            CONNECTION_STATE_COLORS[state]
+                          )}
+                        />
+                        <span className="whitespace-nowrap">
+                          Terminal {index + 1}
                         </span>
-                      ) : (
-                        <X className="h-3 w-3" />
-                      )}
-                    </button>
-                  </div>
-                );
-              })
-            ) : (
-              <span className="text-xs text-neutral-500 dark:text-neutral-400">
-                No terminals detected yet.
-              </span>
-            )}
-          </div>
-          <div className="flex flex-col items-end gap-1 py-2">
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  if (!hasTerminalBackend || isCreatingTerminal) {
-                    return;
-                  }
-                  createTerminalMutation.mutate(undefined);
-                }}
-                disabled={!hasTerminalBackend || isCreatingTerminal}
-                className="flex items-center gap-1 rounded-md border border-neutral-200 px-2 py-1 text-xs font-medium text-neutral-600 transition hover:border-neutral-300 hover:text-neutral-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:text-neutral-100"
-              >
-                {isCreatingTerminal ? (
-                  "Creating…"
-                ) : (
-                  <>
-                    <Plus className="h-3.5 w-3.5" />
-                    <span>New Terminal</span>
-                  </>
-                )}
-              </button>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          event.preventDefault();
+                          if (isDeletingThis || !hasTerminalBackend) {
+                            return;
+                          }
+                          deleteTerminalMutation.mutate(id);
+                        }}
+                        disabled={isDeletingThis}
+                        className={clsx(
+                          "absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+                          isActive
+                            ? "text-neutral-100 hover:text-neutral-50 hover:bg-neutral-900/80 dark:text-neutral-700 dark:hover:text-neutral-900 dark:hover:bg-neutral-200"
+                            : "text-neutral-500 hover:text-neutral-900 hover:bg-neutral-300 dark:text-neutral-400 dark:hover:text-neutral-100 dark:hover:bg-neutral-700"
+                        )}
+                        aria-label={`Close terminal ${index + 1}`}
+                        title="Close terminal"
+                      >
+                        {isDeletingThis ? (
+                          <span className="text-[10px] font-medium leading-none">
+                            …
+                          </span>
+                        ) : (
+                          <X className="h-3 w-3" />
+                        )}
+                      </button>
+                    </div>
+                  );
+                })
+              ) : (
+                <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                  No terminals detected yet.
+                </span>
+              )}
             </div>
-          </div>
+            <div className="flex flex-col items-end gap-1 py-2">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!hasTerminalBackend || isCreatingTerminal) {
+                      return;
+                    }
+                    createTerminalMutation.mutate(undefined);
+                  }}
+                  disabled={!hasTerminalBackend || isCreatingTerminal}
+                  className="flex items-center gap-1 rounded-md border border-neutral-200 px-2 py-1 text-xs font-medium text-neutral-600 transition hover:border-neutral-300 hover:text-neutral-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:text-neutral-100"
+                >
+                  {isCreatingTerminal ? (
+                    "Creating…"
+                  ) : (
+                    <>
+                      <Plus className="h-3.5 w-3.5" />
+                      <span>New Terminal</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+            </div>
           {createTerminalErrorMessage ? (
             <span className="text-xs text-red-500 dark:text-red-400">
               {createTerminalErrorMessage}
@@ -487,35 +506,35 @@ function TaskRunTerminals() {
               {deleteTerminalErrorMessage}
             </span>
           ) : null}
-        </div>
-        <div className="relative flex-1 min-h-0 bg-neutral-950">
-          {tabsQuery.isLoading ? (
-            <div className="absolute inset-0 flex items-center justify-center text-sm text-neutral-300">
-              Loading terminals…
-            </div>
-          ) : tabsQuery.isError ? (
-            renderMessage(
-              tabsQuery.error instanceof Error
-                ? tabsQuery.error.message
-                : "Unable to load terminals."
-            )
-          ) : terminalIds.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center px-6 py-4 text-center text-sm text-neutral-400">
-              No terminal sessions are currently active.
-            </div>
-          ) : (
-            terminalIds.map((id) => (
-              <TaskRunTerminalSession
-                key={id}
-                baseUrl={xtermBaseUrl}
-                terminalId={id}
-                isActive={activeTerminalId === id}
-                onConnectionStateChange={(state) =>
-                  handleConnectionStateChange(id, state)
-                }
-              />
-            ))
-          )}
+          <div className="relative flex-1 min-h-0 bg-neutral-950">
+            {tabsQuery.isLoading ? (
+              <div className="absolute inset-0 flex items-center justify-center text-sm text-neutral-300">
+                Loading terminals…
+              </div>
+            ) : tabsQuery.isError ? (
+              renderMessage(
+                tabsQuery.error instanceof Error
+                  ? tabsQuery.error.message
+                  : "Unable to load terminals."
+              )
+            ) : terminalIds.length === 0 ? (
+              <div className="flex flex-1 items-center justify-center px-6 py-4 text-center text-sm text-neutral-400">
+                No terminal sessions are currently active.
+              </div>
+            ) : (
+              terminalIds.map((id) => (
+                <TaskRunTerminalSession
+                  key={id}
+                  baseUrl={resolvedBaseUrl}
+                  terminalId={id}
+                  isActive={activeTerminalId === id}
+                  onConnectionStateChange={(state) =>
+                    handleConnectionStateChange(id, state)
+                  }
+                />
+              ))
+            )}
+          </div>
         </div>
       </div>
     );

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: 'snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8';
+    snapshotId?: string | ('snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
we need to show the dev script terminal in the preview page... we can use the taskterminalsession react component already created (make sure you add the const created part with tmux attach etc). you should make a toggle next to the open in browser link next to the link that toggles the terminal view from the right side of the screen (makes the width of the preview smaller to make space for the temrinal view). the terminal view should be default closed but expanded only if there is an error. user clicks on the button on the top to toggle/show/hide the terminal view. the terminal view should be the xterm component. make sure you do this correctly. the icon should be the terminal icon and on the top bar...

can you do this without using useEffect