### PR TITLE
refactor preview urls to cmux.app pattern

### DIFF
--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -29,13 +29,15 @@ function rewriteMorphUrl(url: string): string {
     return url;
   }
 
-  // Transform morph URLs to cmux.sh format
-  // https://port-8101-morphvm-jrtutqa3.http.cloud.morph.so/handler/sign-in -> https://port-8101-jrtutqa3.cmux.sh/handler/sign-in
+  // Transform morph URLs to cmux.app format with new pattern
+  // https://port-8101-morphvm-jrtutqa3.http.cloud.morph.so/handler/sign-in -> https://cmux-jrtutqa3-base-8101.cmux.app/handler/sign-in
   if (url.includes("http.cloud.morph.so")) {
-    const result = url
-      .replace("morphvm-", "")
-      .replace("http.cloud.morph.so", "cmux.sh");
-    return result;
+    const match = url.match(/^https:\/\/port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so(\/.*)?$/);
+    if (match) {
+      const [, port, morphId, path = ""] = match;
+      return `https://cmux-${morphId}-base-${port}.cmux.app${path}`;
+    }
+    return url;
   }
   return url;
 }

--- a/packages/shared/src/utils/morph-instance.test.ts
+++ b/packages/shared/src/utils/morph-instance.test.ts
@@ -30,10 +30,10 @@ describe("extractMorphInstanceInfo", () => {
 
   it("detects port rewrite hosts", () => {
     const info = extractMorphInstanceInfo(
-      "https://port-9000-abc123.cmux.sh/path"
+      "https://port-9000-abc123.cmux.app/path"
     );
     expect(info).toEqual({
-      hostname: "port-9000-abc123.cmux.sh",
+      hostname: "port-9000-abc123.cmux.app",
       morphId: "abc123",
       instanceId: "morphvm_abc123",
       port: 9000,


### PR DESCRIPTION
for the preview browsers in sidebar, (as well as the corresponding page components) the current urls are like https://port-5173-g6relr00.cmux.sh/note the cmux.shrefactor so it uses the cmux.app insteadso the pattern is https://cmux-[morphid]-base-[port].cmux.app