### PR TITLE
Copy most recent IDE settings to container

### DIFF
--- a/apps/server/src/utils/editorSettingsSync.ts
+++ b/apps/server/src/utils/editorSettingsSync.ts
@@ -1,0 +1,319 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { Socket } from "@cmux/shared/socket";
+import type { ServerToWorkerEvents, WorkerToServerEvents } from "@cmux/shared";
+import { workerExec } from "./workerExec";
+
+const execFileAsync = promisify(execFile);
+
+export type EditorId = "vscode" | "cursor" | "windsurf";
+
+interface EditorDef {
+  id: EditorId;
+  labels: string[];
+  cliCandidates: string[];
+  extDirs: string[];
+}
+
+interface FilePayload {
+  sourcePath: string;
+  content: string;
+  mtimeMs?: number;
+}
+
+export interface SnippetPayload {
+  filename: string;
+  content: string;
+}
+
+export interface EditorSettingsSelection {
+  id: EditorId;
+  userDir: string;
+  settings?: FilePayload;
+  keybindings?: FilePayload;
+  snippets: SnippetPayload[];
+  extensions?: string[];
+}
+
+const homeDir = os.homedir();
+
+function isMac(): boolean {
+  return process.platform === "darwin";
+}
+
+function isWindows(): boolean {
+  return process.platform === "win32";
+}
+
+function candidateUserDir(appFolderName: string): string {
+  if (isMac()) {
+    return path.join(homeDir, "Library", "Application Support", appFolderName, "User");
+  }
+  if (isWindows()) {
+    const appData = process.env.APPDATA || path.join(homeDir, "AppData", "Roaming");
+    return path.join(appData, appFolderName, "User");
+  }
+  return path.join(homeDir, ".config", appFolderName, "User");
+}
+
+function macAppBin(appName: string, bin: string): string {
+  return path.join("/Applications", `${appName}.app`, "Contents", "Resources", "app", "bin", bin);
+}
+
+const EDITORS: EditorDef[] = [
+  {
+    id: "vscode",
+    labels: ["Code", "Code - Insiders", "VSCodium"],
+    cliCandidates: [
+      "code",
+      "code-insiders",
+      "codium",
+      macAppBin("Visual Studio Code", "code"),
+      macAppBin("Visual Studio Code - Insiders", "code-insiders"),
+      macAppBin("VSCodium", "codium"),
+    ],
+    extDirs: [
+      path.join(homeDir, ".vscode", "extensions"),
+      path.join(homeDir, ".vscode-insiders", "extensions"),
+      path.join(homeDir, ".vscodium", "extensions"),
+    ],
+  },
+  {
+    id: "cursor",
+    labels: ["Cursor"],
+    cliCandidates: [
+      "cursor",
+      macAppBin("Cursor", "cursor"),
+    ],
+    extDirs: [path.join(homeDir, ".cursor", "extensions")],
+  },
+  {
+    id: "windsurf",
+    labels: ["Windsurf"],
+    cliCandidates: [
+      "windsurf",
+      macAppBin("Windsurf", "windsurf"),
+    ],
+    extDirs: [path.join(homeDir, ".windsurf", "extensions")],
+  },
+];
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFilePayload(target: string, includeMtime = false): Promise<FilePayload | undefined> {
+  try {
+    const content = await fs.readFile(target, "utf8");
+    const payload: FilePayload = { sourcePath: target, content };
+    if (includeMtime) {
+      const stat = await fs.stat(target);
+      payload.mtimeMs = stat.mtimeMs;
+    }
+    return payload;
+  } catch {
+    return undefined;
+  }
+}
+
+async function listSnippetPayloads(dir: string): Promise<SnippetPayload[]> {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const jsonFiles = entries.filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".json"));
+    const snippets: SnippetPayload[] = [];
+    for (const file of jsonFiles) {
+      const absPath = path.join(dir, file.name);
+      try {
+        const content = await fs.readFile(absPath, "utf8");
+        snippets.push({ filename: file.name, content });
+      } catch {
+        // ignore individual snippet failures
+      }
+    }
+    return snippets;
+  } catch {
+    return [];
+  }
+}
+
+async function runCliListExtensions(cliCandidates: string[]): Promise<string[] | undefined> {
+  for (const cli of cliCandidates) {
+    if (!cli) continue;
+    try {
+      const { stdout } = await execFileAsync(cli, ["--list-extensions", "--show-versions"], {
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const lines = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+      if (lines.length > 0) {
+        return lines;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  return undefined;
+}
+
+async function listExtensionsFromDirs(dirs: string[]): Promise<string[] | undefined> {
+  const names = new Set<string>();
+  for (const dir of dirs) {
+    if (!(await pathExists(dir))) continue;
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const name = entry.name.trim();
+          if (name && !name.startsWith(".")) names.add(name);
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  if (names.size === 0) return undefined;
+  return Array.from(names).sort();
+}
+
+async function resolveEditorSelection(def: EditorDef): Promise<EditorSettingsSelection | null> {
+  for (const label of def.labels) {
+    const candidateDir = candidateUserDir(label);
+    if (!(await pathExists(candidateDir))) continue;
+
+    const settingsPath = path.join(candidateDir, "settings.json");
+    const keybindingsPath = path.join(candidateDir, "keybindings.json");
+    const snippetsDir = path.join(candidateDir, "snippets");
+
+    const [settings, keybindings] = await Promise.all([
+      readFilePayload(settingsPath, true),
+      readFilePayload(keybindingsPath),
+    ]);
+    const snippets = await listSnippetPayloads(snippetsDir);
+
+    let extensions = await runCliListExtensions(def.cliCandidates);
+    if (!extensions) {
+      extensions = await listExtensionsFromDirs(def.extDirs);
+    }
+
+    return {
+      id: def.id,
+      userDir: candidateDir,
+      settings,
+      keybindings,
+      snippets,
+      extensions,
+    };
+  }
+  return null;
+}
+
+export interface EditorDetectionResult {
+  selection: EditorSettingsSelection | null;
+  all: EditorSettingsSelection[];
+}
+
+export async function detectPreferredEditorSettings(): Promise<EditorDetectionResult> {
+  const results: EditorSettingsSelection[] = [];
+  for (const def of EDITORS) {
+    const selection = await resolveEditorSelection(def);
+    if (selection) {
+      results.push(selection);
+    }
+  }
+
+  if (results.length === 0) {
+    return { selection: null, all: [] };
+  }
+
+  let best = results[0];
+  for (const candidate of results.slice(1)) {
+    const bestMtime = best.settings?.mtimeMs ?? -Infinity;
+    const candidateMtime = candidate.settings?.mtimeMs ?? -Infinity;
+    if (candidateMtime > bestMtime) {
+      best = candidate;
+    }
+  }
+
+  return { selection: best, all: results };
+}
+
+interface Logger {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  warn(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export async function syncEditorSettingsToWorker(options: {
+  workerSocket: Socket<WorkerToServerEvents, ServerToWorkerEvents>;
+  logger: Logger;
+  selection: EditorSettingsSelection;
+}): Promise<void> {
+  const { workerSocket, logger, selection } = options;
+
+  const USER_DIR_REF = "${USER_DIR}";
+  const SNIPPETS_DIR_REF = "${SNIPPETS_DIR}";
+
+  const lines: string[] = [
+    "set -euo pipefail",
+    'BASE_DIR="${HOME}/.openvscode-server/data"',
+    'USER_DIR="${BASE_DIR}/User"',
+    'mkdir -p "${USER_DIR}"',
+  ];
+
+  if (selection.settings) {
+    const base64 = Buffer.from(selection.settings.content, "utf8").toString("base64");
+    lines.push(`echo '${base64}' | base64 --decode > "${USER_DIR_REF}/settings.json"`);
+  }
+
+  if (selection.keybindings) {
+    const base64 = Buffer.from(selection.keybindings.content, "utf8").toString("base64");
+    lines.push(`echo '${base64}' | base64 --decode > "${USER_DIR_REF}/keybindings.json"`);
+  }
+
+  if (selection.snippets.length > 0) {
+    lines.push('SNIPPETS_DIR="${USER_DIR}/snippets"');
+    lines.push('rm -rf "${SNIPPETS_DIR}"');
+    lines.push('mkdir -p "${SNIPPETS_DIR}"');
+    for (const snippet of selection.snippets) {
+      const base64 = Buffer.from(snippet.content, "utf8").toString("base64");
+      const safeName = snippet.filename.replace(/"/g, '\\"');
+      lines.push(`echo '${base64}' | base64 --decode > "${SNIPPETS_DIR_REF}/${safeName}"`);
+    }
+  }
+
+  const script = lines.join("\n");
+
+  try {
+    await workerExec({
+      workerSocket,
+      command: "bash",
+      args: ["-lc", script],
+      cwd: "/root",
+      env: {},
+      timeout: 30_000,
+    });
+    logger.info("Synced editor settings", {
+      editor: selection.id,
+      userDir: selection.userDir,
+      settingsPath: selection.settings?.sourcePath,
+      keybindingsPath: selection.keybindings?.sourcePath,
+      snippetCount: selection.snippets.length,
+    });
+  } catch (error) {
+    logger.warn("Failed to sync editor settings", {
+      editor: selection.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
/*
  Export VS Code, Cursor, and Windsurf user settings, keybindings, snippets, and extensions
  into the current working directory as JSON files. Adds timestamps for settings mtime and
  guesses the default editor based on most recently modified settings.
*/


import { promises as fs } from "node:fs";
import { existsSync, readdirSync } from "node:fs";
import path from "node:path";
import os from "node:os";
import { execFileSync } from "node:child_process";


type EditorId = "vscode" | "cursor" | "windsurf";


interface EditorDef {
  id: EditorId;
  labels: string[]; // Human/app folder names to scan
  cliCandidates: string[]; // command names or absolute paths
  extDirs: string[]; // fallback extension directories
}


interface ExportEntry {
  userDir?: string;
  found: boolean;
  settingsPath?: string;
  keybindingsPath?: string;
  settingsMtimeISO?: string;
  settingsMtimeMs?: number;
  exports: {
    settings?: string;
    keybindings?: string;
    snippets?: string[];
    extensions?: string;
  };
  notes?: string[];
}


const home = os.homedir();
const cwd = process.cwd();


function isMac() { return process.platform === "darwin"; }
function isWin() { return process.platform === "win32"; }


function candidateUserDir(appFolderName: string): string {
  if (isMac()) {
    return path.join(home, "Library", "Application Support", appFolderName, "User");
  }
  if (isWin()) {
    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
    return path.join(appData, appFolderName, "User");
  }
  // Linux and others
  return path.join(home, ".config", appFolderName, "User");
}


function macAppBin(appName: string, bin: string) {
  return path.join("/Applications", `${appName}.app`, "Contents", "Resources", "app", "bin", bin);
}


const editors: EditorDef[] = [
  {
    id: "vscode",
    labels: ["Code", "Code - Insiders", "VSCodium"],
    cliCandidates: [
      "code",
      "code-insiders",
      "codium",
      macAppBin("Visual Studio Code", "code"),
      macAppBin("Visual Studio Code - Insiders", "code-insiders"),
      macAppBin("VSCodium", "codium"),
    ],
    extDirs: [
      path.join(home, ".vscode", "extensions"),
      path.join(home, ".vscode-insiders", "extensions"),
      path.join(home, ".vscodium", "extensions"),
    ],
  },
  {
    id: "cursor",
    labels: ["Cursor"],
    cliCandidates: [
      "cursor",
      macAppBin("Cursor", "cursor"),
    ],
    extDirs: [
      path.join(home, ".cursor", "extensions"),
    ],
  },
  {
    id: "windsurf",
    labels: ["Windsurf"],
    cliCandidates: [
      "windsurf",
      macAppBin("Windsurf", "windsurf"),
    ],
    extDirs: [
      path.join(home, ".windsurf", "extensions"),
    ],
  },
];


function findFirstExisting(...candidates: string[]): string | undefined {
  for (const c of candidates) {
    try {
      if (c && existsSync(c)) return c;
    } catch {}
  }
  return undefined;
}


function listJsonFilesSync(dir: string): string[] {
  try {
    return readdirSync(dir)
      .filter((f) => f.toLowerCase().endsWith(".json"))
      .map((f) => path.join(dir, f));
  } catch {
    return [];
  }
}


function runCliListExtensions(cliCandidates: string[]): string[] | undefined {
  for (const cli of cliCandidates) {
    try {
      if (!cli) continue;
      // If absolute, ensure exists; if command name, let exec try
      if (path.isAbsolute(cli) && !existsSync(cli)) continue;
      const out = execFileSync(cli, ["--list-extensions", "--show-versions"], {
        encoding: "utf8",
        stdio: ["ignore", "pipe", "ignore"],
      });
      const lines = out.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
      if (lines.length) return lines;
    } catch (_) {
      // try next candidate
    }
  }
  return undefined;
}


function listExtensionsFromDirs(dirs: string[]): string[] | undefined {
  const names: string[] = [];
  for (const d of dirs) {
    try {
      if (!existsSync(d)) continue;
      const entries = readdirSync(d, { withFileTypes: true });
      for (const ent of entries) {
        if (ent.isDirectory()) {
          const n = ent.name.trim();
          if (n && !n.startsWith(".")) names.push(n);
        }
      }
    } catch (_) {}
  }
  if (names.length) return Array.from(new Set(names)).sort();
  return undefined;
}


async function exportEditor(def: EditorDef): Promise<ExportEntry> {
  const res: ExportEntry = {
    found: false,
    exports: {},
    notes: [],
  };


  // Find a User dir
  let userDir: string | undefined;
  for (const label of def.labels) {
    const cand = candidateUserDir(label);
    if (existsSync(cand)) { userDir = cand; break; }
  }
  if (!userDir) {
    res.notes!.push("User dir not found for labels: " + def.labels.join(", "));
    return res;
  }


  res.found = true;
  res.userDir = userDir;


  // Copy settings and keybindings
  const settingsSrc = path.join(userDir, "settings.json");
  const keybindingsSrc = path.join(userDir, "keybindings.json");
  const prefix = def.id;


  if (existsSync(settingsSrc)) {
    const settingsDest = path.join(cwd, `${prefix}.settings.json`);
    await fs.copyFile(settingsSrc, settingsDest);
    res.exports.settings = path.basename(settingsDest);
    res.settingsPath = settingsSrc;
    try {
      const st = await fs.stat(settingsSrc);
      res.settingsMtimeMs = st.mtimeMs;
      res.settingsMtimeISO = new Date(st.mtimeMs).toISOString();
    } catch (_) {}
  } else {
    res.notes!.push("settings.json not found");
  }


  if (existsSync(keybindingsSrc)) {
    const keybindingsDest = path.join(cwd, `${prefix}.keybindings.json`);
    await fs.copyFile(keybindingsSrc, keybindingsDest);
    res.exports.keybindings = path.basename(keybindingsDest);
    res.keybindingsPath = keybindingsSrc;
  }


  // Copy snippets JSON files
  const snippetsDir = path.join(userDir, "snippets");
  const snippetTargets: string[] = [];
  if (existsSync(snippetsDir)) {
    const snippetFiles = listJsonFilesSync(snippetsDir);
    for (const sf of snippetFiles) {
      const dest = path.join(cwd, `${prefix}.snippet.${path.basename(sf)}`);
      await fs.copyFile(sf, dest);
      snippetTargets.push(path.basename(dest));
    }
  }
  if (snippetTargets.length) res.exports.snippets = snippetTargets;


  // Extensions: prefer CLI, else read extension directories
  let extensions: string[] | undefined = runCliListExtensions(def.cliCandidates);
  if (!extensions) {
    extensions = listExtensionsFromDirs(def.extDirs);
    if (extensions) res.notes!.push("extensions from directory fallback");
  }
  if (extensions) {
    const extPath = path.join(cwd, `${prefix}.extensions.json`);
    await fs.writeFile(extPath, JSON.stringify(extensions, null, 2));
    res.exports.extensions = path.basename(extPath);
  }


  return res;
}


async function main() {
  const startedAt = new Date();
  const defaultEntry = (): ExportEntry => ({ found: false, exports: {} });
  const results: Record<EditorId, ExportEntry> = {
    vscode: defaultEntry(),
    cursor: defaultEntry(),
    windsurf: defaultEntry(),
  };


  for (const def of editors) {
    const out = await exportEditor(def);
    results[def.id] = out;
    console.log(`[export] ${def.id}: ${out.found ? "ok" : "not found"}`);
  }


  // Guess default editor by most recent settings mtime
  let guess: EditorId | undefined;
  let best = -Infinity;
  for (const id of Object.keys(results) as EditorId[]) {
    const r = results[id];
    if (r.settingsMtimeMs && r.settingsMtimeMs > best) {
      best = r.settingsMtimeMs;
      guess = id;
    }
  }


  // Build index of JSON files in cwd
  const files = (await fs.readdir(cwd)).filter((f) => f.endsWith(".json"));
  const indexMap = new Map<string, string[]>();
  for (const f of files) {
    const key = f.split(".")[0] as string;
    const arr = indexMap.get(key) ?? [];
    arr.push(f);
    indexMap.set(key, arr);
  }
  const index: Record<string, string[]> = Object.fromEntries(
    Array.from(indexMap.entries()).map(([k, v]) => [k, v.sort()])
  );


  const summary = {
    exportedAtISO: startedAt.toISOString(),
    exportedAtEpochMs: startedAt.getTime(),
    editors: results,
    guessedDefaultEditor: guess || null,
  };


  await fs.writeFile(path.join(cwd, "summary.json"), JSON.stringify(summary, null, 2));
  await fs.writeFile(path.join(cwd, "index.json"), JSON.stringify(index, null, 2));


  console.log("Wrote summary.json and index.json");
  if (guess) {
    console.log(`Guessed default editor: ${guess}`);
  } else {
    console.log("Could not determine default editor (no settings found)");
  }
}


main().catch((err) => {
  console.error(err);
  process.exitCode = 1;
});
incorporate above code into electron. we need to copy over the most likely vscode IDE setting (either cursor or vscode or windsurf, depending on which one was most recent)copy it over to $HOME/.openvscode-server/data in the morph/docker containerInside that directory you’ll find the usual VS Code layout (User/settings.json, User/keybindings.json, etc.).