### PR TITLE
Switch updater to universal latest file

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -470,8 +470,7 @@ function setupAutoUpdates(): void {
     autoUpdater.allowPrerelease = false;
 
     if (process.platform === "darwin") {
-      const suffix = process.arch === "arm64" ? "arm64" : "x64";
-      const channel = `latest-${suffix}`;
+      const channel = "latest-universal";
       if (autoUpdater.channel !== channel) {
         autoUpdater.channel = channel;
         mainLog("Configured autoUpdater channel", {


### PR DESCRIPTION
we need to make it so that the updates now checks for latest-universal.yml instead because we are migrating to the universal one instead.. is it possible to get users to migrate from mac arm64 and x64 onto the universal track? think of some ways as wellMAIN] [2025-10-25T03:13:49.322Z] [updater] Error: Error: Cannot find latest-arm64-mac.yml in the latest release artifacts (https://github.com/manaflow-ai/cmux/releases/download/v1.0.130/latest-arm64-mac.yml): HttpError: 404 
"method: GET url: https://github.com/manaflow-ai/cmux/releases/download/v1.0.130/latest-arm64-mac.yml\n\nPlease double check that your authentication token is correct. Due to security reasons, actual status maybe not reported, but 404.\n"
Headers: {
  "cache-control": "no-cache",
  "content-length": "9",
  "content-security-policy": "default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'",
  "content-type": "text/plain; charset=utf-8",
  "date": "Sat, 25 Oct 2025 03:13:49 GMT",
  "referrer-policy": "no-referrer-when-downgrade",
  "server": "github.com",
  "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
  "vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With,Accept-Encoding, Accept, X-Requested-With",
  "x-content-type-options": "nosniff",
  "x-frame-options": "deny",
  "x-github-request-id": "CA9D:323622:12EB1EF:130FB47:68FC406C",
  "x-xss-protection": "0"
}
    at createHttpError (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:21:12)
    at ElectronHttpExecutor.handleResponse (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:121:20)
    at ClientRequest.<anonymous> (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:87:26)
    at ClientRequest.emit (node:events:518:28)
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:124155)
    at SimpleURLLoaderWrapper.emit (node:events:518:28)
    at newError (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/error.js:5:19)
    at fetchData (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:113:63)
    at async GitHubProvider.getLatestVersion (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:123:23)
    at async MacUpdater.getUpdateInfoAndProvider (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:365:19)
    at async MacUpdater.doCheckForUpdates (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:378:24)
(anonymous) @ VM119 index.cjs:225
VM119 index.cjs:225 [MAIN] [2025-10-25T03:13:49.324Z] Updater error Error: Cannot find latest-arm64-mac.yml in the latest release artifacts (https://github.com/manaflow-ai/cmux/releases/download/v1.0.130/latest-arm64-mac.yml): HttpError: 404 
"method: GET url: https://github.com/manaflow-ai/cmux/releases/download/v1.0.130/latest-arm64-mac.yml\n\nPlease double check that your authentication token is correct. Due to security reasons, actual status maybe not reported, but 404.\n"
Headers: {
  "cache-control": "no-cache",
  "content-length": "9",
  "content-security-policy": "default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'",
  "content-type": "text/plain; charset=utf-8",
  "date": "Sat, 25 Oct 2025 03:13:49 GMT",
  "referrer-policy": "no-referrer-when-downgrade",
  "server": "github.com",
  "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
  "vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With,Accept-Encoding, Accept, X-Requested-With",
  "x-content-type-options": "nosniff",
  "x-frame-options": "deny",
  "x-github-request-id": "CA9D:323622:12EB1EF:130FB47:68FC406C",
  "x-xss-protection": "0"
}
    at createHttpError (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:21:12)
    at ElectronHttpExecutor.handleResponse (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:121:20)
    at ClientRequest.<anonymous> (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:87:26)
    at ClientRequest.emit (node:events:518:28)
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:124155)
    at SimpleURLLoaderWrapper.emit (node:events:518:28)
    at newError (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/error.js:5:19)
    at fetchData (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:113:63)
    at async GitHubProvider.getLatestVersion (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:123:23)
    at async MacUpdater.getUpdateInfoAndProvider (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:365:19)
    at async MacUpdater.doCheckForUpdates (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:378:24) {
  code: 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND'
}
(anonymous) @ VM119 index.cjs:225
VM119 index.cjs:225 [MAIN] [2025-10-25T03:13:49.325Z] checkForUpdatesAndNotify failed Error: Cannot find latest-arm64-mac.yml in the latest release artifacts (https://github.com/manaflow-ai/cmux/releases/download/v1.0.130/latest-arm64-mac.yml): HttpError: 404 
"method: GET url: https://github.com/manaflow-ai/cmux/releases/download/v1.0.130/latest-arm64-mac.yml\n\nPlease double check that your authentication token is correct. Due to security reasons, actual status maybe not reported, but 404.\n"
Headers: {
  "cache-control": "no-cache",
  "content-length": "9",
  "content-security-policy": "default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'",
  "content-type": "text/plain; charset=utf-8",
  "date": "Sat, 25 Oct 2025 03:13:49 GMT",
  "referrer-policy": "no-referrer-when-downgrade",
  "server": "github.com",
  "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
  "vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With,Accept-Encoding, Accept, X-Requested-With",
  "x-content-type-options": "nosniff",
  "x-frame-options": "deny",
  "x-github-request-id": "CA9D:323622:12EB1EF:130FB47:68FC406C",
  "x-xss-protection": "0"
}
    at createHttpError (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:21:12)
    at ElectronHttpExecutor.handleResponse (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:121:20)
    at ClientRequest.<anonymous> (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:87:26)
    at ClientRequest.emit (node:events:518:28)
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:124155)
    at SimpleURLLoaderWrapper.emit (node:events:518:28)
    at newError (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/builder-util-runtime/out/error.js:5:19)
    at fetchData (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:113:63)
    at async GitHubProvider.getLatestVersion (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/providers/GitHubProvider.js:123:23)
    at async MacUpdater.getUpdateInfoAndProvider (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:365:19)
    at async MacUpdater.doCheckForUpdates (/Applications/cmux.app/Contents/Resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:378:24) {
  code: 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND'
}
(anonymous) @ VM119 index.cjs:225
_layout-qhDJXI2o.js:3530 [ElectronSocket] No auth token yet; delaying connect