### PR TITLE
Refactor heatmap to intensity-based coloring

### DIFF
--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
@@ -7,6 +7,7 @@ import { ExternalLink, GitPullRequest } from "lucide-react";
 import { type Team } from "@stackframe/stack";
 
 import { PullRequestDiffViewer } from "@/components/pr/pull-request-diff-viewer";
+import { scoreToHeatmapColor } from "@/components/pr/heatmap";
 import {
   fetchPullRequest,
   fetchPullRequestFiles,
@@ -580,8 +581,43 @@ function PullRequestDiffSummary({
           {fileCount} file{fileCount === 1 ? "" : "s"}, {additions} additions,{" "}
           {deletions} deletions
         </p>
+        <HeatmapLegend />
       </div>
     </header>
+  );
+}
+
+function HeatmapLegend() {
+  const stops: Array<{ score: number; label: string }> = [
+    { score: 0.1, label: "Low" },
+    { score: 0.35, label: "Moderate" },
+    { score: 0.55, label: "Elevated" },
+    { score: 0.75, label: "High" },
+    { score: 0.9, label: "Critical" },
+  ];
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-neutral-600">
+      <span className="font-medium text-neutral-700">Review heatmap</span>
+      <div className="flex items-center gap-1">
+        {stops.map((stop) => (
+          <span key={stop.score} className="flex items-center gap-1">
+            <span
+              aria-hidden="true"
+              className="h-3 w-3 rounded-sm border border-neutral-200 shadow-sm"
+              style={{
+                backgroundColor: scoreToHeatmapColor(stop.score, {
+                  alpha: 0.45,
+                }),
+              }}
+            />
+            <span className="hidden text-neutral-500 sm:inline">
+              {stop.label}
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -172,32 +172,42 @@ body {
 
 .cmux-heatmap-tier-1 .diff-gutter,
 .cmux-heatmap-tier-1 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(249, 115, 22, 0.08);
+  box-shadow: inset 0 0 0 999px rgba(16, 185, 129, 0.18);
 }
 
 .cmux-heatmap-tier-2 .diff-gutter,
 .cmux-heatmap-tier-2 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(249, 115, 22, 0.16);
+  box-shadow: inset 0 0 0 999px rgba(101, 163, 13, 0.18);
 }
 
 .cmux-heatmap-tier-3 .diff-gutter,
 .cmux-heatmap-tier-3 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(239, 68, 68, 0.22);
+  box-shadow: inset 0 0 0 999px rgba(250, 204, 21, 0.22);
 }
 
 .cmux-heatmap-tier-4 .diff-gutter,
 .cmux-heatmap-tier-4 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(220, 38, 38, 0.32);
+  box-shadow: inset 0 0 0 999px rgba(251, 146, 60, 0.24);
+}
+
+.cmux-heatmap-tier-5 .diff-gutter,
+.cmux-heatmap-tier-5 .diff-code {
+  box-shadow: inset 0 0 0 999px rgba(248, 113, 113, 0.28);
+}
+
+.cmux-heatmap-tier-6 .diff-gutter,
+.cmux-heatmap-tier-6 .diff-code {
+  box-shadow: inset 0 0 0 999px rgba(220, 38, 38, 0.34);
 }
 
 .dark .cmux-heatmap-tier-1 .diff-gutter,
 .dark .cmux-heatmap-tier-1 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(249, 115, 22, 0.16);
+  box-shadow: inset 0 0 0 999px rgba(16, 185, 129, 0.32);
 }
 
 .dark .cmux-heatmap-tier-2 .diff-gutter,
 .dark .cmux-heatmap-tier-2 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(249, 115, 22, 0.24);
+  box-shadow: inset 0 0 0 999px rgba(101, 163, 13, 0.32);
 }
 
 .diff-syntax {
@@ -224,12 +234,22 @@ body {
 
 .dark .cmux-heatmap-tier-3 .diff-gutter,
 .dark .cmux-heatmap-tier-3 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(239, 68, 68, 0.32);
+  box-shadow: inset 0 0 0 999px rgba(250, 204, 21, 0.28);
 }
 
 .dark .cmux-heatmap-tier-4 .diff-gutter,
 .dark .cmux-heatmap-tier-4 .diff-code {
-  box-shadow: inset 0 0 0 999px rgba(220, 38, 38, 0.4);
+  box-shadow: inset 0 0 0 999px rgba(251, 146, 60, 0.32);
+}
+
+.dark .cmux-heatmap-tier-5 .diff-gutter,
+.dark .cmux-heatmap-tier-5 .diff-code {
+  box-shadow: inset 0 0 0 999px rgba(248, 113, 113, 0.38);
+}
+
+.dark .cmux-heatmap-tier-6 .diff-gutter,
+.dark .cmux-heatmap-tier-6 .diff-code {
+  box-shadow: inset 0 0 0 999px rgba(220, 38, 38, 0.45);
 }
 
 .cmux-heatmap-char {
@@ -239,24 +259,35 @@ body {
 }
 
 .cmux-heatmap-char-wrapper {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   cursor: help;
+  border-radius: 0.35rem;
+  padding: 0 0.08rem;
 }
 
 .cmux-heatmap-char-tier-1 {
-  background-color: rgba(249, 115, 22, 0.35);
+  background-color: rgba(16, 185, 129, 0.45);
 }
 
 .cmux-heatmap-char-tier-2 {
-  background-color: rgba(249, 115, 22, 0.45);
+  background-color: rgba(101, 163, 13, 0.5);
 }
 
 .cmux-heatmap-char-tier-3 {
-  background-color: rgba(239, 68, 68, 0.5);
+  background-color: rgba(250, 204, 21, 0.55);
 }
 
 .cmux-heatmap-char-tier-4 {
-  background-color: rgba(220, 38, 38, 0.6);
+  background-color: rgba(251, 146, 60, 0.6);
+}
+
+.cmux-heatmap-char-tier-5 {
+  background-color: rgba(248, 113, 113, 0.65);
+}
+
+.cmux-heatmap-char-tier-6 {
+  background-color: rgba(220, 38, 38, 0.68);
 }
 
 .cmux-heatmap-focus td.diff-gutter,
@@ -279,19 +310,27 @@ body {
 }
 
 .dark .cmux-heatmap-char-tier-1 {
-  background-color: rgba(249, 115, 22, 0.45);
+  background-color: rgba(16, 185, 129, 0.55);
 }
 
 .dark .cmux-heatmap-char-tier-2 {
-  background-color: rgba(249, 115, 22, 0.55);
+  background-color: rgba(101, 163, 13, 0.6);
 }
 
 .dark .cmux-heatmap-char-tier-3 {
-  background-color: rgba(239, 68, 68, 0.6);
+  background-color: rgba(250, 204, 21, 0.6);
 }
 
 .dark .cmux-heatmap-char-tier-4 {
-  background-color: rgba(220, 38, 38, 0.65);
+  background-color: rgba(251, 146, 60, 0.65);
+}
+
+.dark .cmux-heatmap-char-tier-5 {
+  background-color: rgba(248, 113, 113, 0.7);
+}
+
+.dark .cmux-heatmap-char-tier-6 {
+  background-color: rgba(220, 38, 38, 0.75);
 }
 
 .cmux-heatmap-gutter {

--- a/apps/www/components/pr/heatmap.test.ts
+++ b/apps/www/components/pr/heatmap.test.ts
@@ -99,13 +99,13 @@ describe("buildDiffHeatmap", () => {
     }
 
     expect(heatmap.entries.get(2)?.score).toBeCloseTo(0.7, 5);
-    expect(heatmap.lineClasses.get(2)).toBe("cmux-heatmap-tier-3");
-    expect(heatmap.lineClasses.get(4)).toBe("cmux-heatmap-tier-4");
+    expect(heatmap.lineClasses.get(2)).toBe("cmux-heatmap-tier-4");
+    expect(heatmap.lineClasses.get(4)).toBe("cmux-heatmap-tier-5");
 
     const rangeForLine2 = heatmap.newRanges.find(
       (range) => range.lineNumber === 2
     );
-    expect(rangeForLine2?.start).toBe(6);
+    expect(rangeForLine2?.start).toBe(7);
     expect(rangeForLine2?.length).toBe(1);
 
     const rangeForLine4 = heatmap.newRanges.find(
@@ -119,11 +119,11 @@ describe("buildDiffHeatmap", () => {
     const lineFourChange = file!.hunks[0]?.changes.find(
       (change) => computeNewLineNumber(change) === 4
     );
-    const expectedStart = Math.max(
-      (lineFourChange?.content.length ?? 1) - 1,
-      0
-    );
+    expect(lineFourChange).toBeDefined();
+    const expectedStart = 28;
     expect(rangeForLine4.start).toBe(expectedStart);
-    expect(rangeForLine4.length).toBe(1);
+    expect(rangeForLine4.length).toBe(
+      (lineFourChange?.content.length ?? 0) - expectedStart
+    );
   });
 });

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: 'snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8';
+    snapshotId?: string | ('snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
clone https://github.com/stack-auth/hackathon-curator and figure out how they render the heatmap with more colorsthen refactor @manaflow-ai/cmux/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx so it has like more colors similar to hackathon-curator.like currently we only highlight a single token that's sus, but ideally we use hackathon-curator's approach and use like intensity to make it more colorful.