### PR TITLE
Make bottom-left save button sticky with red unsaved label

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -1061,7 +1061,19 @@ function SettingsComponent() {
         ref={saveButtonRef}
         className="sticky bottom-0 left-0 right-0 border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-lg z-50"
       >
-        <div className="max-w-3xl mx-auto px-6 py-3 flex items-center justify-between gap-3">
+        <div className="max-w-3xl mx-auto px-6 py-3 flex items-center justify-start gap-3">
+          {hasChanges() && !isSaving && (
+            <span className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400 font-medium">
+              <svg
+                className="w-2 h-2 fill-current"
+                viewBox="0 0 8 8"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle cx="4" cy="4" r="4" />
+              </svg>
+              Unsaved changes
+            </span>
+          )}
           <button
             onClick={saveApiKeys}
             disabled={!hasChanges() || isSaving}
@@ -1073,11 +1085,6 @@ function SettingsComponent() {
           >
             {isSaving ? "Saving..." : "Save Changes"}
           </button>
-          {hasChanges() && !isSaving && (
-            <span className="text-sm text-red-600 dark:text-red-400 font-medium">
-              Unsaved changes
-            </span>
-          )}
         </div>
       </div>
     </FloatingPane>

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -1059,9 +1059,9 @@ function SettingsComponent() {
       {/* Footer Save bar */}
       <div
         ref={saveButtonRef}
-        className="sticky bottom-0 border-t border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 supports-[backdrop-filter]:dark:bg-neutral-900/60"
+        className="sticky bottom-0 left-0 right-0 border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-lg z-50"
       >
-        <div className="max-w-3xl mx-auto px-6 py-3 flex items-center justify-end gap-3">
+        <div className="max-w-3xl mx-auto px-6 py-3 flex items-center justify-between gap-3">
           <button
             onClick={saveApiKeys}
             disabled={!hasChanges() || isSaving}
@@ -1073,6 +1073,11 @@ function SettingsComponent() {
           >
             {isSaving ? "Saving..." : "Save Changes"}
           </button>
+          {hasChanges() && !isSaving && (
+            <span className="text-sm text-red-600 dark:text-red-400 font-medium">
+              Unsaved changes
+            </span>
+          )}
         </div>
       </div>
     </FloatingPane>


### PR DESCRIPTION
make the save changes button in the settings page actually sticky to the bottom so it is visible at all times... (add something like unsaved changes to make sure that users know they have to save) move the save changes to the left side (on the bottom) and add the unsaved changes in red with to the right of the save changes button