### PR TITLE
Copy most recent IDE settings to container

### DIFF
--- a/apps/server/src/utils/editorSettingsIntegration.test.ts
+++ b/apps/server/src/utils/editorSettingsIntegration.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { collectPreferredEditorSettingsFiles } from "./editorSettingsIntegration";
+
+async function createTempHome(prefix: string): Promise<string> {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  return base;
+}
+
+describe("collectPreferredEditorSettingsFiles", () => {
+  it("selects the most recently modified editor settings", async () => {
+    const homeDir = await createTempHome("cmux-editor-settings-");
+    try {
+      const vscodeUserDir = path.join(homeDir, ".config", "Code", "User");
+      await fs.mkdir(vscodeUserDir, { recursive: true });
+      const vscodeSettingsPath = path.join(vscodeUserDir, "settings.json");
+      await fs.writeFile(vscodeSettingsPath, JSON.stringify({ theme: "Dark" }));
+      await fs.utimes(vscodeSettingsPath, new Date(Date.now() - 20_000), new Date(Date.now() - 20_000));
+
+      const cursorUserDir = path.join(homeDir, ".config", "Cursor", "User");
+      await fs.mkdir(cursorUserDir, { recursive: true });
+      const cursorSettingsPath = path.join(cursorUserDir, "settings.json");
+      await fs.writeFile(cursorSettingsPath, JSON.stringify({ theme: "Light" }));
+      const cursorKeybindingsPath = path.join(cursorUserDir, "keybindings.json");
+      await fs.writeFile(cursorKeybindingsPath, JSON.stringify([{ key: "ctrl+k" }]));
+      const snippetDir = path.join(cursorUserDir, "snippets");
+      await fs.mkdir(snippetDir, { recursive: true });
+      const snippetPath = path.join(snippetDir, "sample.json");
+      await fs.writeFile(snippetPath, JSON.stringify({ "Print Hello": "console.log('hi')" }));
+
+      const result = await collectPreferredEditorSettingsFiles({
+        homeDir,
+        platform: "linux",
+      });
+
+      expect(result.editorId).toBe("cursor");
+      expect(result.files.length).toBeGreaterThan(0);
+
+      const userSettingsFile = result.files.find((file) =>
+        file.destinationPath.endsWith("/User/settings.json")
+      );
+      expect(userSettingsFile).toBeDefined();
+      const decodedSettings = Buffer.from(
+        userSettingsFile!.contentBase64,
+        "base64"
+      ).toString("utf8");
+      expect(decodedSettings).toContain("Light");
+
+      const snippetFile = result.files.find((file) =>
+        file.destinationPath.includes("snippets/sample.json")
+      );
+      expect(snippetFile).toBeDefined();
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns no files when no editor settings exist", async () => {
+    const homeDir = await createTempHome("cmux-editor-settings-empty-");
+    try {
+      const result = await collectPreferredEditorSettingsFiles({
+        homeDir,
+        platform: "linux",
+      });
+      expect(result.editorId).toBeUndefined();
+      expect(result.files).toHaveLength(0);
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/utils/editorSettingsIntegration.ts
+++ b/apps/server/src/utils/editorSettingsIntegration.ts
@@ -1,1 +1,281 @@
+import { type AuthFile } from "@cmux/shared";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { serverLogger } from "./fileLogger";
 
+const POSIX = path.posix;
+const HOME_PLACEHOLDER = "$HOME";
+const OPEN_VSCODE_BASE = POSIX.join(HOME_PLACEHOLDER, ".openvscode-server", "data");
+const USER_DIR = POSIX.join(OPEN_VSCODE_BASE, "User");
+const DEFAULT_PROFILE_DIR = POSIX.join(USER_DIR, "profiles", "default-profile");
+
+export type EditorId = "vscode" | "cursor" | "windsurf";
+
+interface EditorDef {
+  id: EditorId;
+  labels: string[];
+}
+
+interface SnippetExport {
+  filename: string;
+  content: string;
+  mtimeMs: number | undefined;
+}
+
+interface EditorExport {
+  id: EditorId;
+  settingsContent?: string;
+  keybindingsContent?: string;
+  snippets: SnippetExport[];
+  lastModifiedMs?: number;
+  userDir: string;
+}
+
+export interface CollectEditorSettingsOptions {
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+interface CollectContext {
+  homeDir: string;
+  platform: NodeJS.Platform;
+}
+
+const EDITORS: EditorDef[] = [
+  {
+    id: "vscode",
+    labels: ["Code", "Code - Insiders", "VSCodium"],
+  },
+  {
+    id: "cursor",
+    labels: ["Cursor"],
+  },
+  {
+    id: "windsurf",
+    labels: ["Windsurf"],
+  },
+];
+
+function candidateUserDir(
+  appFolderName: string,
+  context: CollectContext
+): string {
+  const { homeDir, platform } = context;
+  if (platform === "darwin") {
+    return path.join(homeDir, "Library", "Application Support", appFolderName, "User");
+  }
+  if (platform === "win32") {
+    const appData =
+      process.env.APPDATA || path.join(homeDir, "AppData", "Roaming");
+    return path.join(appData, appFolderName, "User");
+  }
+  return path.join(homeDir, ".config", appFolderName, "User");
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFileIfExists(target: string): Promise<{
+  content: string;
+  mtimeMs: number | undefined;
+} | null> {
+  try {
+    const content = await fs.readFile(target, "utf8");
+    const stat = await fs.stat(target);
+    return { content, mtimeMs: stat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+async function collectSnippetExports(snippetsDir: string): Promise<SnippetExport[]> {
+  try {
+    const entries = await fs.readdir(snippetsDir, { withFileTypes: true });
+    const snippets: SnippetExport[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.toLowerCase().endsWith(".json")) continue;
+      const snippetPath = path.join(snippetsDir, entry.name);
+      try {
+        const content = await fs.readFile(snippetPath, "utf8");
+        const stat = await fs.stat(snippetPath);
+        snippets.push({
+          filename: entry.name,
+          content,
+          mtimeMs: stat.mtimeMs,
+        });
+      } catch (error) {
+        serverLogger.debug(
+          `[EditorSettings] Failed to read snippet ${snippetPath}:`,
+          error
+        );
+      }
+    }
+    return snippets;
+  } catch {
+    return [];
+  }
+}
+
+function computeLastModified(
+  parts: Array<number | undefined>
+): number | undefined {
+  const timestamps = parts.filter(
+    (value): value is number => typeof value === "number" && !Number.isNaN(value)
+  );
+  if (timestamps.length === 0) return undefined;
+  return Math.max(...timestamps);
+}
+
+async function collectEditorExport(
+  def: EditorDef,
+  context: CollectContext
+): Promise<EditorExport | null> {
+  let userDir: string | null = null;
+  for (const label of def.labels) {
+    const cand = candidateUserDir(label, context);
+    if (await pathExists(cand)) {
+      userDir = cand;
+      break;
+    }
+  }
+
+  if (!userDir) {
+    return null;
+  }
+
+  const settingsPath = path.join(userDir, "settings.json");
+  const keybindingsPath = path.join(userDir, "keybindings.json");
+  const snippetsDir = path.join(userDir, "snippets");
+
+  const settings = await readFileIfExists(settingsPath);
+  const keybindings = await readFileIfExists(keybindingsPath);
+  const snippets = await collectSnippetExports(snippetsDir);
+
+  if (!settings && !keybindings && snippets.length === 0) {
+    return null;
+  }
+
+  const lastModifiedMs = computeLastModified([
+    settings?.mtimeMs,
+    keybindings?.mtimeMs,
+    ...snippets.map((snippet) => snippet.mtimeMs),
+  ]);
+
+  return {
+    id: def.id,
+    settingsContent: settings?.content,
+    keybindingsContent: keybindings?.content,
+    snippets,
+    lastModifiedMs,
+    userDir,
+  };
+}
+
+function toAuthFile(destination: string, content: string): AuthFile {
+  return {
+    destinationPath: destination,
+    contentBase64: Buffer.from(content, "utf8").toString("base64"),
+    mode: "600",
+  };
+}
+
+function selectPreferredEditor(exports: EditorExport[]): EditorExport | null {
+  if (exports.length === 0) return null;
+  const order: Record<EditorId, number> = { vscode: 0, cursor: 1, windsurf: 2 };
+
+  return exports.reduce<EditorExport>((best, current) => {
+    const bestTime = best.lastModifiedMs ?? -Infinity;
+    const currentTime = current.lastModifiedMs ?? -Infinity;
+    if (currentTime > bestTime) {
+      return current;
+    }
+    if (currentTime === bestTime) {
+      return order[current.id] < order[best.id] ? current : best;
+    }
+    return best;
+  });
+}
+
+export async function collectPreferredEditorSettingsFiles(
+  options: CollectEditorSettingsOptions = {}
+): Promise<{ files: AuthFile[]; editorId?: EditorId }> {
+  const context: CollectContext = {
+    homeDir: options.homeDir ?? os.homedir(),
+    platform: options.platform ?? process.platform,
+  };
+
+  const exports: EditorExport[] = [];
+  for (const def of EDITORS) {
+    try {
+      const result = await collectEditorExport(def, context);
+      if (result) {
+        exports.push(result);
+      }
+    } catch (error) {
+      serverLogger.debug(
+        `[EditorSettings] Failed to collect settings for ${def.id}:`,
+        error
+      );
+    }
+  }
+
+  if (exports.length === 0) {
+    serverLogger.info("[EditorSettings] No editor settings detected on host");
+    return { files: [], editorId: undefined };
+  }
+
+  const preferred = selectPreferredEditor(exports);
+  if (!preferred) {
+    serverLogger.info(
+      "[EditorSettings] No preferred editor determined from collected settings"
+    );
+    return { files: [], editorId: undefined };
+  }
+
+  const files: AuthFile[] = [];
+
+  if (preferred.settingsContent) {
+    const destinations = [
+      POSIX.join(USER_DIR, "settings.json"),
+      POSIX.join(DEFAULT_PROFILE_DIR, "settings.json"),
+    ];
+    for (const destination of destinations) {
+      files.push(toAuthFile(destination, preferred.settingsContent));
+    }
+  }
+
+  if (preferred.keybindingsContent) {
+    const destinations = [
+      POSIX.join(USER_DIR, "keybindings.json"),
+      POSIX.join(DEFAULT_PROFILE_DIR, "keybindings.json"),
+    ];
+    for (const destination of destinations) {
+      files.push(toAuthFile(destination, preferred.keybindingsContent));
+    }
+  }
+
+  for (const snippet of preferred.snippets) {
+    files.push(
+      toAuthFile(
+        POSIX.join(USER_DIR, "snippets", snippet.filename),
+        snippet.content
+      )
+    );
+  }
+
+  if (files.length > 0) {
+    serverLogger.info(
+      `[EditorSettings] Prepared ${files.length} file(s) from ${preferred.id} settings (${preferred.userDir})`
+    );
+  }
+
+  return { files, editorId: preferred.id };
+}


### PR DESCRIPTION
/*
  Export VS Code, Cursor, and Windsurf user settings, keybindings, snippets, and extensions
  into the current working directory as JSON files. Adds timestamps for settings mtime and
  guesses the default editor based on most recently modified settings.
*/


import { promises as fs } from "node:fs";
import { existsSync, readdirSync } from "node:fs";
import path from "node:path";
import os from "node:os";
import { execFileSync } from "node:child_process";


type EditorId = "vscode" | "cursor" | "windsurf";


interface EditorDef {
  id: EditorId;
  labels: string[]; // Human/app folder names to scan
  cliCandidates: string[]; // command names or absolute paths
  extDirs: string[]; // fallback extension directories
}


interface ExportEntry {
  userDir?: string;
  found: boolean;
  settingsPath?: string;
  keybindingsPath?: string;
  settingsMtimeISO?: string;
  settingsMtimeMs?: number;
  exports: {
    settings?: string;
    keybindings?: string;
    snippets?: string[];
    extensions?: string;
  };
  notes?: string[];
}


const home = os.homedir();
const cwd = process.cwd();


function isMac() { return process.platform === "darwin"; }
function isWin() { return process.platform === "win32"; }


function candidateUserDir(appFolderName: string): string {
  if (isMac()) {
    return path.join(home, "Library", "Application Support", appFolderName, "User");
  }
  if (isWin()) {
    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
    return path.join(appData, appFolderName, "User");
  }
  // Linux and others
  return path.join(home, ".config", appFolderName, "User");
}


function macAppBin(appName: string, bin: string) {
  return path.join("/Applications", `${appName}.app`, "Contents", "Resources", "app", "bin", bin);
}


const editors: EditorDef[] = [
  {
    id: "vscode",
    labels: ["Code", "Code - Insiders", "VSCodium"],
    cliCandidates: [
      "code",
      "code-insiders",
      "codium",
      macAppBin("Visual Studio Code", "code"),
      macAppBin("Visual Studio Code - Insiders", "code-insiders"),
      macAppBin("VSCodium", "codium"),
    ],
    extDirs: [
      path.join(home, ".vscode", "extensions"),
      path.join(home, ".vscode-insiders", "extensions"),
      path.join(home, ".vscodium", "extensions"),
    ],
  },
  {
    id: "cursor",
    labels: ["Cursor"],
    cliCandidates: [
      "cursor",
      macAppBin("Cursor", "cursor"),
    ],
    extDirs: [
      path.join(home, ".cursor", "extensions"),
    ],
  },
  {
    id: "windsurf",
    labels: ["Windsurf"],
    cliCandidates: [
      "windsurf",
      macAppBin("Windsurf", "windsurf"),
    ],
    extDirs: [
      path.join(home, ".windsurf", "extensions"),
    ],
  },
];


function findFirstExisting(...candidates: string[]): string | undefined {
  for (const c of candidates) {
    try {
      if (c && existsSync(c)) return c;
    } catch {}
  }
  return undefined;
}


function listJsonFilesSync(dir: string): string[] {
  try {
    return readdirSync(dir)
      .filter((f) => f.toLowerCase().endsWith(".json"))
      .map((f) => path.join(dir, f));
  } catch {
    return [];
  }
}


function runCliListExtensions(cliCandidates: string[]): string[] | undefined {
  for (const cli of cliCandidates) {
    try {
      if (!cli) continue;
      // If absolute, ensure exists; if command name, let exec try
      if (path.isAbsolute(cli) && !existsSync(cli)) continue;
      const out = execFileSync(cli, ["--list-extensions", "--show-versions"], {
        encoding: "utf8",
        stdio: ["ignore", "pipe", "ignore"],
      });
      const lines = out.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
      if (lines.length) return lines;
    } catch (_) {
      // try next candidate
    }
  }
  return undefined;
}


function listExtensionsFromDirs(dirs: string[]): string[] | undefined {
  const names: string[] = [];
  for (const d of dirs) {
    try {
      if (!existsSync(d)) continue;
      const entries = readdirSync(d, { withFileTypes: true });
      for (const ent of entries) {
        if (ent.isDirectory()) {
          const n = ent.name.trim();
          if (n && !n.startsWith(".")) names.push(n);
        }
      }
    } catch (_) {}
  }
  if (names.length) return Array.from(new Set(names)).sort();
  return undefined;
}


async function exportEditor(def: EditorDef): Promise<ExportEntry> {
  const res: ExportEntry = {
    found: false,
    exports: {},
    notes: [],
  };


  // Find a User dir
  let userDir: string | undefined;
  for (const label of def.labels) {
    const cand = candidateUserDir(label);
    if (existsSync(cand)) { userDir = cand; break; }
  }
  if (!userDir) {
    res.notes!.push("User dir not found for labels: " + def.labels.join(", "));
    return res;
  }


  res.found = true;
  res.userDir = userDir;


  // Copy settings and keybindings
  const settingsSrc = path.join(userDir, "settings.json");
  const keybindingsSrc = path.join(userDir, "keybindings.json");
  const prefix = def.id;


  if (existsSync(settingsSrc)) {
    const settingsDest = path.join(cwd, `${prefix}.settings.json`);
    await fs.copyFile(settingsSrc, settingsDest);
    res.exports.settings = path.basename(settingsDest);
    res.settingsPath = settingsSrc;
    try {
      const st = await fs.stat(settingsSrc);
      res.settingsMtimeMs = st.mtimeMs;
      res.settingsMtimeISO = new Date(st.mtimeMs).toISOString();
    } catch (_) {}
  } else {
    res.notes!.push("settings.json not found");
  }


  if (existsSync(keybindingsSrc)) {
    const keybindingsDest = path.join(cwd, `${prefix}.keybindings.json`);
    await fs.copyFile(keybindingsSrc, keybindingsDest);
    res.exports.keybindings = path.basename(keybindingsDest);
    res.keybindingsPath = keybindingsSrc;
  }


  // Copy snippets JSON files
  const snippetsDir = path.join(userDir, "snippets");
  const snippetTargets: string[] = [];
  if (existsSync(snippetsDir)) {
    const snippetFiles = listJsonFilesSync(snippetsDir);
    for (const sf of snippetFiles) {
      const dest = path.join(cwd, `${prefix}.snippet.${path.basename(sf)}`);
      await fs.copyFile(sf, dest);
      snippetTargets.push(path.basename(dest));
    }
  }
  if (snippetTargets.length) res.exports.snippets = snippetTargets;


  // Extensions: prefer CLI, else read extension directories
  let extensions: string[] | undefined = runCliListExtensions(def.cliCandidates);
  if (!extensions) {
    extensions = listExtensionsFromDirs(def.extDirs);
    if (extensions) res.notes!.push("extensions from directory fallback");
  }
  if (extensions) {
    const extPath = path.join(cwd, `${prefix}.extensions.json`);
    await fs.writeFile(extPath, JSON.stringify(extensions, null, 2));
    res.exports.extensions = path.basename(extPath);
  }


  return res;
}


async function main() {
  const startedAt = new Date();
  const defaultEntry = (): ExportEntry => ({ found: false, exports: {} });
  const results: Record<EditorId, ExportEntry> = {
    vscode: defaultEntry(),
    cursor: defaultEntry(),
    windsurf: defaultEntry(),
  };


  for (const def of editors) {
    const out = await exportEditor(def);
    results[def.id] = out;
    console.log(`[export] ${def.id}: ${out.found ? "ok" : "not found"}`);
  }


  // Guess default editor by most recent settings mtime
  let guess: EditorId | undefined;
  let best = -Infinity;
  for (const id of Object.keys(results) as EditorId[]) {
    const r = results[id];
    if (r.settingsMtimeMs && r.settingsMtimeMs > best) {
      best = r.settingsMtimeMs;
      guess = id;
    }
  }


  // Build index of JSON files in cwd
  const files = (await fs.readdir(cwd)).filter((f) => f.endsWith(".json"));
  const indexMap = new Map<string, string[]>();
  for (const f of files) {
    const key = f.split(".")[0] as string;
    const arr = indexMap.get(key) ?? [];
    arr.push(f);
    indexMap.set(key, arr);
  }
  const index: Record<string, string[]> = Object.fromEntries(
    Array.from(indexMap.entries()).map(([k, v]) => [k, v.sort()])
  );


  const summary = {
    exportedAtISO: startedAt.toISOString(),
    exportedAtEpochMs: startedAt.getTime(),
    editors: results,
    guessedDefaultEditor: guess || null,
  };


  await fs.writeFile(path.join(cwd, "summary.json"), JSON.stringify(summary, null, 2));
  await fs.writeFile(path.join(cwd, "index.json"), JSON.stringify(index, null, 2));


  console.log("Wrote summary.json and index.json");
  if (guess) {
    console.log(`Guessed default editor: ${guess}`);
  } else {
    console.log("Could not determine default editor (no settings found)");
  }
}


main().catch((err) => {
  console.error(err);
  process.exitCode = 1;
});
incorporate above code into electron. we need to copy over the most likely vscode IDE setting (either cursor or vscode or windsurf, depending on which one was most recent)copy it over to $HOME/.openvscode-server/data in the morph/docker containerInside that directory you’ll find the usual VS Code layout (User/settings.json, User/keybindings.json, etc.).