### PR TITLE
Fallback to Codex/Claude API keys when signed out

### DIFF
--- a/packages/shared/src/providers/openai/check-requirements.ts
+++ b/packages/shared/src/providers/openai/check-requirements.ts
@@ -1,22 +1,31 @@
-export async function checkOpenAIRequirements(): Promise<string[]> {
+import type { ProviderRequirementsContext } from "../../agentConfig";
+
+export async function checkOpenAIRequirements(
+  context?: ProviderRequirementsContext
+): Promise<string[]> {
   const { access } = await import("node:fs/promises");
   const { homedir } = await import("node:os");
   const { join } = await import("node:path");
   
   const missing: string[] = [];
+  const hasApiKey = Boolean(context?.apiKeys?.OPENAI_API_KEY?.trim());
 
   // Check for .codex/auth.json (required for Codex CLI)
   try {
     await access(join(homedir(), ".codex", "auth.json"));
   } catch {
-    missing.push(".codex/auth.json file");
+    if (!hasApiKey) {
+      missing.push(".codex/auth.json file or OPENAI_API_KEY");
+    }
   }
 
   // Check for .codex/config.toml (new preferred config)
   try {
     await access(join(homedir(), ".codex", "config.toml"));
   } catch {
-    missing.push(".codex/config.toml file");
+    if (!hasApiKey) {
+      missing.push(".codex/config.toml file or OPENAI_API_KEY");
+    }
   }
 
   return missing;


### PR DESCRIPTION
currently for some reason, we do not support codex or claude code api keys... if there is no local setup (not signed in locally) for either we should next try the api key... this should work without breaking any of the other funcationality, like tmux attach etc. we used to support this, figure out root cause of the issue.