### PR TITLE
Reimplement completion detection for Gemini CLI

### DIFF
--- a/packages/shared/src/morph-snapshots.ts
+++ b/packages/shared/src/morph-snapshots.ts
@@ -9,7 +9,7 @@ export interface MorphSnapshotPreset {
 
 export const MORPH_SNAPSHOT_PRESETS = [
   {
-    id: "snapshot_2nwm6jjm",
+    id: "snapshot_wwadg8oa",
     label: "Standard workspace",
     cpu: "4 vCPU",
     memory: "16 GB RAM",
@@ -18,7 +18,7 @@ export const MORPH_SNAPSHOT_PRESETS = [
       "Great default for day-to-day work. Balanced CPU, memory, and storage.",
   },
   {
-    id: "snapshot_a0wb2lw8",
+    id: "snapshot_4zurivwd",
     label: "Performance workspace",
     cpu: "6 vCPU",
     memory: "32 GB RAM",

--- a/packages/shared/src/providers/gemini/configs.ts
+++ b/packages/shared/src/providers/gemini/configs.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "../../agentConfig";
 import { GEMINI_API_KEY } from "../../apiKeys";
 import { checkGeminiRequirements } from "./check-requirements";
 import { startGeminiCompletionDetector } from "./completion-detector";
+import { GEMINI_TELEMETRY_OUTFILE_TEMPLATE } from "./telemetry";
 import { getGeminiEnvironment } from "./environment";
 
 export const GEMINI_FLASH_CONFIG: AgentConfig = {
@@ -15,7 +16,7 @@ export const GEMINI_FLASH_CONFIG: AgentConfig = {
     "--telemetry",
     "--telemetry-target=local",
     "--telemetry-otlp-endpoint=",
-    "--telemetry-outfile=/tmp/gemini-telemetry-$CMUX_TASK_RUN_ID.log",
+    `--telemetry-outfile=${GEMINI_TELEMETRY_OUTFILE_TEMPLATE}`,
     "--telemetry-log-prompts",
     "--prompt-interactive",
     "$PROMPT",
@@ -37,7 +38,7 @@ export const GEMINI_PRO_CONFIG: AgentConfig = {
     "--telemetry",
     "--telemetry-target=local",
     "--telemetry-otlp-endpoint=",
-    "--telemetry-outfile=/tmp/gemini-telemetry-$CMUX_TASK_RUN_ID.log",
+    `--telemetry-outfile=${GEMINI_TELEMETRY_OUTFILE_TEMPLATE}`,
     "--telemetry-log-prompts",
     "--prompt-interactive",
     "$PROMPT",

--- a/packages/shared/src/providers/gemini/environment.ts
+++ b/packages/shared/src/providers/gemini/environment.ts
@@ -2,14 +2,30 @@ import type {
   EnvironmentContext,
   EnvironmentResult,
 } from "../common/environment-result";
+import { getGeminiTelemetryPath } from "./telemetry";
+
+type GeminiModelSettings = {
+  skipNextSpeakerCheck?: boolean;
+  [key: string]: unknown;
+};
+
+type GeminiTelemetrySettings = {
+  outfile?: string;
+  target?: string;
+  otlpEndpoint?: string;
+  logPrompts?: boolean;
+  [key: string]: unknown;
+};
 
 type GeminiSettings = {
   selectedAuthType?: string;
+  model?: GeminiModelSettings;
+  telemetry?: GeminiTelemetrySettings;
   [key: string]: unknown;
 };
 
 export async function getGeminiEnvironment(
-  _ctx: EnvironmentContext
+  ctx: EnvironmentContext
 ): Promise<EnvironmentResult> {
   // These must be lazy since configs are imported into the browser
   const { readFile, stat } = await import("node:fs/promises");
@@ -20,6 +36,7 @@ export async function getGeminiEnvironment(
   const files: EnvironmentResult["files"] = [];
   const env: Record<string, string> = {};
   const startupCommands: string[] = [];
+  const telemetryOutfile = getGeminiTelemetryPath(ctx.taskRunId);
 
   // Ensure .gemini directory exists
   startupCommands.push("mkdir -p ~/.gemini");
@@ -92,6 +109,29 @@ export async function getGeminiEnvironment(
 
     // Force the desired auth type
     settings.selectedAuthType = "gemini-api-key";
+
+    // Ensure telemetry is routed to our per-task logfile.
+    const telemetrySettings =
+      settings.telemetry && typeof settings.telemetry === "object"
+        ? (settings.telemetry as GeminiTelemetrySettings)
+        : {};
+    settings.telemetry = {
+      ...telemetrySettings,
+      outfile: telemetryOutfile,
+      target: "local",
+      otlpEndpoint: "",
+      logPrompts: true,
+    };
+
+    // Force skipNextSpeakerCheck=false so completion events are emitted.
+    const modelSettings =
+      settings.model && typeof settings.model === "object"
+        ? (settings.model as GeminiModelSettings)
+        : {};
+    settings.model = {
+      ...modelSettings,
+      skipNextSpeakerCheck: false,
+    };
 
     const mergedContent = JSON.stringify(settings, null, 2) + "\n";
     files.push({

--- a/packages/shared/src/providers/gemini/telemetry.ts
+++ b/packages/shared/src/providers/gemini/telemetry.ts
@@ -1,0 +1,6 @@
+export const GEMINI_TELEMETRY_OUTFILE_TEMPLATE =
+  "/tmp/gemini-telemetry-$CMUX_TASK_RUN_ID.log";
+
+export function getGeminiTelemetryPath(taskRunId: string): string {
+  return `/tmp/gemini-telemetry-${taskRunId}.log`;
+}

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_2nwm6jjm' | 'snapshot_a0wb2lw8');
+    snapshotId?: string | ('snapshot_wwadg8oa' | 'snapshot_4zurivwd');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
we need to reimplement completion detection for gemini cli. this is a plan of how you can go about tackling this problem:  Detection Signals

  - gemini_cli.next_speaker_check is emitted right after a turn completes
  (once there are no pending tool calls) and contains both the model’s
  finish_reason and the computed result ('user' or 'model'). It is logged in
  sendMessageStream before control returns to the REPL, so a record with result:
  "user" is the moment Gemini is done and waiting for input; result: "model"
  means the CLI will immediately auto-send another “continue” prompt (packages/
  core/src/core/client.ts:622-657, packages/core/src/telemetry/types.ts:601-
  630, docs/get-started/configuration.md:256). This signal only fires when
  model.skipNextSpeakerCheck is false, so set that explicitly in .gemini/
  settings.json (or via env flag) if you need the heartbeat.
  - When working through declarative “tasks” (agents), a complete_task tool call
  is emitted as a normal gemini_cli.tool_call entry, and the executor always
  follows it with a gemini_cli.agent.finish log that includes duration_ms,
  turn_count, and terminate_reason (packages/core/src/agents/executor.ts:197-
  237, packages/core/src/telemetry/types.ts:1408-1460). Watching for
  function_name == "complete_task" or for agent.finish with terminate_reason ==
  "GOAL" gives you an unambiguous “task finished” signal.
  - Session-wide teardown is marked by gemini_cli.conversation_finished, which
  notes the approval mode and total turn count so you can tell when the CLI
  fully exits (packages/core/src/telemetry/types.ts:780-805). Use this to close
  out any lingering state if you’re tailing telemetry continuously.

  Working with telemetry.log

  - The local telemetry target writes concatenated JSON objects (each object
  is an OTLP log record with an attributes map). The integration test helper
  shows exactly how to parse it: wait for .gemini/telemetry.log to exist, split
  by }\n{, and inspect logData.attributes['event.name'] (integration-tests/test-
  helper.ts:571-918). Reusing that helper logic (or translating it into your
  preferred language) gives you a resilient parser.
  - Example quick filter to fire when Gemini hands control back to the user:

    jq -c 'select(.attributes["event.name"]=="gemini_cli.next_speaker_check")
            | {prompt:.attributes.prompt_id,
               finish:.attributes.finish_reason,
               result:.attributes.result}' ~/.gemini/telemetry.log

    Trigger your downstream “ready for user” handling when result=="user".
  - To detect agent completion, filter the same stream
  either for function_name=="complete_task" or directly for
  event.name=="gemini_cli.agent.finish" and branch on terminate_reason.

  Next steps

  1. Turn on telemetry to a local file with telemetry.outfile and set
  model.skipNextSpeakerCheck = false so next_speaker_check logs are generated.
  2. Reuse the parsing pattern from integration-tests/test-helper.ts in your
  watcher to tail the file and raise events on gemini_cli.next_speaker_check
  (result="user"), gemini_cli.agent.finish, and (optionally)
  gemini_cli.conversation_finished.
  3. If you need richer status dashboards, emit lightweight counters whenever
  those events arrive (result="model" can feed an “auto-follow-up” metric,
  finish_reason reveals truncations, and terminate_reason distinguishes success
  vs. timeout).