### PR TITLE
Link tasks to /vscode pathname

### DIFF
--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -353,12 +353,11 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
           } else if (action === "vs") {
             if (runId) {
               await router.preloadRoute({
-                to: "/$teamSlugOrId/task/$taskId/run/$runId",
+                to: "/$teamSlugOrId/task/$taskId/run/$runId/vscode",
                 params: {
                   teamSlugOrId,
                   taskId,
                   runId,
-                  taskRunId: runId,
                 },
               });
             } else {
@@ -549,12 +548,11 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
         } else if (action === "vs") {
           if (runId) {
             navigate({
-              to: "/$teamSlugOrId/task/$taskId/run/$runId",
+              to: "/$teamSlugOrId/task/$taskId/run/$runId/vscode",
               params: {
                 teamSlugOrId,
                 taskId,
                 runId,
-                taskRunId: runId,
               },
             });
           } else {

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -821,12 +821,11 @@ function TaskRunDetails({
     <Fragment>
       {hasActiveVSCode ? (
         <TaskRunDetailLink
-          to="/$teamSlugOrId/task/$taskId/run/$runId"
+          to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
           params={{
             teamSlugOrId,
             taskId,
             runId: run._id,
-            taskRunId: run._id,
           }}
           icon={
             <VSCodeIcon className="w-3 h-3 mr-2 text-neutral-400 grayscale opacity-60" />

--- a/apps/client/src/components/task-timeline.tsx
+++ b/apps/client/src/components/task-timeline.tsx
@@ -184,12 +184,11 @@ export function TaskTimeline({
         );
         content = event.runId ? (
           <Link
-            to="/$teamSlugOrId/task/$taskId/run/$runId"
+            to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
             params={{
               teamSlugOrId: params.teamSlugOrId,
               taskId: params.taskId,
               runId: event.runId,
-              taskRunId: event.runId,
             }}
             className="hover:underline inline"
           >
@@ -233,12 +232,11 @@ export function TaskTimeline({
           <>
             {event.runId ? (
               <Link
-                to="/$teamSlugOrId/task/$taskId/run/$runId"
+                to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
                 params={{
                   teamSlugOrId: params.teamSlugOrId,
                   taskId: params.taskId,
                   runId: event.runId,
-                  taskRunId: event.runId,
                 }}
                 className="hover:underline inline"
               >
@@ -293,12 +291,11 @@ export function TaskTimeline({
           <>
             {event.runId ? (
               <Link
-                to="/$teamSlugOrId/task/$taskId/run/$runId"
+                to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
                 params={{
                   teamSlugOrId: params.teamSlugOrId,
                   taskId: params.taskId,
                   runId: event.runId,
-                  taskRunId: event.runId,
                 }}
                 className="hover:underline inline"
               >
@@ -345,12 +342,11 @@ export function TaskTimeline({
           <>
             {event.runId ? (
               <Link
-                to="/$teamSlugOrId/task/$taskId/run/$runId"
+                to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
                 params={{
                   teamSlugOrId: params.teamSlugOrId,
                   taskId: params.taskId,
                   runId: event.runId,
-                  taskRunId: event.runId,
                 }}
                 className="hover:underline inline"
               >

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
@@ -116,12 +116,11 @@ function TaskDetailPage() {
 
         if (flatRuns[runIndex]) {
           navigate({
-            to: "/$teamSlugOrId/task/$taskId/run/$runId",
+            to: "/$teamSlugOrId/task/$taskId/run/$runId/vscode",
             params: {
               teamSlugOrId,
               taskId,
               runId: flatRuns[runIndex]._id,
-              taskRunId: flatRuns[runIndex]._id,
             },
           });
         }
@@ -187,12 +186,11 @@ function TaskDetailPage() {
             {flatRuns.map((run, index) => (
               <Link
                 key={run._id}
-                to="/$teamSlugOrId/task/$taskId/run/$runId"
+                to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
                 params={{
                   teamSlugOrId,
                   taskId,
                   runId: run._id,
-                  taskRunId: run._id,
                 }}
                 className={clsx(
                   "px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 transition-colors select-none",


### PR DESCRIPTION
><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play size-[9px] text-blue-600 dark:text-blue-400" aria-hidden="true"><polygon points="6 3 20 12 6 21 6 3"></polygon></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd72whz8v10z7wx6n3x962hng97sxkq6" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> started working</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play size-[9px] text-blue-600 dark:text-blue-400" aria-hidden="true"><polygon points="6 3 20 12 6 21 6 3"></polygon></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd7e4nwx4g1tgs9933b67beesh7sx8cv" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> started working</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play size-[9px] text-blue-600 dark:text-blue-400" aria-hidden="true"><polygon points="6 3 20 12 6 21 6 3"></polygon></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd75sm2j4a3j08b0h03t4q1f597sx10q" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> started working</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check size-2.5 text-green-600 dark:text-green-400" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd7e4nwx4g1tgs9933b67beesh7sx8cv" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> completed</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check size-2.5 text-green-600 dark:text-green-400" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd72whz8v10z7wx6n3x962hng97sxkq6" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> completed</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy size-2.5 text-amber-600 dark:text-amber-400" aria-hidden="true"><path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"></path><path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"></path><path d="M18 9h1.5a1 1 0 0 0 0-5H18"></path><path d="M4 22h16"></path><path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"></path><path d="M6 9H4.5a1 1 0 0 1 0-5H6"></path></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd75sm2j4a3j08b0h03t4q1f597sx10q" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> completed and won the crown</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a><div class="mt-2 text-sm text-neutral-600 dark:text-neutral-400 bg-neutral-50 dark:bg-neutral-900 rounded-md p-3">## PR Review Summary
- What Changed:
  - Adds macOS native notifications for crowned task completion.
  - Main process (apps/client/electron/main/index.ts): imports Notification, tracks active notifications, validates payloads, builds notification UI (title/subtitle/body), handles click to focus window and forward a navigation event (`cmux:event:task-notification:open-diff`) to the renderer, and registers an IPC handler `cmux:notification:task-complete`.
  - Preload (apps/client/electron/preload/*): exposes notifications.showTaskComplete to renderer and updates types to include TaskCompletionNotificationRequest.
  - New shared type/module (apps/client/src/lib/electron-notifications.ts): defines TASK_NOTIFICATION_OPEN_DIFF_EVENT and request/navigation payload types.
  - Renderer hook (apps/client/src/hooks/useTaskCompletionNotifications.ts): watches tasks, detects newly crowned completed runs, and invokes the preload notification API (avoids notifying on initial load or duplicate runs).
  - Route/layout (apps/client/src/routes/_layout.$teamSlugOrId.tsx): registers useTaskCompletionNotifications and listens for TASK_NOTIFICATION_OPEN_DIFF_EVENT to navigate to the task run diff (parses IDs with typedZid).
  - Types updated (apps/client/src/types/electron.d.ts, preload index.d.ts).

- Review Focus:
  - Event wiring: main sends `cmux:event:${TASK_NOTIFICATION_OPEN_DIFF_EVENT}` via webContents.send while renderer listens for `TASK_NOTIFICATION_OPEN_DIFF_EVENT` through window.cmux?.on — verify preload forwards/strips the `cmux:event:` prefix so the listener receives the bare event.
  - Platform restriction: code short-circuits for non-darwin; confirm intended behavior for other OSes.
  - Payload validation: ensure validateTaskCompletionNotificationPayload covers all cases (null vs undefined agentName/crownReason) and matches renderer payload shapes.
  - Error handling: check focus/navigation edge cases when mainWindow is null/destroyed and when typedZid parsing throws.
  - Resource lifecycle: activeNotifications set is used; ensure notifications always remove themselves (close/click) and cannot leak.
  - UX: subtitle/body truncation lengths and multi-line body on macOS; ensure readability.

- Test Plan:
  - On macOS build/run: create a task, crown it (complete + crowned). Confirm native notification appears with expected title, subtitle, body.
  - Click the notification: app should come to front (focused) and navigate to /$team/task/$taskId/run/$runId/diff.
  - Verify no notification on initial app load for already-crowned runs; new crown events only trigger once per run.
  - Test repeated crowns/spam protection: crown same run again — should not duplicate notification; new run ID should notify.
  - Test invalid payload via IPC (manual invoke): ensure handler returns { ok: false, reason: 'invalid-payload' } and no crash.
  - On non-mac (Linux/Windows), ensure no throw and handler returns ok or a meaningful reason; app behavior unchanged.
  - Simulate missing mainWindow/destroyed window and ensure click handler doesn’t crash.

- Follow-ups:
  - Consider adding unit tests for validateTaskCompletionNotificationPayload and e2e test for notification click -&gt; navigation.
  - Consider exposing metrics/logging for notification delivery failures or user interaction.</div><div class="mt-2 text-[13px] text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded-md p-3"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy inline size-3 mr-2" aria-hidden="true"><path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"></path><path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"></path><path d="M18 9h1.5a1 1 0 0 0 0-5H18"></path><path d="M4 22h16"></path><path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"></path><path d="M6 9H4.5a1 1 0 0 1 0-5H6"></path></svg>Most complete and well-structured: it adds typed payloads and a shared event constant, validates/normalizes input, handles macOS-only cases, queues/cleans notifications, focuses and navigates the renderer on click, and wires preload + client hooks/routes consistently. Error handling and clear separation of concerns make it the best quality overall.</div></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check size-2.5 text-green-600 dark:text-green-400" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><path d="m9 12 2 2 4-4"></path></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd7evtpyykzp764mp13w248y0s7sxymd" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">codex/gpt-5-codex-high</span><span class="text-neutral-600 dark:text-neutral-400"> completed</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 7 hours ago</span></a></div></div></div><div class="absolute left-1.5 top-5 -bottom-3 w-px transform translate-x-[1px] bg-neutral-200 dark:bg-neutral-800"></div></div><div class="relative flex gap-3"><div class="shrink-0 flex items-start justify-center"><div class="size-4 rounded-full bg-purple-100 dark:bg-purple-900/30 flex items-center justify-center"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sparkles size-2.5 text-purple-600 dark:text-purple-400" aria-hidden="true"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"></path><path d="M20 3v4"></path><path d="M22 5h-4"></path><path d="M4 17v2"></path><path d="M5 18H3"></path></svg></div></div><div class="flex-1 min-w-0 flex items-center"><div class="text-xs"><div><a href="/index.html#/manaflow/task/kn7163eq3af77z0pf4vt7046a57sxdgr/run/kd75sm2j4a3j08b0h03t4q1f597sx10q" class="hover:underline inline"><span class="font-medium text-neutral-900 dark:text-neutral-100">Crown evaluation</span><span class="text-neutral-600 dark:text-neutral-400"> completed</span><span class="text-neutral-500 dark:text-neutral-500 ml-1">about 6 hours ago</span></a></div></div></div></div></div>"""ensure we link to the /vscode pathname