### PR TITLE
Add persistent dark mode toggle on PR-review page

### DIFF
--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/_components/review-diff-content.tsx
+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/_components/review-diff-content.tsx
@@ -74,10 +74,10 @@ export function ReviewDiffSummary({
   return (
     <header className="flex flex-wrap items-center justify-between gap-3">
       <div>
-        <h2 className="text-lg font-semibold text-neutral-900">
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">
           Files changed
         </h2>
-        <p className="text-sm text-neutral-600">
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
           {fileCount} file{fileCount === 1 ? "" : "s"}, {additions} additions,{" "}
           {deletions} deletions
         </p>
@@ -97,12 +97,12 @@ export function ReviewChangeSummary({
 }) {
   return (
     <div className="flex items-center gap-2">
-      <span className="text-neutral-600">
-        <GitPullRequest className="inline h-3 w-3" /> {changedFiles}
+      <span className="text-neutral-600 dark:text-neutral-300">
+        <GitPullRequest className="inline h-3 w-3" aria-hidden /> {changedFiles}
       </span>
-      <span className="text-neutral-400">•</span>
-      <span className="text-emerald-700">+{additions}</span>
-      <span className="text-rose-700">-{deletions}</span>
+      <span className="text-neutral-400 dark:text-neutral-600">•</span>
+      <span className="text-emerald-700 dark:text-emerald-400">+{additions}</span>
+      <span className="text-rose-700 dark:text-rose-400">-{deletions}</span>
     </div>
   );
 }
@@ -110,7 +110,7 @@ export function ReviewChangeSummary({
 export function ReviewGitHubLinkButton({ href }: { href: string }) {
   return (
     <a
-      className="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 font-medium text-neutral-700 transition hover:border-neutral-400 hover:text-neutral-900"
+      className="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 font-medium text-neutral-700 transition hover:border-neutral-400 hover:text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:text-neutral-50"
       href={href}
       target="_blank"
       rel="noreferrer"
@@ -159,12 +159,12 @@ export function ReviewDiffViewerWrapper({
 export function DiffViewerSkeleton() {
   return (
     <div className="space-y-4">
-      <div className="h-6 w-48 rounded bg-neutral-200" />
+      <div className="h-6 w-48 rounded bg-neutral-200 dark:bg-neutral-700" />
       <div className="space-y-3">
         {Array.from({ length: 3 }).map((_, index) => (
           <div
             key={index}
-            className="h-32 rounded-xl border border-neutral-200 bg-neutral-100"
+            className="h-32 rounded-xl border border-neutral-200 bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-800"
           />
         ))}
       </div>
@@ -182,11 +182,11 @@ export function ErrorPanel({
   documentationUrl?: string;
 }) {
   return (
-    <div className="rounded-xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700">
+    <div className="rounded-xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
       <p className="font-semibold">{title}</p>
       <p className="mt-2 leading-relaxed">{message}</p>
       {documentationUrl ? (
-        <p className="mt-3 text-xs text-rose-600 underline">
+        <p className="mt-3 text-xs text-rose-600 underline dark:text-rose-300">
           <Link href={documentationUrl} target="_blank" rel="noreferrer">
             View GitHub documentation
           </Link>

--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/theme-provider.tsx
+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/theme-provider.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import { Moon, Sun } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import {
+  DEFAULT_THEME,
+  THEME_COOKIE_NAME,
+  type ThemePreference,
+  isThemePreference,
+} from "./theme";
+
+const THEME_STORAGE_KEY = "prReviewTheme";
+
+type ThemeContextValue = {
+  theme: ThemePreference;
+  setTheme: (theme: ThemePreference) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function PageThemeProvider({
+  initialTheme,
+  children,
+}: {
+  initialTheme?: ThemePreference | null;
+  children: ReactNode;
+}) {
+  const [theme, setThemeState] = useState<ThemePreference>(
+    initialTheme ?? DEFAULT_THEME
+  );
+
+  useEffect(() => {
+    if (!initialTheme) {
+      return;
+    }
+
+    setThemeState((current) =>
+      current === initialTheme ? current : initialTheme
+    );
+  }, [initialTheme]);
+
+  useEffect(() => {
+    if (initialTheme && isThemePreference(initialTheme)) {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+      if (isThemePreference(stored)) {
+        setThemeState(stored);
+      }
+    } catch {
+      // Access to localStorage can fail in non-browser environments; ignore.
+    }
+  }, [initialTheme]);
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => (current === "light" ? "dark" : "light"));
+  }, []);
+
+  useEffect(() => {
+    const maxAgeSeconds = 60 * 60 * 24 * 365; // 1 year
+    document.cookie = `${THEME_COOKIE_NAME}=${theme}; path=/; max-age=${maxAgeSeconds}; sameSite=lax`;
+
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Ignore localStorage failures.
+    }
+
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    document.documentElement.dataset.prReviewTheme = theme;
+  }, [theme]);
+
+  const contextValue = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme]
+  );
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <div className={cn(theme === "dark" && "dark", "transition-colors")}>
+        {children}
+      </div>
+    </ThemeContext.Provider>
+  );
+}
+
+export function usePageTheme(): ThemeContextValue {
+  const value = useContext(ThemeContext);
+
+  if (!value) {
+    throw new Error("usePageTheme must be used within a PageThemeProvider");
+  }
+
+  return value;
+}
+
+export function ThemeToggleButton({ className }: { className?: string }) {
+  const { theme, toggleTheme } = usePageTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-pressed={isDark}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-xs font-medium text-neutral-700 transition hover:border-neutral-400 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-neutral-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:text-neutral-50 dark:focus-visible:ring-neutral-400 dark:focus-visible:ring-offset-neutral-900",
+        className
+      )}
+    >
+      {isDark ? (
+        <Sun className="h-3.5 w-3.5" aria-hidden />
+      ) : (
+        <Moon className="h-3.5 w-3.5" aria-hidden />
+      )}
+      <span>{isDark ? "Light mode" : "Dark mode"}</span>
+    </button>
+  );
+}

--- a/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/theme.ts
+++ b/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/theme.ts
@@ -1,0 +1,8 @@
+export type ThemePreference = "light" | "dark";
+
+export const DEFAULT_THEME: ThemePreference = "light";
+export const THEME_COOKIE_NAME = "pr-review-theme";
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "light" || value === "dark";
+}


### PR DESCRIPTION
make a button somewhere that you can toggle between light and dark mode (save it) for @manaflow-ai/cmux/apps/www/app/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx (not just dark mode for the git diff viewer but all the stuff on that page light mode is what it is currently, you just need to implement dark mode and add a toggle so i can toggle to dark mode (save this setting for future use as well)