### PR TITLE
Add loading and error states to Crown, update tasks table

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -197,7 +197,7 @@ function TaskTreeInner({
 
   const handleCopyDescription = useCallback(() => {
     if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(task.text).catch(() => { });
+      navigator.clipboard.writeText(task.text).catch(() => {});
     }
   }, [task.text]);
 
@@ -220,8 +220,32 @@ function TaskTreeInner({
   const taskSecondary = taskSecondaryParts.join(" • ");
 
   const canExpand = true;
+  const isCrownEvaluating = task.crownEvaluationStatus === "in_progress";
 
   const taskLeadingIcon = (() => {
+    if (isCrownEvaluating) {
+      return (
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <div className="relative flex items-center justify-center">
+              <Crown className="w-3 h-3 text-neutral-500 group-hover:animate-pulse group-hover:text-neutral-400" />
+              <span className="sr-only">Crown evaluation in progress</span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent
+            side="right"
+            sideOffset={6}
+            className="max-w-sm p-3 text-left z-[var(--z-overlay)]"
+          >
+            <p className="font-medium text-sm">Selecting best implementation</p>
+            <p className="text-xs text-muted-foreground">
+              Evaluating runs to choose the best implementation...
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
     if (task.mergeStatus && task.mergeStatus !== "none") {
       switch (task.mergeStatus) {
         case "pr_draft":
@@ -524,7 +548,9 @@ function TaskRunTreeInner({
           className="max-w-sm p-3 z-[var(--z-overlay)]"
         >
           <div className="space-y-1.5">
-            <p className="font-medium text-sm text-neutral-200">Evaluation Reason</p>
+            <p className="font-medium text-sm text-neutral-200">
+              Evaluation Reason
+            </p>
             <p className="text-xs text-neutral-400">{run.crownReason}</p>
           </div>
         </TooltipContent>
@@ -572,7 +598,7 @@ function TaskRunTreeInner({
   const shouldRenderTerminalLink = shouldRenderBrowserLink;
   const shouldRenderPullRequestLink = Boolean(
     (run.pullRequestUrl && run.pullRequestUrl !== "pending") ||
-    run.pullRequests?.some((pr) => pr.url)
+      run.pullRequests?.some((pr) => pr.url)
   );
   const shouldRenderPreviewLink = previewServices.length > 0;
   const hasOpenWithActions = openWithActions.length > 0;
@@ -801,7 +827,9 @@ function TaskRunDetails({
         className="max-w-sm p-3 z-[var(--z-overlay)]"
       >
         <div className="space-y-1.5">
-          <p className="font-medium text-sm text-neutral-200">Environment Issue</p>
+          <p className="font-medium text-sm text-neutral-200">
+            Environment Issue
+          </p>
           {environmentError?.maintenanceError && (
             <p className="text-xs text-neutral-400">
               Maintenance: {environmentError.maintenanceError}

--- a/apps/client/src/components/dashboard/CrownTooltip.tsx
+++ b/apps/client/src/components/dashboard/CrownTooltip.tsx
@@ -31,7 +31,13 @@ export function CrownStatus({ taskId, teamSlugOrId }: CrownStatusProps) {
   );
 
   const crownStatus = task?.crownEvaluationStatus ?? null;
-  const crownErrorMessage = task?.crownEvaluationError ?? null;
+  const isCrownEvaluating = task?.crownEvaluationStatus === "in_progress";
+  const rawCrownErrorMessage = task?.crownEvaluationError ?? null;
+  const crownErrorMessage =
+    rawCrownErrorMessage === "pending_evaluation" ||
+    rawCrownErrorMessage === "in_progress"
+      ? null
+      : rawCrownErrorMessage;
 
   const isLoadingRuns = taskRuns === undefined;
   const isLoadingCrownedRun = crownedRun === undefined;
@@ -44,6 +50,10 @@ export function CrownStatus({ taskId, teamSlugOrId }: CrownStatusProps) {
 
   const resolvedCrownedRun = crownedRun ?? null;
   const displayState = (() => {
+    if (isCrownEvaluating) {
+      return "evaluating" as const;
+    }
+
     if (
       !hasMultipleRuns &&
       crownStatus !== "pending" &&
@@ -63,12 +73,8 @@ export function CrownStatus({ taskId, teamSlugOrId }: CrownStatusProps) {
       return "waiting" as const;
     }
 
-    if (resolvedCrownedRun) {
+    if (resolvedCrownedRun && (crownStatus === "succeeded" || crownStatus === null)) {
       return "winner" as const;
-    }
-
-    if (crownStatus === "in_progress") {
-      return "evaluating" as const;
     }
 
     if (crownStatus === "pending") {

--- a/packages/convex/convex/crown.ts
+++ b/packages/convex/convex/crown.ts
@@ -73,11 +73,11 @@ export const evaluateAndCrownWinner = authMutation({
 
       // Check if already marked for evaluation
       if (
-        task.crownEvaluationError === "pending_evaluation" ||
-        task.crownEvaluationError === "in_progress"
+        task.crownEvaluationStatus === "pending" ||
+        task.crownEvaluationStatus === "in_progress"
       ) {
         console.log(
-          `[Crown] Task ${args.taskId} already marked for evaluation (${task.crownEvaluationError})`
+          `[Crown] Task ${args.taskId} already marked for evaluation (${task.crownEvaluationStatus})`
         );
         return "pending";
       }
@@ -85,7 +85,8 @@ export const evaluateAndCrownWinner = authMutation({
       // Mark that crown evaluation is needed
       // The server will handle the actual evaluation using Claude Code
       await ctx.db.patch(args.taskId, {
-        crownEvaluationError: "pending_evaluation",
+        crownEvaluationStatus: "pending",
+        crownEvaluationError: undefined,
         updatedAt: Date.now(),
       });
 
@@ -149,6 +150,7 @@ export const setCrownWinner = authMutation({
 
     // Clear crown evaluation error
     await ctx.db.patch(taskRun.taskId, {
+      crownEvaluationStatus: "succeeded",
       crownEvaluationError: undefined,
       updatedAt: Date.now(),
     });
@@ -350,6 +352,7 @@ export const workerFinalize = internalMutation({
     }
 
     await ctx.db.patch(args.taskId, {
+      crownEvaluationStatus: "succeeded",
       crownEvaluationError: undefined,
       isCompleted: true,
       updatedAt: now,

--- a/packages/convex/convex/crown_http.ts
+++ b/packages/convex/convex/crown_http.ts
@@ -507,6 +507,7 @@ async function handleCrownCheckRequest(
       : null,
     task: {
       text: task.text,
+      crownEvaluationStatus: task.crownEvaluationStatus ?? null,
       crownEvaluationError: task.crownEvaluationError ?? null,
       isCompleted: task.isCompleted,
       baseBranch: task.baseBranch ?? null,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -107,6 +107,14 @@ const convexSchema = defineSchema({
     userId: v.string(), // Link to user who created the task
     teamId: v.string(),
     environmentId: v.optional(v.id("environments")),
+    crownEvaluationStatus: v.optional(
+      v.union(
+        v.literal("pending"),
+        v.literal("in_progress"),
+        v.literal("succeeded"),
+        v.literal("error"),
+      ),
+    ), // State of crown evaluation workflow
     crownEvaluationError: v.optional(v.string()), // Error message if crown evaluation failed
     mergeStatus: v.optional(
       v.union(

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -284,6 +284,14 @@ export const updateCrownError = authMutation({
   args: {
     teamSlugOrId: v.string(),
     id: v.id("tasks"),
+    crownEvaluationStatus: v.optional(
+      v.union(
+        v.literal("pending"),
+        v.literal("in_progress"),
+        v.literal("succeeded"),
+        v.literal("error"),
+      ),
+    ),
     crownEvaluationError: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -314,11 +322,12 @@ export const tryBeginCrownEvaluation = authMutation({
     if (!task || task.teamId !== teamId || task.userId !== userId) {
       throw new Error("Task not found or unauthorized");
     }
-    if (task.crownEvaluationError === "in_progress") {
+    if (task.crownEvaluationStatus === "in_progress") {
       return false;
     }
     await ctx.db.patch(args.id, {
-      crownEvaluationError: "in_progress",
+      crownEvaluationStatus: "in_progress",
+      crownEvaluationError: undefined,
       updatedAt: Date.now(),
     });
     return true;
@@ -423,9 +432,7 @@ export const getTasksWithPendingCrownEvaluation = authQuery({
       .withIndex("by_team_user", (q) =>
         q.eq("teamId", teamId).eq("userId", userId),
       )
-      .filter((q) =>
-        q.eq(q.field("crownEvaluationError"), "pending_evaluation"),
-      )
+      .filter((q) => q.eq(q.field("crownEvaluationStatus"), "pending"))
       .collect();
 
     // Double-check that no evaluation exists for these tasks
@@ -557,11 +564,11 @@ export const checkAndEvaluateCrown = authMutation({
     // Check if crown evaluation is already pending or in progress
     const task = await ctx.db.get(args.taskId);
     if (
-      task?.crownEvaluationError === "pending_evaluation" ||
-      task?.crownEvaluationError === "in_progress"
+      task?.crownEvaluationStatus === "pending" ||
+      task?.crownEvaluationStatus === "in_progress"
     ) {
       console.log(
-        `[CheckCrown] Crown evaluation already ${task.crownEvaluationError} for task ${args.taskId}`,
+        `[CheckCrown] Crown evaluation already ${task.crownEvaluationStatus} for task ${args.taskId}`,
       );
       return "pending";
     }
@@ -598,6 +605,7 @@ export const checkAndEvaluateCrown = authMutation({
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       await ctx.db.patch(args.taskId, {
+        crownEvaluationStatus: "error",
         crownEvaluationError: errorMessage,
         updatedAt: Date.now(),
       });

--- a/packages/shared/src/crown/types.ts
+++ b/packages/shared/src/crown/types.ts
@@ -19,6 +19,16 @@ export const WorkerRunContextSchema = z.object({
 });
 export type WorkerRunContext = z.infer<typeof WorkerRunContextSchema>;
 
+export const CrownEvaluationStatusSchema = z.enum([
+  "pending",
+  "in_progress",
+  "succeeded",
+  "error",
+]);
+export type CrownEvaluationStatus = z.infer<
+  typeof CrownEvaluationStatusSchema
+>;
+
 export const CrownWorkerCheckResponseSchema = z.object({
   ok: z.literal(true),
   taskId: z.string(),
@@ -34,6 +44,7 @@ export const CrownWorkerCheckResponseSchema = z.object({
     .nullable(),
   task: z.object({
     text: z.string(),
+    crownEvaluationStatus: CrownEvaluationStatusSchema.nullable(),
     crownEvaluationError: z.string().nullable(),
     isCompleted: z.boolean(),
     baseBranch: z.string().nullable(),

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: 'snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8';
+    snapshotId?: string | ('snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
add loading states and error states to crown. this deserves to have its own column in the tasks table. we need to update it accordingly and ensure the logic is resilient.