### PR TITLE
Auto refresh expired auth tokens

### DIFF
--- a/apps/client/src/contexts/convex/authJsonQueryOptions.ts
+++ b/apps/client/src/contexts/convex/authJsonQueryOptions.ts
@@ -8,12 +8,14 @@ export interface StackUserLike {
   getAuthJson: () => Promise<{ accessToken: string | null }>;
 }
 
+export const AUTH_JSON_QUERY_KEY = ["authJson"] as const;
+
 // Refresh every 9 minutes to beat the ~10 minute Stack access token expiry window
 export const defaultAuthJsonRefreshInterval = 9 * 60 * 1000;
 
 export function authJsonQueryOptions() {
   return queryOptions<AuthJson>({
-    queryKey: ["authJson"],
+    queryKey: AUTH_JSON_QUERY_KEY,
     queryFn: async () => {
       const user = await cachedGetUser(stackClientApp);
       if (!user) return null;

--- a/apps/client/src/lib/cachedGetUser.ts
+++ b/apps/client/src/lib/cachedGetUser.ts
@@ -9,6 +9,12 @@ declare global {
   }
 }
 
+export function resetCachedUserCache() {
+  if (typeof window === "undefined") return;
+  window.cachedUser = null;
+  window.userPromise = null;
+}
+
 export async function cachedGetUser(
   stackClientApp: StackClientApp
 ): Promise<User | null> {
@@ -17,21 +23,18 @@ export async function cachedGetUser(
     try {
       const tokens = await window.cachedUser.currentSession.getTokens();
       if (!tokens.accessToken) {
-        window.cachedUser = null;
-        window.userPromise = null;
+        resetCachedUserCache();
         return null;
       }
       const jwt = decodeJwt(tokens.accessToken);
       if (jwt.exp && jwt.exp < Date.now() / 1000) {
-        window.cachedUser = null;
-        window.userPromise = null;
+        resetCachedUserCache();
         return null;
       }
       return window.cachedUser;
     } catch (error) {
       console.warn("Error checking cached user validity:", error);
-      window.cachedUser = null;
-      window.userPromise = null;
+      resetCachedUserCache();
     }
   }
 
@@ -44,16 +47,14 @@ export async function cachedGetUser(
       const user = await stackClientApp.getUser();
 
       if (!user) {
-        window.cachedUser = null;
-        window.userPromise = null;
+        resetCachedUserCache();
         return null;
       }
 
       const tokens = await user.currentSession.getTokens();
 
       if (!tokens.accessToken) {
-        window.cachedUser = null;
-        window.userPromise = null;
+        resetCachedUserCache();
         return null;
       }
       window.cachedUser = user;
@@ -61,8 +62,7 @@ export async function cachedGetUser(
       return user;
     } catch (error) {
       console.error("Error fetching user:", error);
-      window.cachedUser = null;
-      window.userPromise = null;
+      resetCachedUserCache();
       return null;
     } finally {
       window.userPromise = null;

--- a/apps/client/src/lib/stack.ts
+++ b/apps/client/src/lib/stack.ts
@@ -2,9 +2,11 @@ import { client as wwwOpenAPIClient } from "@cmux/www-openapi-client/client.gen"
 import { StackClientApp } from "@stackframe/react";
 import { useNavigate as useTanstackNavigate } from "@tanstack/react-router";
 import { env } from "../client-env";
+import { AUTH_JSON_QUERY_KEY } from "../contexts/convex/authJsonQueryOptions";
 import { signalConvexAuthReady } from "../contexts/convex/convex-auth-ready";
 import { convexQueryClient } from "../contexts/convex/convex-query-client";
-import { cachedGetUser } from "./cachedGetUser";
+import { queryClient } from "../query-client";
+import { cachedGetUser, resetCachedUserCache } from "./cachedGetUser";
 import { WWW_ORIGIN } from "./wwwOrigin";
 
 export const stackClientApp = new StackClientApp({
@@ -28,40 +30,126 @@ convexQueryClient.convexClient.setAuth(
   },
 );
 
-const fetchWithAuth = (async (request: Request) => {
+const MAX_AUTH_RETRIES = 1;
+
+function applyHeaders(target: Headers, source?: HeadersInit) {
+  if (!source) {
+    return;
+  }
+  new Headers(source).forEach((value, key) => {
+    target.set(key, value);
+  });
+}
+
+async function performAuthedFetch(requestTemplate: Request) {
   const user = await cachedGetUser(stackClientApp);
   if (!user) {
     throw new Error("User not found");
   }
+
   const authHeaders = await user.getAuthHeaders();
   const mergedHeaders = new Headers();
   for (const [key, value] of Object.entries(authHeaders)) {
-    mergedHeaders.set(key, value);
-  }
-  for (const [key, value] of request instanceof Request
-    ? request.headers.entries()
-    : []) {
-    mergedHeaders.set(key, value);
-  }
-  const response = await fetch(request, {
-    headers: mergedHeaders,
-  });
-  if (!response.ok) {
-    try {
-      const clone = response.clone();
-      const bodyText = await clone.text();
-      console.error("[APIError]", {
-        url: response.url,
-        status: response.status,
-        statusText: response.statusText,
-        body: bodyText.slice(0, 2000),
-      });
-    } catch (e) {
-      console.error("[APIError] Failed to read error body", e);
+    if (value !== undefined) {
+      mergedHeaders.set(key, value);
     }
   }
+
+  const baseRequest = new Request(requestTemplate);
+  applyHeaders(mergedHeaders, baseRequest.headers);
+
+  const authedRequest = new Request(baseRequest, {
+    headers: mergedHeaders,
+  });
+
+  return fetch(authedRequest);
+}
+
+async function logApiError(response: Response) {
+  try {
+    const clone = response.clone();
+    const bodyText = await clone.text();
+    console.error("[APIError]", {
+      url: response.url,
+      status: response.status,
+      statusText: response.statusText,
+      body: bodyText.slice(0, 2000),
+    });
+  } catch (error) {
+    console.error("[APIError] Failed to read error body", error);
+  }
+}
+
+async function shouldRetryForAuth(response: Response) {
+  if (response.status === 401) {
+    return true;
+  }
+
+  if (response.status === 400) {
+    try {
+      const clone = response.clone();
+      const contentType = clone.headers.get("content-type") ?? "";
+      if (contentType.toLowerCase().includes("application/json")) {
+        const data = (await clone.json()) as { message?: unknown } | null;
+        const message =
+          typeof data === "object" && data && "message" in data
+            ? data.message
+            : undefined;
+        if (
+          typeof message === "string" &&
+          message.toLowerCase().includes("invalid stack auth")
+        ) {
+          return true;
+        }
+      } else {
+        const text = await clone.text();
+        if (text.toLowerCase().includes("invalid stack auth")) {
+          return true;
+        }
+      }
+    } catch {
+      // Swallow JSON parsing errors; we'll fall back to logging below.
+    }
+  }
+
+  return false;
+}
+
+function invalidateAuthQueryCache() {
+  try {
+    void queryClient.invalidateQueries({ queryKey: AUTH_JSON_QUERY_KEY });
+  } catch (error) {
+    console.warn(
+      "[fetchWithAuth] Failed to invalidate auth query cache after auth error",
+      error,
+    );
+  }
+}
+
+const fetchWithAuth: typeof fetch = async (input, init) => {
+  const requestTemplate = new Request(input, init);
+  let response = await performAuthedFetch(requestTemplate);
+
+  for (let attempt = 0; attempt < MAX_AUTH_RETRIES; attempt += 1) {
+    if (!(await shouldRetryForAuth(response))) {
+      break;
+    }
+
+    console.warn("[fetchWithAuth] Auth error detected; retrying with refresh", {
+      status: response.status,
+      attempt: attempt + 1,
+    });
+    resetCachedUserCache();
+    invalidateAuthQueryCache();
+    response = await performAuthedFetch(requestTemplate);
+  }
+
+  if (!response.ok) {
+    await logApiError(response);
+  }
+
   return response;
-}) as typeof fetch; // TODO: remove when bun types dont conflict with node types
+};
 
 wwwOpenAPIClient.setConfig({
   baseUrl: WWW_ORIGIN,


### PR DESCRIPTION
we have a problem with invalid auth header. this happens because some auth token expires and we are forced to quit the app and restart it in order to get it to work again. we need to do this refresh automatically without the user needing to quit the app and restart it.