### PR TITLE
Retry refresh flow on expired tokens

### DIFF
--- a/apps/server/src/utils/convexClient.ts
+++ b/apps/server/src/utils/convexClient.ts
@@ -1,5 +1,6 @@
 import { convexClientCache } from "@cmux/shared/node/convex-cache";
 import { ConvexHttpClient } from "convex/browser";
+import { decodeJwt } from "jose";
 import { getAuthToken } from "./requestContext";
 import { env } from "./server-env";
 
@@ -14,6 +15,26 @@ export function getConvex() {
   const cachedClient = convexClientCache.get(auth, env.NEXT_PUBLIC_CONVEX_URL);
   if (cachedClient) {
     return cachedClient;
+  }
+
+  // Validate token expiration before creating a new client
+  try {
+    const jwt = decodeJwt(auth);
+    const now = Date.now() / 1000;
+
+    if (jwt.exp && jwt.exp < now) {
+      const expiredSeconds = Math.floor(now - jwt.exp);
+      throw new Error(
+        `Auth token expired ${expiredSeconds} seconds ago. ` +
+        `Client must refresh the token and retry the request.`
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("expired")) {
+      throw error;
+    }
+    console.warn("Failed to decode/validate JWT token:", error);
+    // Continue anyway - let Convex validate the token
   }
 
   // Create new client and cache it


### PR DESCRIPTION
there seems to be a problem where auth header token expires and we don't even try to refresh it with our refresh token? what is the [SERVER] Failed to load API keys for team 33e9f970-20c0-44ce-be20-6ef75c6b9b2b: warn: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 18 seconds ago"}
[SERVER]       at queryInner (/Users/austinwang/cmux5/cmux/node_modules/convex/dist/esm/browser/http_client.js:229:17)
[SERVER] 
[SERVER] Failed to load API keys for team 33e9f970-20c0-44ce-be20-6ef75c6b9b2b: warn: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 77 seconds ago"}
[SERVER]       at queryInner (/Users/austinwang/cmux5/cmux/node_modules/convex/dist/esm/browser/http_client.js:229:17)
[SERVER] 
[SERVER] Failed to load API keys for team 33e9f970-20c0-44ce-be20-6ef75c6b9b2b: warn: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 137 seconds ago"}
[SERVER]       at queryInner (/Users/austinwang/cmux5/cmux/node_modules/convex/dist/esm/browser/http_client.js:229:17)
[SERVER] 
[SERVER] Failed to load API keys for team 33e9f970-20c0-44ce-be20-6ef75c6b9b2b: warn: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 197 seconds ago"}
[SERVER]       at queryInner (/Users/austinwang/cmux5/cmux/node_modules/convex/dist/esm/browser/http_client.js:229:17)
[SERVER] 
[SERVER] Failed to load API keys for team 33e9f970-20c0-44ce-be20-6ef75c6b9b2b: warn: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 257 seconds ago"}
[SERVER]       at queryInner (/Users/austinwang/cmux5/cmux/node_modules/convex/dist/esm/browser/http_client.js:229:17)