### PR TITLE
Add subtle loading animation for in-progress state

### DIFF
--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -298,3 +298,76 @@ body {
   display: inline-flex;
   cursor: help;
 }
+
+@keyframes cmuxProgressSheen {
+  0% {
+    background-position: -120% 0;
+  }
+  100% {
+    background-position: 120% 0;
+  }
+}
+
+@keyframes cmuxPendingPulse {
+  0%,
+  100% {
+    transform: scale(0.9);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+}
+
+.cmux-progress-bar {
+  position: relative;
+  overflow: hidden;
+}
+
+.cmux-progress-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.35) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  background-size: 200% 100%;
+  animation: cmuxProgressSheen 1.6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.cmux-progress-sheen {
+  background-image: linear-gradient(
+    90deg,
+    rgba(14, 165, 233, 0) 0%,
+    rgba(14, 165, 233, 0.32) 50%,
+    rgba(14, 165, 233, 0) 100%
+  );
+  background-size: 200% 100%;
+  animation: cmuxProgressSheen 1.6s ease-in-out infinite;
+  opacity: 0.6;
+}
+
+.dark .cmux-progress-bar::after {
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.28) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  opacity: 0.7;
+}
+
+.dark .cmux-progress-sheen {
+  background-image: linear-gradient(
+    90deg,
+    rgba(56, 189, 248, 0) 0%,
+    rgba(56, 189, 248, 0.25) 50%,
+    rgba(56, 189, 248, 0) 100%
+  );
+  opacity: 0.45;
+}

--- a/apps/www/components/pr/pull-request-diff-viewer.tsx
+++ b/apps/www/components/pr/pull-request-diff-viewer.tsx
@@ -997,6 +997,8 @@ function ReviewProgressIndicator({
     processedFileCount === null ? "— done" : `${processedFileCount} done`;
   const pendingBadgeText =
     processedFileCount === null ? "— waiting" : `${pendingFileCount} waiting`;
+  const showPendingAnimation =
+    !isLoading && processedFileCount !== null && pendingFileCount > 0;
 
   return (
     <div
@@ -1013,7 +1015,7 @@ function ReviewProgressIndicator({
         <div className="flex items-center gap-2 text-xs font-semibold">
           <span
             className={cn(
-              "rounded-md bg-emerald-100 px-2 py-0.5 text-emerald-700",
+              "inline-flex items-center gap-1 rounded-md bg-emerald-100 px-2 py-0.5 text-emerald-700",
               isLoading ? "animate-pulse" : undefined
             )}
           >
@@ -1021,17 +1023,30 @@ function ReviewProgressIndicator({
           </span>
           <span
             className={cn(
-              "rounded-md bg-amber-100 px-2 py-0.5 text-amber-700",
+              "inline-flex items-center gap-1 rounded-md bg-amber-100 px-2 py-0.5 text-amber-700",
               isLoading ? "animate-pulse" : undefined
             )}
           >
-            {pendingBadgeText}
+            {showPendingAnimation ? (
+              <>
+                <span
+                  aria-hidden
+                  className="h-1.5 w-1.5 rounded-full bg-amber-500/90 shadow-[0_0_0_2px_rgba(253,230,138,0.45)] animate-[cmuxPendingPulse_1400ms_ease-in-out_infinite]"
+                />
+                {pendingBadgeText}
+              </>
+            ) : (
+              pendingBadgeText
+            )}
           </span>
         </div>
       </div>
-      <div className="mt-3 h-2 rounded-full bg-neutral-200">
+      <div className="relative mt-3 h-2 overflow-hidden rounded-full bg-neutral-200">
         <div
-          className="h-full rounded-full bg-sky-500 transition-[width] duration-300 ease-out"
+          className={cn(
+            "h-full rounded-full bg-sky-500 transition-[width] duration-300 ease-out",
+            showPendingAnimation ? "cmux-progress-bar" : undefined
+          )}
           style={{ width: `${progressPercent}%` }}
           role="progressbar"
           aria-label="Automated review progress"
@@ -1039,6 +1054,12 @@ function ReviewProgressIndicator({
           aria-valuemax={totalFileCount}
           aria-valuenow={processedFileCount ?? 0}
         />
+        {showPendingAnimation ? (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 cmux-progress-sheen"
+          />
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
for the compare and pull page in apps/www for the loading indicator, make the in progress state have a subtle animation to indicate that it's still loading.