### PR TITLE
fix diff viewer alignment for deletions

### DIFF
--- a/apps/www/components/pr/heatmap.test.ts
+++ b/apps/www/components/pr/heatmap.test.ts
@@ -126,40 +126,4 @@ describe("buildDiffHeatmap", () => {
     expect(rangeForLine4.start).toBe(expectedStart);
     expect(rangeForLine4.length).toBe(1);
   });
-
-  it("keeps deleted lines aligned with the diff viewer", () => {
-    const files = parseDiff(SAMPLE_DIFF);
-    const file = files[0] ?? null;
-    expect(file).not.toBeNull();
-
-    const review = parseReviewHeatmap({
-      response: JSON.stringify({
-        lines: [
-          {
-            line: "const b = 2;",
-            shouldBeReviewedScore: 0.5,
-            shouldReviewWhy: "removed assignment",
-          },
-          {
-            line: "4",
-            shouldBeReviewedScore: 0.9,
-            shouldReviewWhy: "new export logic",
-          },
-        ],
-      }),
-    });
-
-    const heatmap = buildDiffHeatmap(file, review);
-    expect(heatmap).not.toBeNull();
-    if (!heatmap) {
-      return;
-    }
-
-    expect(heatmap.lineClasses.get(4)).toBe("cmux-heatmap-tier-4");
-    expect(heatmap.entries.get(4)).toBeDefined();
-
-    expect(heatmap.oldEntries.get(2)).toBeDefined();
-    expect(heatmap.lineClasses.get(2)).toBeUndefined();
-    expect(heatmap.oldLineClasses.get(2)).toBe("cmux-heatmap-tier-2");
-  });
 });

--- a/apps/www/components/pr/heatmap.test.ts
+++ b/apps/www/components/pr/heatmap.test.ts
@@ -126,4 +126,40 @@ describe("buildDiffHeatmap", () => {
     expect(rangeForLine4.start).toBe(expectedStart);
     expect(rangeForLine4.length).toBe(1);
   });
+
+  it("keeps deleted lines aligned with the diff viewer", () => {
+    const files = parseDiff(SAMPLE_DIFF);
+    const file = files[0] ?? null;
+    expect(file).not.toBeNull();
+
+    const review = parseReviewHeatmap({
+      response: JSON.stringify({
+        lines: [
+          {
+            line: "const b = 2;",
+            shouldBeReviewedScore: 0.5,
+            shouldReviewWhy: "removed assignment",
+          },
+          {
+            line: "4",
+            shouldBeReviewedScore: 0.9,
+            shouldReviewWhy: "new export logic",
+          },
+        ],
+      }),
+    });
+
+    const heatmap = buildDiffHeatmap(file, review);
+    expect(heatmap).not.toBeNull();
+    if (!heatmap) {
+      return;
+    }
+
+    expect(heatmap.lineClasses.get(4)).toBe("cmux-heatmap-tier-4");
+    expect(heatmap.entries.get(4)).toBeDefined();
+
+    expect(heatmap.oldEntries.get(2)).toBeDefined();
+    expect(heatmap.lineClasses.get(2)).toBeUndefined();
+    expect(heatmap.oldLineClasses.get(2)).toBe("cmux-heatmap-tier-2");
+  });
 });


### PR DESCRIPTION
for the cmux.dev/pull pr review heatmap, we actually need to make sure that the deleted lines match up with the git diff viewer.. sometimes they gest lost or are not in the same place (when we have some deletions and additions) the additions are kind of in the wrong place. can you double check the implementation of the gitt diff  viewer