### PR TITLE
Update home page copy to 100x

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -10,12 +10,12 @@ import clsx from "clsx";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "cmux - Manage AI coding agents in parallel — 10x your 10x engineers",
+  title: "cmux - Manage AI coding agents in parallel — 100x your 100x engineers",
   description:
     "cmux spawns Claude Code, Codex, Gemini CLI, Amp, Opencode, and other coding agent CLIs in parallel across multiple tasks. For each run, cmux spawns an isolated VS Code instance via Docker with the git diff UI and terminal.",
   openGraph: {
     title:
-      "cmux - Manage AI coding agents in parallel — 10x your 10x engineers",
+      "cmux - Manage AI coding agents in parallel — 100x your 100x engineers",
     description:
       "Run multiple AI coding agents simultaneously with isolated VS Code instances",
     type: "website",
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title:
-      "cmux - Manage AI coding agents in parallel — 10x your 10x engineers",
+      "cmux - Manage AI coding agents in parallel — 100x your 100x engineers",
     description:
       "Run multiple AI coding agents simultaneously with isolated VS Code instances",
   },

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -174,7 +174,7 @@ export default async function LandingPage() {
 
               <div className="space-y-6">
                 <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
-                  Universal AI coding agent manager for 10x engineers
+                  Universal AI coding agent manager for 100x engineers
                 </h1>
                 <div className="space-y-4 text-base text-neutral-300 sm:text-lg">
                   <p>


### PR DESCRIPTION
for the home page, make "Universal AI coding agent manager for 10x engineers" 100x instead of 10x