### PR TITLE
Switch preview URLs to cmux.app pattern

### DIFF
--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -29,13 +29,20 @@ function rewriteMorphUrl(url: string): string {
     return url;
   }
 
-  // Transform morph URLs to cmux.sh format
-  // https://port-8101-morphvm-jrtutqa3.http.cloud.morph.so/handler/sign-in -> https://port-8101-jrtutqa3.cmux.sh/handler/sign-in
+  // Transform morph URLs to cmux.app format
+  // https://port-8101-morphvm-jrtutqa3.http.cloud.morph.so/handler/sign-in -> https://cmux-jrtutqa3-base-8101.cmux.app/handler/sign-in
   if (url.includes("http.cloud.morph.so")) {
-    const result = url
-      .replace("morphvm-", "")
-      .replace("http.cloud.morph.so", "cmux.sh");
-    return result;
+    // Extract port and morphId from the URL
+    const match = url.match(/port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so/);
+    if (match) {
+      const [fullMatch, port, morphId] = match;
+      const scope = "base";
+      const result = url.replace(
+        fullMatch,
+        `cmux-${morphId}-${scope}-${port}.cmux.app`
+      );
+      return result;
+    }
   }
   return url;
 }


### PR DESCRIPTION
for the preview browsers in sidebar, (as well as the corresponding page components) the current urls are like https://port-5173-g6relr00.cmux.sh/note the cmux.shrefactor so it uses the cmux.app insteadso the pattern is https://cmux-[morphid]-base-[port].cmux.appdo this in a resilient way. maybe there's a helper fn somewhere else in the codebase you can reuse?