### PR TITLE
Fix updater skipping newer updates

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -504,7 +504,8 @@ function setupAutoUpdates(): void {
       `${p.percent?.toFixed?.(1) ?? 0}% (${p.transferred}/${p.total})`
     )
   );
-  autoUpdater.on("update-downloaded", (_event, info?: UpdateInfo) => {
+  autoUpdater.on("update-downloaded", () => {
+    const info = autoUpdater.updateInfo;
     const version =
       info &&
       typeof info === "object" &&


### PR DESCRIPTION
there is this bug with autoupdates not entirely working for some reason  [MAIN] [2025-10-24T05:16:27.045Z] [updater] Update has already been downloaded to /Users/austinwang/Library/Caches/@cmuxclient-updater/pending/cmux-1.0.110-arm64-mac.zip).
_layout-CMqxYHN9.js:3530 [ElectronSocket] No auth token yet; delaying connect
(anonymous) @ _layout-CMqxYHN9.js:3530
_layout-CMqxYHN9.js:3546 [ElectronSocket] Connecting via IPC (cmux)...
index-Cv5D8hjA.js:72009 signalConvexAuthReady true
_layout-CMqxYHN9.js:3562 [ElectronSocket] Available editors: Object
_layout-CMqxYHN9.js:3562 [ElectronSocket] Available editors: Object
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:27.212Z] Ignoring downloaded update that is not newer than current build { version: null, currentVersion: '1.0.108' }
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:27.326Z] [updater] / requested
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:27.328Z] [updater] /90564cf695b067b8eabde21e35edb274cf603938293c1518583c93aca006c430bcb474fa6f3aacc4c9b6750832b5bf5c5124888fc567dc03e5f47cf733c8ee62.zip requested
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:27.328Z] [updater] /90564cf695b067b8eabde21e35edb274cf603938293c1518583c93aca006c430bcb474fa6f3aacc4c9b6750832b5bf5c5124888fc567dc03e5f47cf733c8ee62.zip requested by Squirrel.Mac, pipe /Users/austinwang/Library/Caches/@cmuxclient-updater/pending/cmux-1.0.110-arm64-mac.zip
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.140Z] Manual update check initiated
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.141Z] [updater] Checking for update
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.141Z] Checking for update…
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.329Z] [updater] Found version 1.0.110 (url: cmux-1.0.110-arm64-mac.zip, cmux-1.0.110-arm64.dmg)
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.330Z] Update available 1.0.110
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.330Z] [updater] Downloading update from cmux-1.0.110-arm64-mac.zip, cmux-1.0.110-arm64.dmg
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.335Z] [updater] Checked for macOS Rosetta environment (isRosetta=false)
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.338Z] [updater] Checked 'uname -a': arm64=true
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.526Z] [updater] Proxy server for native Squirrel.Mac is closed (fileToProxy=https://github.com/manaflow-ai/cmux/releases/download/v1.0.110/cmux-1.0.110-arm64-mac.zip)
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.527Z] Ignoring downloaded update that is not newer than current build { version: null, currentVersion: '1.0.108' }
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.665Z] [updater] / requested
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.667Z] [updater] /454c5f4b9977af11f9e74b1220fa25b1da8c1c1348299aa2e30e712116d0a45f5858a7e839f9b1b7ea26ee214a62fe770db0ee9d7f11fe06276480c1f503d5a3.zip requested
VM119 index.cjs:225 [MAIN] [2025-10-24T05:16:34.667Z] [updater] /454c5f4b9977af11f9e74b1220fa25b1da8c1c1348299aa2e30e712116d0a45f5858a7e839f9b1b7ea26ee214a62fe770db0ee9d7f11fe06276480c1f503d5a3.zip requested by Squirrel.Mac, pipe /Users/austinwang/Library/Caches/@cmuxclient-updater/pending/cmux-1.0.110-arm64-mac.zip