### PR TITLE
Create bun script to run maintenance then dev

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -506,9 +506,9 @@ function setupAutoUpdates(): void {
   autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
     const version =
       info &&
-      typeof info === "object" &&
-      "version" in info &&
-      typeof info.version === "string"
+        typeof info === "object" &&
+        "version" in info &&
+        typeof info.version === "string"
         ? info.version
         : null;
 

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -317,6 +317,10 @@ sandboxesRouter.openapi(
             maintenanceScript: maintenanceScript || undefined,
             devScript: devScript || undefined,
             identifiers: scriptIdentifiers ?? undefined,
+            convexUrl: taskRunConvexId ? env.NEXT_PUBLIC_CONVEX_URL : undefined,
+            accessToken: taskRunConvexId ? accessToken : undefined,
+            taskRunId: taskRunConvexId || undefined,
+            teamSlugOrId: taskRunConvexId ? body.teamSlugOrId : undefined,
           });
           if (taskRunConvexId && (result.maintenanceError || result.devError)) {
             try {

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -317,10 +317,8 @@ sandboxesRouter.openapi(
             maintenanceScript: maintenanceScript || undefined,
             devScript: devScript || undefined,
             identifiers: scriptIdentifiers ?? undefined,
-            convexUrl: taskRunConvexId ? env.NEXT_PUBLIC_CONVEX_URL : undefined,
-            accessToken: taskRunConvexId ? accessToken : undefined,
-            taskRunId: taskRunConvexId || undefined,
-            teamSlugOrId: taskRunConvexId ? body.teamSlugOrId : undefined,
+            convexUrl: body.taskRunJwt ? env.NEXT_PUBLIC_CONVEX_URL : undefined,
+            taskRunJwt: body.taskRunJwt || undefined,
           });
           if (taskRunConvexId && (result.maintenanceError || result.devError)) {
             try {

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -6,7 +6,6 @@ import { verifyTeamAccess } from "@/lib/utils/team-verification";
 import { env } from "@/lib/utils/www-env";
 import { api } from "@cmux/convex/api";
 import { RESERVED_CMUX_PORT_SET } from "@cmux/shared/utils/reserved-cmux-ports";
-import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { MorphCloudClient } from "morphcloud";
@@ -146,10 +145,6 @@ sandboxesRouter.openapi(
 
     try {
       const convex = getConvex({ accessToken });
-
-      const taskRunConvexId = body.taskRunId
-        ? typedZid("taskRuns").parse(body.taskRunId)
-        : null;
 
       const {
         team,
@@ -312,7 +307,7 @@ sandboxesRouter.openapi(
 
       if (maintenanceScript || devScript) {
         (async () => {
-          const result = await runMaintenanceAndDevScripts({
+          await runMaintenanceAndDevScripts({
             instance,
             maintenanceScript: maintenanceScript || undefined,
             devScript: devScript || undefined,
@@ -320,21 +315,6 @@ sandboxesRouter.openapi(
             convexUrl: body.taskRunJwt ? env.NEXT_PUBLIC_CONVEX_URL : undefined,
             taskRunJwt: body.taskRunJwt || undefined,
           });
-          if (taskRunConvexId && (result.maintenanceError || result.devError)) {
-            try {
-              await convex.mutation(api.taskRuns.updateEnvironmentError, {
-                teamSlugOrId: body.teamSlugOrId,
-                id: taskRunConvexId,
-                maintenanceError: result.maintenanceError ?? undefined,
-                devError: result.devError ?? undefined,
-              });
-            } catch (mutationError) {
-              console.error(
-                "[sandboxes.start] Failed to record environment error to taskRun",
-                mutationError,
-              );
-            }
-          }
         })().catch((error) => {
           console.error(
             "[sandboxes.start] Background script execution failed:",

--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -74,128 +74,271 @@ fi`;
   let maintenanceError: string | null = null;
   let devError: string | null = null;
 
-  if (maintenanceScript && maintenanceScript.trim().length > 0) {
-    const maintenanceRunId = `maintenance_${Date.now().toString(36)}_${Math.random()
-      .toString(36)
-      .slice(2, 10)}`;
-    const maintenanceExitCodePath = `${ids.maintenance.scriptPath}.${maintenanceRunId}.exit-code`;
+  // Generate unique run IDs for this execution
+  const runId = `${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+  const orchestratorScriptPath = `${CMUX_RUNTIME_DIR}/orchestrator_${runId}.ts`;
+  const maintenanceExitCodePath = `${CMUX_RUNTIME_DIR}/maintenance_${runId}.exit-code`;
 
-    const maintenanceScriptContent = `#!/bin/zsh
+  // Create maintenance script if provided
+  const maintenanceScriptContent = maintenanceScript && maintenanceScript.trim().length > 0
+    ? `#!/bin/zsh
 set -eux
 cd ${WORKSPACE_ROOT}
 
 echo "=== Maintenance Script Started at \$(date) ==="
 ${maintenanceScript}
 echo "=== Maintenance Script Completed at \$(date) ==="
-`;
+`
+    : null;
 
-    const maintenanceWindowCommand = `zsh "${ids.maintenance.scriptPath}"
-EXIT_CODE=$?
-echo "$EXIT_CODE" > "${maintenanceExitCodePath}"
-if [ "$EXIT_CODE" -ne 0 ]; then
-  echo "[MAINTENANCE] Script exited with code $EXIT_CODE" >&2
-else
-  echo "[MAINTENANCE] Script completed successfully"
-fi
-exec zsh`;
-
-    const maintenanceCommand = `set -eu
-mkdir -p ${CMUX_RUNTIME_DIR}
-cat > ${ids.maintenance.scriptPath} <<'SCRIPT_EOF'
-${maintenanceScriptContent}
-SCRIPT_EOF
-chmod +x ${ids.maintenance.scriptPath}
-rm -f ${maintenanceExitCodePath}
-${waitForTmuxSession}
-tmux new-window -t cmux: -n ${ids.maintenance.windowName} -d ${singleQuote(maintenanceWindowCommand)}
-sleep 2
-if tmux list-windows -t cmux | grep -q "${ids.maintenance.windowName}"; then
-  echo "[MAINTENANCE] Window is running"
-else
-  echo "[MAINTENANCE] Window may have exited (normal if script completed)"
-fi
-while [ ! -f ${maintenanceExitCodePath} ]; do
-  sleep 1
-done
-MAINTENANCE_EXIT_CODE=0
-if [ -f ${maintenanceExitCodePath} ]; then
-  MAINTENANCE_EXIT_CODE=$(cat ${maintenanceExitCodePath} || echo 0)
-else
-  echo "[MAINTENANCE] Missing exit code file; assuming failure" >&2
-  MAINTENANCE_EXIT_CODE=1
-fi
-rm -f ${maintenanceExitCodePath}
-echo "[MAINTENANCE] Wait complete with exit code $MAINTENANCE_EXIT_CODE"
-exit $MAINTENANCE_EXIT_CODE
-`;
-
-    try {
-      const result = await instance.exec(
-        `zsh -lc ${singleQuote(maintenanceCommand)}`,
-      );
-
-      if (result.exit_code !== 0) {
-        const stderr = result.stderr?.trim() || "";
-        const stdout = result.stdout?.trim() || "";
-        const messageParts = [
-          `Maintenance script finished with exit code ${result.exit_code}`,
-          stderr ? `stderr: ${stderr}` : null,
-          stdout ? `stdout: ${stdout}` : null,
-        ].filter((part): part is string => part !== null);
-        maintenanceError = messageParts.join(" | ");
-      } else {
-        console.log(`[MAINTENANCE SCRIPT VERIFICATION]\n${result.stdout || ""}`);
-      }
-    } catch (error) {
-      maintenanceError = `Maintenance script execution failed: ${error instanceof Error ? error.message : String(error)}`;
-    }
-  }
-
-  if (devScript && devScript.trim().length > 0) {
-    const devScriptContent = `#!/bin/zsh
+  // Create dev script if provided
+  const devScriptContent = devScript && devScript.trim().length > 0
+    ? `#!/bin/zsh
 set -ux
 cd ${WORKSPACE_ROOT}
 
 echo "=== Dev Script Started at \$(date) ==="
 ${devScript}
-`;
+`
+    : null;
 
-    const devCommand = `set -eu
-mkdir -p ${CMUX_RUNTIME_DIR}
-cat > ${ids.dev.scriptPath} <<'SCRIPT_EOF'
-${devScriptContent}
-SCRIPT_EOF
-chmod +x ${ids.dev.scriptPath}
-${waitForTmuxSession}
-tmux new-window -t cmux: -n ${ids.dev.windowName} -d
-tmux send-keys -t cmux:${ids.dev.windowName} "zsh ${ids.dev.scriptPath}" C-m
-sleep 2
-if tmux list-windows -t cmux | grep -q "${ids.dev.windowName}"; then
-  echo "[DEV] Window is running"
-else
-  echo "[DEV] ERROR: Window not found" >&2
-  exit 1
-fi
-`;
+  // Create Bun orchestrator script that runs both sequentially in a single process
+  const orchestratorScript = `#!/usr/bin/env bun
+import { $ } from "bun";
 
+const WORKSPACE_ROOT = "${WORKSPACE_ROOT}";
+const CMUX_RUNTIME_DIR = "${CMUX_RUNTIME_DIR}";
+const maintenanceScriptPath = "${ids.maintenance.scriptPath}";
+const devScriptPath = "${ids.dev.scriptPath}";
+const maintenanceWindowName = "${ids.maintenance.windowName}";
+const devWindowName = "${ids.dev.windowName}";
+const maintenanceExitCodePath = "${maintenanceExitCodePath}";
+const hasMaintenanceScript = ${maintenanceScriptContent !== null};
+const hasDevScript = ${devScriptContent !== null};
+
+// Wait for tmux session to be ready
+async function waitForTmuxSession(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
     try {
-      const result = await instance.exec(`zsh -lc ${singleQuote(devCommand)}`);
+      const result = await $\`tmux has-session -t cmux 2>/dev/null\`.quiet();
+      if (result.exitCode === 0) {
+        return;
+      }
+    } catch (error) {
+      // Session not ready yet
+    }
+    await Bun.sleep(500);
+  }
 
-      if (result.exit_code !== 0) {
-        const stderr = result.stderr?.trim() || "";
-        const stdout = result.stdout?.trim() || "";
+  // Final check
+  const result = await $\`tmux has-session -t cmux 2>/dev/null\`.quiet();
+  if (result.exitCode !== 0) {
+    throw new Error("Error: cmux session does not exist");
+  }
+}
+
+// Run maintenance script and wait for completion
+async function runMaintenanceScript(): Promise<{ exitCode: number; error: string | null }> {
+  if (!hasMaintenanceScript) {
+    console.log("[MAINTENANCE] No maintenance script to run");
+    return { exitCode: 0, error: null };
+  }
+
+  try {
+    console.log("[MAINTENANCE] Starting maintenance script...");
+
+    const maintenanceWindowCommand = \`zsh "\${maintenanceScriptPath}"
+EXIT_CODE=$?
+echo "$EXIT_CODE" > "\${maintenanceExitCodePath}"
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "[MAINTENANCE] Script exited with code $EXIT_CODE" >&2
+else
+  echo "[MAINTENANCE] Script completed successfully"
+fi
+exec zsh\`;
+
+    await waitForTmuxSession();
+
+    // Start maintenance window
+    await $\`tmux new-window -t cmux: -n \${maintenanceWindowName} -d \${maintenanceWindowCommand}\`;
+
+    await Bun.sleep(2000);
+
+    // Check if window is running
+    const windowCheck = await $\`tmux list-windows -t cmux\`.text();
+    if (windowCheck.includes(maintenanceWindowName)) {
+      console.log("[MAINTENANCE] Window is running");
+    } else {
+      console.log("[MAINTENANCE] Window may have exited (normal if script completed)");
+    }
+
+    // Wait for exit code file
+    while (true) {
+      const file = Bun.file(maintenanceExitCodePath);
+      if (await file.exists()) {
+        break;
+      }
+      await Bun.sleep(1000);
+    }
+
+    // Read exit code
+    const exitCodeFile = Bun.file(maintenanceExitCodePath);
+    const exitCodeText = await exitCodeFile.text();
+    const exitCode = parseInt(exitCodeText.trim()) || 0;
+
+    // Clean up exit code file
+    await $\`rm -f \${maintenanceExitCodePath}\`;
+
+    console.log(\`[MAINTENANCE] Wait complete with exit code \${exitCode}\`);
+
+    if (exitCode !== 0) {
+      return {
+        exitCode,
+        error: \`Maintenance script finished with exit code \${exitCode}\`
+      };
+    }
+
+    return { exitCode: 0, error: null };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(\`[MAINTENANCE] Error: \${errorMessage}\`);
+    return {
+      exitCode: 1,
+      error: \`Maintenance script execution failed: \${errorMessage}\`
+    };
+  }
+}
+
+// Start dev script in background (does not wait for completion)
+async function startDevScript(): Promise<{ error: string | null }> {
+  if (!hasDevScript) {
+    console.log("[DEV] No dev script to run");
+    return { error: null };
+  }
+
+  try {
+    console.log("[DEV] Starting dev script...");
+
+    await waitForTmuxSession();
+
+    // Create new window and send keys to start script
+    await $\`tmux new-window -t cmux: -n \${devWindowName} -d\`;
+    await $\`tmux send-keys -t cmux:\${devWindowName} "zsh \${devScriptPath}" C-m\`;
+
+    await Bun.sleep(2000);
+
+    // Verify window is running
+    const windowCheck = await $\`tmux list-windows -t cmux\`.text();
+    if (windowCheck.includes(devWindowName)) {
+      console.log("[DEV] Window is running");
+      return { error: null };
+    } else {
+      const error = "Dev window not found after creation";
+      console.error(\`[DEV] ERROR: \${error}\`);
+      return { error };
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(\`[DEV] Error: \${errorMessage}\`);
+    return {
+      error: \`Dev script execution failed: \${errorMessage}\`
+    };
+  }
+}
+
+// Main execution
+(async () => {
+  try {
+    // Run maintenance first, capture any errors but continue
+    const maintenanceResult = await runMaintenanceScript();
+    if (maintenanceResult.error) {
+      console.error(\`[ORCHESTRATOR] Maintenance completed with error: \${maintenanceResult.error}\`);
+    } else {
+      console.log("[ORCHESTRATOR] Maintenance completed successfully");
+    }
+
+    // Always run dev script regardless of maintenance outcome
+    const devResult = await startDevScript();
+    if (devResult.error) {
+      console.error(\`[ORCHESTRATOR] Dev script failed: \${devResult.error}\`);
+      process.exit(1);
+    } else {
+      console.log("[ORCHESTRATOR] Dev script started successfully");
+    }
+
+    // Exit with success - maintenance errors don't affect overall success
+    process.exit(0);
+  } catch (error) {
+    console.error(\`[ORCHESTRATOR] Fatal error: \${error}\`);
+    process.exit(1);
+  }
+})();
+`;
+
+  // Create the command that sets up all scripts and runs the orchestrator
+  const setupAndRunCommand = `set -eu
+mkdir -p ${CMUX_RUNTIME_DIR}
+
+# Write maintenance script if provided
+${maintenanceScriptContent ? `cat > ${ids.maintenance.scriptPath} <<'MAINTENANCE_SCRIPT_EOF'
+${maintenanceScriptContent}
+MAINTENANCE_SCRIPT_EOF
+chmod +x ${ids.maintenance.scriptPath}
+rm -f ${maintenanceExitCodePath}` : ''}
+
+# Write dev script if provided
+${devScriptContent ? `cat > ${ids.dev.scriptPath} <<'DEV_SCRIPT_EOF'
+${devScriptContent}
+DEV_SCRIPT_EOF
+chmod +x ${ids.dev.scriptPath}` : ''}
+
+# Write orchestrator script
+cat > ${orchestratorScriptPath} <<'ORCHESTRATOR_EOF'
+${orchestratorScript}
+ORCHESTRATOR_EOF
+chmod +x ${orchestratorScriptPath}
+
+# Run orchestrator with bun
+bun ${orchestratorScriptPath}
+`;
+
+  try {
+    const result = await instance.exec(
+      `zsh -lc ${singleQuote(setupAndRunCommand)}`,
+    );
+
+    // Parse the output to determine maintenance and dev errors
+    const stdout = result.stdout?.trim() || "";
+    const stderr = result.stderr?.trim() || "";
+
+    if (stdout.includes("[ORCHESTRATOR] Maintenance completed with error:")) {
+      const match = stdout.match(/\[ORCHESTRATOR\] Maintenance completed with error: (.+)/);
+      if (match) {
+        maintenanceError = match[1];
+      }
+    }
+
+    if (result.exit_code !== 0 || stdout.includes("[DEV] ERROR:") || stdout.includes("[ORCHESTRATOR] Dev script failed:")) {
+      const devMatch = stdout.match(/\[(?:DEV|ORCHESTRATOR)\] (?:ERROR: |Dev script failed: )(.+)/);
+      if (devMatch) {
+        devError = devMatch[1];
+      } else if (result.exit_code !== 0) {
         const messageParts = [
-          `Failed to start dev script with exit code ${result.exit_code}`,
+          `Script execution failed with exit code ${result.exit_code}`,
           stderr ? `stderr: ${stderr}` : null,
           stdout ? `stdout: ${stdout}` : null,
         ].filter((part): part is string => part !== null);
         devError = messageParts.join(" | ");
-      } else {
-        console.log(`[DEV SCRIPT VERIFICATION]\n${result.stdout || ""}`);
       }
-    } catch (error) {
-      devError = `Dev script execution failed: ${error instanceof Error ? error.message : String(error)}`;
     }
+
+    if (result.exit_code === 0) {
+      console.log(`[ORCHESTRATOR VERIFICATION]\n${stdout}`);
+    }
+  } catch (error) {
+    devError = `Script orchestrator execution failed: ${error instanceof Error ? error.message : String(error)}`;
   }
 
   return {

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as _shared_verifyTaskRunToken from "../_shared/verifyTaskRunToken.js";
 import type * as apiKeys from "../apiKeys.js";
 import type * as backfill from "../backfill.js";
 import type * as codeReview from "../codeReview.js";
@@ -60,6 +61,7 @@ import type {
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  "_shared/verifyTaskRunToken": typeof _shared_verifyTaskRunToken;
   apiKeys: typeof apiKeys;
   backfill: typeof backfill;
   codeReview: typeof codeReview;

--- a/packages/convex/convex/_shared/verifyTaskRunToken.ts
+++ b/packages/convex/convex/_shared/verifyTaskRunToken.ts
@@ -1,0 +1,28 @@
+import { jwtVerify } from "jose";
+import { z } from "zod";
+
+const TaskRunTokenPayloadSchema = z.object({
+  taskRunId: z.string().min(1),
+  teamId: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+export type TaskRunTokenPayload = z.infer<typeof TaskRunTokenPayloadSchema>;
+
+function toKey(secret: string | Uint8Array): Uint8Array {
+  return typeof secret === "string" ? new TextEncoder().encode(secret) : secret;
+}
+
+export async function verifyTaskRunToken(
+  token: string,
+  secret: string | Uint8Array
+): Promise<TaskRunTokenPayload> {
+  const verification = await jwtVerify(token, toKey(secret));
+  const parsed = TaskRunTokenPayloadSchema.safeParse(verification.payload);
+
+  if (!parsed.success) {
+    throw new Error("Invalid CMUX task run token payload");
+  }
+
+  return parsed.data;
+}

--- a/packages/convex/convex/http.ts
+++ b/packages/convex/convex/http.ts
@@ -12,6 +12,7 @@ import {
 } from "./codeReview_http";
 import { githubSetup } from "./github_setup";
 import { githubWebhook } from "./github_webhook";
+import { updateEnvironmentErrorHttp } from "./taskRuns";
 import { stackWebhook } from "./stack_webhook";
 
 const http = httpRouter();
@@ -74,6 +75,12 @@ http.route({
   path: "/github_setup",
   method: "GET",
   handler: githubSetup,
+});
+
+http.route({
+  path: "/taskRuns/update-environment-error",
+  method: "POST",
+  handler: updateEnvironmentErrorHttp,
 });
 
 export default http;

--- a/packages/shared/src/utils/morph-instance.ts
+++ b/packages/shared/src/utils/morph-instance.ts
@@ -86,8 +86,8 @@ function parseCmuxProxyHost(hostname: string): MorphInstanceInfo | null {
         return null;
       }
 
-      const portSegment = segments.at(-1);
-      const rawMorphId = segments.at(0);
+      const portSegment = segments[segments.length - 1];
+      const rawMorphId = segments[0];
       if (!portSegment || !rawMorphId) {
         return null;
       }

--- a/scripts/run-maintenance-and-dev.ts
+++ b/scripts/run-maintenance-and-dev.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env bun
+/**
+ * Orchestrator script for running maintenance and dev scripts in sequence.
+ * This script is uploaded to the sandbox and run in the background to avoid Vercel timeouts.
+ *
+ * Flow:
+ * 1. Create both tmux windows upfront
+ * 2. Run maintenance script and wait for completion
+ * 3. Run dev script (regardless of maintenance outcome)
+ */
+
+import { $ } from "bun";
+
+// These values will be replaced when the script is uploaded to the sandbox
+const MAINTENANCE_SCRIPT_PATH = "{{MAINTENANCE_SCRIPT_PATH}}";
+const DEV_SCRIPT_PATH = "{{DEV_SCRIPT_PATH}}";
+const MAINTENANCE_WINDOW_NAME = "{{MAINTENANCE_WINDOW_NAME}}";
+const DEV_WINDOW_NAME = "{{DEV_WINDOW_NAME}}";
+const MAINTENANCE_EXIT_CODE_PATH = "{{MAINTENANCE_EXIT_CODE_PATH}}";
+const HAS_MAINTENANCE_SCRIPT = ("{{HAS_MAINTENANCE_SCRIPT}}" as "true" | "false") === "true";
+const HAS_DEV_SCRIPT = ("{{HAS_DEV_SCRIPT}}" as "true" | "false") === "true";
+
+// Wait for tmux session to be ready
+async function waitForTmuxSession(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    try {
+      const result = await $`tmux has-session -t cmux 2>/dev/null`.quiet();
+      if (result.exitCode === 0) {
+        console.log("[ORCHESTRATOR] tmux session found");
+        return;
+      }
+    } catch (error) {
+      // Session not ready yet
+    }
+    await Bun.sleep(500);
+  }
+
+  // Final check
+  const result = await $`tmux has-session -t cmux 2>/dev/null`.quiet();
+  if (result.exitCode !== 0) {
+    throw new Error("Error: cmux session does not exist");
+  }
+}
+
+// Create both windows upfront
+async function createWindows(): Promise<void> {
+  await waitForTmuxSession();
+
+  // Create maintenance window if needed
+  if (HAS_MAINTENANCE_SCRIPT) {
+    try {
+      console.log(`[ORCHESTRATOR] Creating ${MAINTENANCE_WINDOW_NAME} window...`);
+      await $`tmux new-window -t cmux: -n ${MAINTENANCE_WINDOW_NAME} -d`;
+      console.log(`[ORCHESTRATOR] ${MAINTENANCE_WINDOW_NAME} window created`);
+    } catch (error) {
+      console.error(`[ORCHESTRATOR] Failed to create ${MAINTENANCE_WINDOW_NAME} window:`, error);
+      throw error;
+    }
+  }
+
+  // Create dev window if needed
+  if (HAS_DEV_SCRIPT) {
+    try {
+      console.log(`[ORCHESTRATOR] Creating ${DEV_WINDOW_NAME} window...`);
+      await $`tmux new-window -t cmux: -n ${DEV_WINDOW_NAME} -d`;
+      console.log(`[ORCHESTRATOR] ${DEV_WINDOW_NAME} window created`);
+    } catch (error) {
+      console.error(`[ORCHESTRATOR] Failed to create ${DEV_WINDOW_NAME} window:`, error);
+      throw error;
+    }
+  }
+}
+
+// Run maintenance script and wait for completion
+async function runMaintenanceScript(): Promise<{ exitCode: number; error: string | null }> {
+  if (!HAS_MAINTENANCE_SCRIPT) {
+    console.log("[MAINTENANCE] No maintenance script to run");
+    return { exitCode: 0, error: null };
+  }
+
+  try {
+    console.log("[MAINTENANCE] Starting maintenance script...");
+
+    // Send command to run the script and capture exit code
+    const scriptCommand = `zsh "${MAINTENANCE_SCRIPT_PATH}"
+EXIT_CODE=$?
+echo "$EXIT_CODE" > "${MAINTENANCE_EXIT_CODE_PATH}"
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "[MAINTENANCE] Script exited with code $EXIT_CODE" >&2
+else
+  echo "[MAINTENANCE] Script completed successfully"
+fi
+exec zsh`;
+
+    await $`tmux send-keys -t cmux:${MAINTENANCE_WINDOW_NAME} ${scriptCommand} C-m`;
+
+    await Bun.sleep(2000);
+
+    // Wait for exit code file to appear
+    console.log("[MAINTENANCE] Waiting for script to complete...");
+    let attempts = 0;
+    const maxAttempts = 600; // 10 minutes max
+    while (attempts < maxAttempts) {
+      const file = Bun.file(MAINTENANCE_EXIT_CODE_PATH);
+      if (await file.exists()) {
+        break;
+      }
+      await Bun.sleep(1000);
+      attempts++;
+    }
+
+    if (attempts >= maxAttempts) {
+      console.error("[MAINTENANCE] Script timed out after 10 minutes");
+      return {
+        exitCode: 124,
+        error: "Maintenance script timed out after 10 minutes"
+      };
+    }
+
+    // Read exit code
+    const exitCodeFile = Bun.file(MAINTENANCE_EXIT_CODE_PATH);
+    const exitCodeText = await exitCodeFile.text();
+    const exitCode = parseInt(exitCodeText.trim()) || 0;
+
+    // Clean up exit code file
+    await $`rm -f ${MAINTENANCE_EXIT_CODE_PATH}`;
+
+    console.log(`[MAINTENANCE] Script completed with exit code ${exitCode}`);
+
+    if (exitCode !== 0) {
+      return {
+        exitCode,
+        error: `Maintenance script finished with exit code ${exitCode}`
+      };
+    }
+
+    return { exitCode: 0, error: null };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`[MAINTENANCE] Error: ${errorMessage}`);
+    return {
+      exitCode: 1,
+      error: `Maintenance script execution failed: ${errorMessage}`
+    };
+  }
+}
+
+// Start dev script (does not wait for completion)
+async function startDevScript(): Promise<{ error: string | null }> {
+  if (!HAS_DEV_SCRIPT) {
+    console.log("[DEV] No dev script to run");
+    return { error: null };
+  }
+
+  try {
+    console.log("[DEV] Starting dev script...");
+
+    // Send command to run the script
+    await $`tmux send-keys -t cmux:${DEV_WINDOW_NAME} "zsh \\"${DEV_SCRIPT_PATH}\\"" C-m`;
+
+    await Bun.sleep(2000);
+
+    // Verify window is still running
+    const windowCheck = await $`tmux list-windows -t cmux`.text();
+    if (windowCheck.includes(DEV_WINDOW_NAME)) {
+      console.log("[DEV] Script started successfully");
+      return { error: null };
+    } else {
+      const error = "Dev window not found after starting script";
+      console.error(`[DEV] ERROR: ${error}`);
+      return { error };
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`[DEV] Error: ${errorMessage}`);
+    return {
+      error: `Dev script execution failed: ${errorMessage}`
+    };
+  }
+}
+
+// Main execution
+(async () => {
+  try {
+    console.log("[ORCHESTRATOR] Starting orchestrator...");
+
+    // Create both windows upfront
+    await createWindows();
+
+    // Run maintenance first, capture any errors but continue
+    const maintenanceResult = await runMaintenanceScript();
+    if (maintenanceResult.error) {
+      console.error(`[ORCHESTRATOR] Maintenance completed with error: ${maintenanceResult.error}`);
+    } else {
+      console.log("[ORCHESTRATOR] Maintenance completed successfully");
+    }
+
+    // Always run dev script regardless of maintenance outcome
+    const devResult = await startDevScript();
+    if (devResult.error) {
+      console.error(`[ORCHESTRATOR] Dev script failed: ${devResult.error}`);
+      process.exit(1);
+    } else {
+      console.log("[ORCHESTRATOR] Dev script started successfully");
+    }
+
+    // Exit with success - maintenance errors don't affect overall success
+    console.log("[ORCHESTRATOR] Orchestrator completed successfully");
+    process.exit(0);
+  } catch (error) {
+    console.error(`[ORCHESTRATOR] Fatal error: ${error}`);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
currently we have @manaflow-ai/cmux/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts and we actually need to make a bun script that we can run in order to start both the maintenance and dev script (make the window for both at the start)... and the reason is so that we can avoid the vercel timeout.. currently if the maintenance script takes too long, sometimes vercel times out and then the dev script never gets run. by putting it into one single process or script we can avoid that from happening. follow the same logic for running dev script no matter outcome of maintenance script as well.

make sure that we aren't starting the scripts in parallel though. it should be strictly maintenance first and then dev second. we do not want any errors in maintenance to affect dev tho... errors in maintenance should not block dev script from running.