### PR TITLE
Add buttons to start cloud or local workspace

### DIFF
--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -583,6 +583,7 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
           projectFullName: undefined, // No repo for cloud environment workspaces
           baseBranch: undefined, // No branch for environments
           environmentId,
+          isCloudWorkspace: true,
         });
 
         // Hint the sidebar to auto-expand this task once it appears

--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -14,7 +14,10 @@ import {
 import { useLocalVSCodeServeWebQuery } from "@/queries/local-vscode-serve-web";
 import { api } from "@cmux/convex/api";
 import type { Doc, Id } from "@cmux/convex/dataModel";
-import type { CreateLocalWorkspaceResponse } from "@cmux/shared";
+import type {
+  CreateLocalWorkspaceResponse,
+  CreateCloudWorkspaceResponse,
+} from "@cmux/shared";
 import { deriveRepoBaseName, generateWorkspaceName } from "@cmux/shared";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useUser, type Team } from "@stackframe/react";
@@ -115,6 +118,12 @@ type LocalWorkspaceOption = {
   keywords: string[];
 };
 
+type CloudWorkspaceOption = {
+  environmentId: Id<"environments">;
+  name: string;
+  keywords: string[];
+};
+
 type CommandListEntry = {
   value: string;
   label: string;
@@ -158,9 +167,11 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   const [search, setSearch] = useState("");
   const [openedWithShift, setOpenedWithShift] = useState(false);
   const [activePage, setActivePage] = useState<
-    "root" | "teams" | "local-workspaces"
+    "root" | "teams" | "local-workspaces" | "cloud-workspaces"
   >("root");
   const [isCreatingLocalWorkspace, setIsCreatingLocalWorkspace] =
+    useState(false);
+  const [isCreatingCloudWorkspace, setIsCreatingCloudWorkspace] =
     useState(false);
   const [commandValue, setCommandValue] = useState<string | undefined>(
     undefined
@@ -174,7 +185,7 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   const prevFocusedElRef = useRef<HTMLElement | null>(null);
   const navigate = useNavigate();
   const router = useRouter();
-  const { setTheme } = useTheme();
+  const { setTheme, theme } = useTheme();
   const { addTaskToExpand } = useExpandTasks();
   const { socket } = useSocket();
   const localServeWeb = useLocalVSCodeServeWebQuery();
@@ -218,6 +229,7 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   const selectedTeamId = stackUser?.selectedTeam?.id ?? null;
   const teamMemberships = useQuery(api.teams.listTeamMemberships, {});
   const reposByOrg = useQuery(api.github.getReposByOrg, { teamSlugOrId });
+  const environments = useQuery(api.environments.list, { teamSlugOrId });
 
   const localWorkspaceOptions = useMemo<LocalWorkspaceOption[]>(() => {
     const repoGroups = reposByOrg ?? {};
@@ -271,6 +283,27 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   }, [reposByOrg]);
 
   const isLocalWorkspaceLoading = reposByOrg === undefined;
+
+  const cloudWorkspaceOptions = useMemo<CloudWorkspaceOption[]>(() => {
+    if (!environments) return [];
+    return environments
+      .sort((a, b) => {
+        // Sort by creation time, most recent first
+        return b.createdAt - a.createdAt;
+      })
+      .map((env) => ({
+        environmentId: env._id,
+        name: env.name,
+        keywords: compactStrings([
+          env.name,
+          env.description,
+          env.morphSnapshotId,
+          ...(env.selectedRepos ?? []),
+        ]),
+      }));
+  }, [environments]);
+
+  const isCloudWorkspaceLoading = environments === undefined;
 
   const getClientSlug = useCallback((meta: unknown): string | undefined => {
     if (!isRecord(meta)) return undefined;
@@ -353,6 +386,7 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   });
   const predictedWorkspaceSequence = nextWorkspaceSequence?.sequence ?? null;
   const reserveLocalWorkspace = useMutation(api.localWorkspaces.reserve);
+  const createTask = useMutation(api.tasks.create);
   const failTaskRun = useMutation(api.taskRuns.fail);
 
   useEffect(() => {
@@ -521,6 +555,95 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
       void createLocalWorkspace(projectFullName);
     },
     [closeCommand, createLocalWorkspace]
+  );
+
+  const createCloudWorkspace = useCallback(
+    async (environmentId: Id<"environments">) => {
+      if (isCreatingCloudWorkspace) {
+        return;
+      }
+      if (!socket) {
+        console.warn(
+          "Socket is not connected yet. Please try again momentarily."
+        );
+        return;
+      }
+
+      setIsCreatingCloudWorkspace(true);
+
+      try {
+        // Find environment name for the task text
+        const environment = environments?.find((env) => env._id === environmentId);
+        const environmentName = environment?.name ?? "Unknown Environment";
+
+        // Create task in Convex without task description (it's just a workspace)
+        const taskId = await createTask({
+          teamSlugOrId,
+          text: `Cloud Workspace: ${environmentName}`,
+          projectFullName: undefined, // No repo for cloud environment workspaces
+          baseBranch: undefined, // No branch for environments
+          environmentId,
+        });
+
+        // Hint the sidebar to auto-expand this task once it appears
+        addTaskToExpand(taskId);
+
+        await new Promise<void>((resolve) => {
+          socket.emit(
+            "create-cloud-workspace",
+            {
+              teamSlugOrId,
+              environmentId,
+              taskId,
+              theme,
+            },
+            async (response: CreateCloudWorkspaceResponse) => {
+              try {
+                if (response.success) {
+                  toast.success("Cloud workspace created successfully");
+                } else {
+                  toast.error(
+                    response.error || "Failed to create cloud workspace"
+                  );
+                }
+              } catch (callbackError) {
+                const message =
+                  callbackError instanceof Error
+                    ? callbackError.message
+                    : String(callbackError ?? "Unknown");
+                console.error("Failed to create cloud workspace", message);
+              } finally {
+                resolve();
+              }
+            }
+          );
+        });
+
+        console.log("Cloud workspace created:", taskId);
+      } catch (error) {
+        console.error("Error creating cloud workspace:", error);
+        toast.error("Failed to create cloud workspace");
+      } finally {
+        setIsCreatingCloudWorkspace(false);
+      }
+    },
+    [
+      addTaskToExpand,
+      createTask,
+      environments,
+      isCreatingCloudWorkspace,
+      socket,
+      teamSlugOrId,
+      theme,
+    ]
+  );
+
+  const handleCloudWorkspaceSelect = useCallback(
+    (environmentId: Id<"environments">) => {
+      closeCommand();
+      void createCloudWorkspace(environmentId);
+    },
+    [closeCommand, createCloudWorkspace]
   );
 
   useEffect(() => {
@@ -731,6 +854,10 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
         });
       } else if (value === "local-workspaces") {
         setActivePage("local-workspaces");
+        setSearch("");
+        return;
+      } else if (value === "cloud-workspaces") {
+        setActivePage("cloud-workspaces");
         setSearch("");
         return;
       } else if (value === "pull-requests") {
@@ -965,6 +1092,24 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
           <>
             <FolderPlus className="h-4 w-4 text-neutral-500" />
             <span className="text-sm">New Local Workspace</span>
+          </>
+        ),
+      },
+      {
+        value: "cloud-workspaces",
+        label: "New Cloud Workspace",
+        keywords: ["workspace", "cloud", "environment", "env"],
+        searchText: buildSearchText(
+          "New Cloud Workspace",
+          ["workspace", "cloud", "environment"],
+          ["cloud-workspaces"]
+        ),
+        className: baseCommandItemClassName,
+        execute: () => handleSelect("cloud-workspaces"),
+        renderContent: () => (
+          <>
+            <Server className="h-4 w-4 text-neutral-500" />
+            <span className="text-sm">New Cloud Workspace</span>
           </>
         ),
       },
@@ -1364,6 +1509,31 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
     predictedWorkspaceSequence,
   ]);
 
+  const cloudWorkspaceEntries = useMemo<CommandListEntry[]>(() => {
+    return cloudWorkspaceOptions.map((option) => {
+      const value = `cloud-workspace:${option.environmentId}`;
+      return {
+        value,
+        label: option.name,
+        keywords: option.keywords,
+        searchText: buildSearchText(option.name, option.keywords, [
+          option.environmentId,
+        ]),
+        className: baseCommandItemClassName,
+        disabled: isCreatingCloudWorkspace,
+        execute: () => handleCloudWorkspaceSelect(option.environmentId),
+        renderContent: () => (
+          <>
+            <Server className="h-4 w-4 text-neutral-500" />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-sm">{option.name}</span>
+            </div>
+          </>
+        ),
+      };
+    });
+  }, [cloudWorkspaceOptions, handleCloudWorkspaceSelect, isCreatingCloudWorkspace]);
+
   const {
     history: rootSuggestionHistory,
     record: recordRootUsage,
@@ -1374,6 +1544,11 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
     record: recordLocalWorkspaceUsage,
     prune: pruneLocalWorkspaceHistory,
   } = useSuggestionHistory(buildScopeKey("local-workspaces", teamSlugOrId));
+  const {
+    history: cloudWorkspaceSuggestionHistory,
+    record: recordCloudWorkspaceUsage,
+    prune: pruneCloudWorkspaceHistory,
+  } = useSuggestionHistory(buildScopeKey("cloud-workspaces", teamSlugOrId));
 
   useEffect(() => {
     pruneRootHistory(new Set(rootCommandEntries.map((entry) => entry.value)));
@@ -1385,6 +1560,12 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
     );
   }, [localWorkspaceEntries, pruneLocalWorkspaceHistory]);
 
+  useEffect(() => {
+    pruneCloudWorkspaceHistory(
+      new Set(cloudWorkspaceEntries.map((entry) => entry.value))
+    );
+  }, [cloudWorkspaceEntries, pruneCloudWorkspaceHistory]);
+
   const filteredRootEntries = useMemo(
     () => filterCommandItems(search, rootCommandEntries),
     [rootCommandEntries, search]
@@ -1393,6 +1574,10 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
   const filteredLocalWorkspaceEntries = useMemo(
     () => filterCommandItems(search, localWorkspaceEntries),
     [localWorkspaceEntries, search]
+  );
+  const filteredCloudWorkspaceEntries = useMemo(
+    () => filterCommandItems(search, cloudWorkspaceEntries),
+    [cloudWorkspaceEntries, search]
   );
   const filteredTeamEntries = useMemo(
     () => filterCommandItems(search, teamCommandEntries),
@@ -1485,6 +1670,53 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
       ].map((entry) => entry.value),
     [localWorkspaceCommandsToRender, localWorkspaceSuggestionsToRender]
   );
+
+  const cloudWorkspaceSuggestedEntries = useMemo(
+    () =>
+      selectSuggestedItems(
+        cloudWorkspaceSuggestionHistory,
+        filteredCloudWorkspaceEntries,
+        5
+      ),
+    [filteredCloudWorkspaceEntries, cloudWorkspaceSuggestionHistory]
+  );
+  const cloudWorkspaceSuggestedValueSet = useMemo(
+    () => new Set(cloudWorkspaceSuggestedEntries.map((entry) => entry.value)),
+    [cloudWorkspaceSuggestedEntries]
+  );
+  const cloudWorkspaceRemainingEntries = useMemo(
+    () =>
+      filteredCloudWorkspaceEntries.filter(
+        (entry) => !cloudWorkspaceSuggestedValueSet.has(entry.value)
+      ),
+    [filteredCloudWorkspaceEntries, cloudWorkspaceSuggestedValueSet]
+  );
+
+  const cloudWorkspaceSuggestionsToRender = useMemo(
+    () => (!hasSearchQuery ? cloudWorkspaceSuggestedEntries : []),
+    [hasSearchQuery, cloudWorkspaceSuggestedEntries]
+  );
+  const cloudWorkspaceCommandsToRender = useMemo(
+    () =>
+      hasSearchQuery || cloudWorkspaceSuggestionsToRender.length === 0
+        ? filteredCloudWorkspaceEntries
+        : cloudWorkspaceRemainingEntries,
+    [
+      filteredCloudWorkspaceEntries,
+      hasSearchQuery,
+      cloudWorkspaceRemainingEntries,
+      cloudWorkspaceSuggestionsToRender.length,
+    ]
+  );
+  const cloudWorkspaceVisibleValues = useMemo(
+    () =>
+      [
+        ...cloudWorkspaceSuggestionsToRender,
+        ...cloudWorkspaceCommandsToRender,
+      ].map((entry) => entry.value),
+    [cloudWorkspaceCommandsToRender, cloudWorkspaceSuggestionsToRender]
+  );
+
   const teamVisibleValues = useMemo(() => {
     if (!filteredTeamEntries.length) return [];
     return filteredTeamEntries.map((entry) => entry.value);
@@ -1545,6 +1777,8 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
       availableValues = rootVisibleValues;
     } else if (activePage === "local-workspaces") {
       availableValues = localWorkspaceVisibleValues;
+    } else if (activePage === "cloud-workspaces") {
+      availableValues = cloudWorkspaceVisibleValues;
     } else if (activePage === "teams") {
       availableValues = teamVisibleValues;
     }
@@ -1559,6 +1793,7 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
     }
   }, [
     activePage,
+    cloudWorkspaceVisibleValues,
     commandValue,
     localWorkspaceVisibleValues,
     open,
@@ -1583,6 +1818,8 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
       availableValues = rootVisibleValues;
     } else if (activePage === "local-workspaces") {
       availableValues = localWorkspaceVisibleValues;
+    } else if (activePage === "cloud-workspaces") {
+      availableValues = cloudWorkspaceVisibleValues;
     } else if (activePage === "teams") {
       availableValues = teamVisibleValues;
     }
@@ -1599,6 +1836,7 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
     scrollCommandItemIntoView(firstValue);
   }, [
     activePage,
+    cloudWorkspaceVisibleValues,
     commandValue,
     localWorkspaceVisibleValues,
     open,
@@ -1678,7 +1916,11 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
                   ? isLocalWorkspaceLoading
                     ? "Loading repositories…"
                     : "No matching repositories."
-                  : "No results found."}
+                  : activePage === "cloud-workspaces"
+                    ? isCloudWorkspaceLoading
+                      ? "Loading environments…"
+                      : "No matching environments."
+                    : "No results found."}
             </Command.Empty>
 
             {activePage === "root" ? (
@@ -1725,6 +1967,39 @@ export function CommandBar({ teamSlugOrId }: CommandBarProps) {
                       <Command.Group>
                         {localWorkspaceCommandsToRender.map((entry) =>
                           renderCommandItem(entry, recordLocalWorkspaceUsage)
+                        )}
+                      </Command.Group>
+                    ) : null}
+                  </>
+                )}
+              </>
+            ) : null}
+
+            {activePage === "cloud-workspaces" ? (
+              <>
+                {isCloudWorkspaceLoading ? (
+                  <div className={placeholderClassName}>
+                    Loading environments…
+                  </div>
+                ) : (
+                  <>
+                    {cloudWorkspaceSuggestionsToRender.length > 0 ? (
+                      <Command.Group>
+                        {cloudWorkspaceSuggestionsToRender.map((entry) =>
+                          renderCommandItem(entry, recordCloudWorkspaceUsage)
+                        )}
+                      </Command.Group>
+                    ) : null}
+                    {cloudWorkspaceSuggestionsToRender.length > 0 &&
+                    cloudWorkspaceCommandsToRender.length > 0 ? (
+                      <div className="px-2">
+                        <hr className="border-neutral-200 dark:border-neutral-800" />
+                      </div>
+                    ) : null}
+                    {cloudWorkspaceCommandsToRender.length > 0 ? (
+                      <Command.Group>
+                        {cloudWorkspaceCommandsToRender.map((entry) =>
+                          renderCommandItem(entry, recordCloudWorkspaceUsage)
                         )}
                       </Command.Group>
                     ) : null}

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -204,7 +204,7 @@ function TaskTreeInner({
 
   const handleCopyDescription = useCallback(() => {
     if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(task.text).catch(() => {});
+      navigator.clipboard.writeText(task.text).catch(() => { });
     }
   }, [task.text]);
 
@@ -229,6 +229,7 @@ function TaskTreeInner({
   const canExpand = true;
   const isCrownEvaluating = task.crownEvaluationStatus === "in_progress";
   const isLocalWorkspace = task.isLocalWorkspace;
+  const isCloudWorkspace = Boolean(task.environmentId && !task.projectFullName);
 
   const taskLeadingIcon = (() => {
     if (isCrownEvaluating) {
@@ -315,7 +316,7 @@ function TaskTreeInner({
       }
     }
 
-    if (isLocalWorkspace) {
+    if (isLocalWorkspace || isCloudWorkspace) {
       return null;
     }
 
@@ -600,6 +601,7 @@ function TaskRunTreeInner({
   );
 
   const isLocalWorkspaceRunEntry = run.isLocalWorkspace;
+  const isCloudWorkspaceRunEntry = Boolean(run.environmentId);
 
   const statusIcon = {
     pending: <Circle className="w-3 h-3 text-neutral-400" />,
@@ -609,7 +611,7 @@ function TaskRunTreeInner({
   }[run.status];
 
   const shouldHideStatusIcon =
-    isLocalWorkspaceRunEntry && run.status !== "failed";
+    (isLocalWorkspaceRunEntry || isCloudWorkspaceRunEntry) && run.status !== "failed";
 
   const pullRequestState = useMemo<RunPullRequestState | null>(() => {
     if (run.pullRequests && run.pullRequests.length > 0) {
@@ -761,7 +763,7 @@ function TaskRunTreeInner({
   const shouldRenderTerminalLink = shouldRenderBrowserLink;
   const shouldRenderPullRequestLink = Boolean(
     (run.pullRequestUrl && run.pullRequestUrl !== "pending") ||
-      run.pullRequests?.some((pr) => pr.url)
+    run.pullRequests?.some((pr) => pr.url)
   );
   const shouldRenderPreviewLink = previewServices.length > 0;
   const hasOpenWithActions = openWithActions.length > 0;

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -229,7 +229,7 @@ function TaskTreeInner({
   const canExpand = true;
   const isCrownEvaluating = task.crownEvaluationStatus === "in_progress";
   const isLocalWorkspace = task.isLocalWorkspace;
-  const isCloudWorkspace = Boolean(task.environmentId && !task.projectFullName);
+  const isCloudWorkspace = task.isCloudWorkspace;
 
   const taskLeadingIcon = (() => {
     if (isCrownEvaluating) {
@@ -601,7 +601,7 @@ function TaskRunTreeInner({
   );
 
   const isLocalWorkspaceRunEntry = run.isLocalWorkspace;
-  const isCloudWorkspaceRunEntry = Boolean(run.environmentId);
+  const isCloudWorkspaceRunEntry = run.isCloudWorkspace;
 
   const statusIcon = {
     pending: <Circle className="w-3 h-3 text-neutral-400" />,

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -204,7 +204,7 @@ function TaskTreeInner({
 
   const handleCopyDescription = useCallback(() => {
     if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(task.text).catch(() => { });
+      navigator.clipboard.writeText(task.text);
     }
   }, [task.text]);
 

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -31,7 +31,8 @@ export function WorkspaceCreationButtons({
   const { socket } = useSocket();
   const { addTaskToExpand } = useExpandTasks();
   const { theme } = useTheme();
-  const [isCreating, setIsCreating] = useState(false);
+  const [isCreatingLocal, setIsCreatingLocal] = useState(false);
+  const [isCreatingCloud, setIsCreatingCloud] = useState(false);
 
   const reserveLocalWorkspace = useMutation(api.localWorkspaces.reserve);
   const createTask = useMutation(api.tasks.create);
@@ -55,7 +56,7 @@ export function WorkspaceCreationButtons({
     const projectFullName = selectedProject[0];
     const repoUrl = `https://github.com/${projectFullName}.git`;
 
-    setIsCreating(true);
+    setIsCreatingLocal(true);
 
     try {
       const reservation = await reserveLocalWorkspace({
@@ -100,7 +101,7 @@ export function WorkspaceCreationButtons({
       console.error("Error creating local workspace:", error);
       toast.error("Failed to create local workspace");
     } finally {
-      setIsCreating(false);
+      setIsCreatingLocal(false);
     }
   }, [
     socket,
@@ -133,7 +134,7 @@ export function WorkspaceCreationButtons({
       ""
     ) as Id<"environments">;
 
-    setIsCreating(true);
+    setIsCreatingCloud(true);
 
     try {
       // Create task in Convex without task description (it's just a workspace)
@@ -175,7 +176,7 @@ export function WorkspaceCreationButtons({
       console.error("Error creating cloud workspace:", error);
       toast.error("Failed to create cloud workspace");
     } finally {
-      setIsCreating(false);
+      setIsCreatingCloud(false);
     }
   }, [
     socket,
@@ -196,10 +197,10 @@ export function WorkspaceCreationButtons({
         <TooltipTrigger asChild>
           <button
             onClick={handleCreateLocalWorkspace}
-            disabled={!canCreateLocal || isCreating}
+            disabled={!canCreateLocal || isCreatingLocal}
             className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium transition-colors rounded-lg bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isCreating ? (
+            {isCreatingLocal ? (
               <Loader2 className="w-3.5 h-3.5 animate-spin" />
             ) : (
               <FolderOpen className="w-3.5 h-3.5" />
@@ -220,10 +221,14 @@ export function WorkspaceCreationButtons({
         <TooltipTrigger asChild>
           <button
             onClick={handleCreateCloudWorkspace}
-            disabled={!canCreateCloud || isCreating}
+            disabled={!canCreateCloud || isCreatingCloud}
             className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium transition-colors rounded-lg bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <ServerIcon className="w-3.5 h-3.5" />
+            {isCreatingCloud ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <ServerIcon className="w-3.5 h-3.5" />
+            )}
             <span>Create Cloud Workspace</span>
           </button>
         </TooltipTrigger>

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -147,6 +147,7 @@ export function WorkspaceCreationButtons({
         projectFullName: undefined, // No repo for cloud environment workspaces
         baseBranch: undefined, // No branch for environments
         environmentId,
+        isCloudWorkspace: true,
       });
 
       // Hint the sidebar to auto-expand this task once it appears

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -1,0 +1,240 @@
+import type { SelectOption } from "@/components/ui/searchable-select";
+import { SearchableSelect } from "@/components/ui/searchable-select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useExpandTasks } from "@/contexts/expand-tasks/ExpandTasksContext";
+import { useSocket } from "@/contexts/socket/use-socket";
+import { api } from "@cmux/convex/api";
+import type { CreateLocalWorkspaceResponse } from "@cmux/shared";
+import { useMutation } from "convex/react";
+import { Server as ServerIcon, Plus, FolderOpen } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { useNavigate } from "@tanstack/react-router";
+
+type WorkspaceCreationButtonsProps = {
+  teamSlugOrId: string;
+  projectOptions: SelectOption[];
+};
+
+export function WorkspaceCreationButtons({
+  teamSlugOrId,
+  projectOptions,
+}: WorkspaceCreationButtonsProps) {
+  const { socket } = useSocket();
+  const { addTaskToExpand } = useExpandTasks();
+  const navigate = useNavigate();
+  const [isCreatingLocal, setIsCreatingLocal] = useState(false);
+  const [showLocalPicker, setShowLocalPicker] = useState(false);
+  const [showCloudPicker, setShowCloudPicker] = useState(false);
+  const [selectedRepo, setSelectedRepo] = useState<string[]>([]);
+  const [selectedEnvironment, setSelectedEnvironment] = useState<string[]>([]);
+
+  const reserveLocalWorkspace = useMutation(api.localWorkspaces.reserve);
+
+  const handleCreateLocalWorkspace = useCallback(async () => {
+    if (!socket) {
+      toast.error("Socket not connected");
+      return;
+    }
+
+    if (selectedRepo.length === 0) {
+      toast.error("Please select a repository");
+      return;
+    }
+
+    const projectFullName = selectedRepo[0];
+    const repoUrl = `https://github.com/${projectFullName}.git`;
+
+    setIsCreatingLocal(true);
+
+    try {
+      const reservation = await reserveLocalWorkspace({
+        teamSlugOrId,
+        projectFullName,
+        repoUrl,
+      });
+
+      if (!reservation) {
+        throw new Error("Unable to reserve workspace name");
+      }
+
+      addTaskToExpand(reservation.taskId);
+
+      await new Promise<void>((resolve) => {
+        socket.emit(
+          "create-local-workspace",
+          {
+            teamSlugOrId,
+            projectFullName,
+            repoUrl,
+            taskId: reservation.taskId,
+            taskRunId: reservation.taskRunId,
+            workspaceName: reservation.workspaceName,
+            descriptor: reservation.descriptor,
+          },
+          async (response: CreateLocalWorkspaceResponse) => {
+            if (response.success) {
+              toast.success(
+                `Local workspace "${reservation.workspaceName}" created successfully`
+              );
+              setShowLocalPicker(false);
+              setSelectedRepo([]);
+            } else {
+              toast.error(
+                response.error || "Failed to create local workspace"
+              );
+            }
+            resolve();
+          }
+        );
+      });
+    } catch (error) {
+      console.error("Error creating local workspace:", error);
+      toast.error("Failed to create local workspace");
+    } finally {
+      setIsCreatingLocal(false);
+    }
+  }, [
+    socket,
+    selectedRepo,
+    teamSlugOrId,
+    reserveLocalWorkspace,
+    addTaskToExpand,
+  ]);
+
+  const handleCreateCloudWorkspace = useCallback(() => {
+    if (selectedEnvironment.length === 0) {
+      toast.error("Please select an environment");
+      return;
+    }
+
+    const environmentId = selectedEnvironment[0].replace(/^env:/, "");
+    // Navigate to dashboard with environment preselected
+    navigate({
+      to: "/$teamSlugOrId/dashboard",
+      params: { teamSlugOrId },
+      search: { environmentId },
+    });
+    setShowCloudPicker(false);
+    setSelectedEnvironment([]);
+  }, [selectedEnvironment, navigate, teamSlugOrId]);
+
+  // Filter options for local (repos only) and cloud (environments only)
+  const repoOptions = projectOptions.filter((opt) => {
+    if (typeof opt === "string") return false;
+    return opt.iconKey === "github" && !opt.heading;
+  });
+  const environmentOptions = projectOptions.filter((opt) => {
+    if (typeof opt === "string") return false;
+    return opt.iconKey === "environment" && !opt.heading;
+  });
+
+  return (
+    <div className="flex items-center gap-2 mb-6">
+      {/* Local Workspace Button */}
+      <div className="flex items-center gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setShowLocalPicker(!showLocalPicker)}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-200 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
+            >
+              <FolderOpen className="w-4 h-4" />
+              <span>New Local Workspace</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Create a new local workspace from a repository
+          </TooltipContent>
+        </Tooltip>
+
+        {showLocalPicker && (
+          <div className="flex items-center gap-2">
+            <div className="min-w-[300px]">
+              <SearchableSelect
+                options={repoOptions}
+                value={selectedRepo}
+                onChange={setSelectedRepo}
+                placeholder="Select repository..."
+                singleSelect={true}
+                disabled={isCreatingLocal}
+              />
+            </div>
+            <button
+              onClick={handleCreateLocalWorkspace}
+              disabled={selectedRepo.length === 0 || isCreatingLocal}
+              className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              {isCreatingLocal ? "Creating..." : "Create"}
+            </button>
+            <button
+              onClick={() => {
+                setShowLocalPicker(false);
+                setSelectedRepo([]);
+              }}
+              className="px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Cloud Workspace Button */}
+      {environmentOptions.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setShowCloudPicker(!showCloudPicker)}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-200 bg-white dark:bg-neutral-800 border border-neutral-300 dark:border-neutral-600 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
+              >
+                <ServerIcon className="w-4 h-4" />
+                <span>New Cloud Workspace</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Create a new cloud workspace from an environment
+            </TooltipContent>
+          </Tooltip>
+
+          {showCloudPicker && (
+            <div className="flex items-center gap-2">
+              <div className="min-w-[300px]">
+                <SearchableSelect
+                  options={environmentOptions}
+                  value={selectedEnvironment}
+                  onChange={setSelectedEnvironment}
+                  placeholder="Select environment..."
+                  singleSelect={true}
+                />
+              </div>
+              <button
+                onClick={handleCreateCloudWorkspace}
+                disabled={selectedEnvironment.length === 0}
+                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                Create
+              </button>
+              <button
+                onClick={() => {
+                  setShowCloudPicker(false);
+                  setSelectedEnvironment([]);
+                }}
+                className="px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -134,13 +134,16 @@ export function WorkspaceCreationButtons({
       ""
     ) as Id<"environments">;
 
+    // Extract environment name from the selectedProject (format is "env:id:name")
+    const environmentName = projectFullName.split(":")[2] || "Unknown Environment";
+
     setIsCreatingCloud(true);
 
     try {
-      // Create task in Convex without task description (it's just a workspace)
+      // Create task in Convex with environment name
       const taskId = await createTask({
         teamSlugOrId,
-        text: "Cloud Workspace",
+        text: `Cloud Workspace: ${environmentName}`,
         projectFullName: undefined, // No repo for cloud environment workspaces
         baseBranch: undefined, // No branch for environments
         environmentId,
@@ -190,6 +193,12 @@ export function WorkspaceCreationButtons({
 
   const canCreateLocal = selectedProject.length > 0 && !isEnvSelected;
   const canCreateCloud = selectedProject.length > 0 && isEnvSelected;
+
+  const SHOW_WORKSPACE_BUTTONS = false;
+
+  if (!SHOW_WORKSPACE_BUTTONS) {
+    return null;
+  }
 
   return (
     <div className="flex items-center gap-2 mb-3">

--- a/apps/client/src/components/task-detail-header.tsx
+++ b/apps/client/src/components/task-detail-header.tsx
@@ -297,20 +297,23 @@ export function TaskDetailHeader({
           <h1 className="text-sm font-bold truncate min-w-0" title={taskTitle}>
             {taskTitle || "Loading..."}
           </h1>
-          <Suspense
-            fallback={
-              <div className="flex items-center gap-2 text-[11px] ml-2 shrink-0">
-                <Skeleton className="rounded min-w-[20px] h-[14px] fade-out" />
-                <Skeleton className="rounded min-w-[20px] h-[14px] fade-out" />
-              </div>
-            }
-          >
-            <AdditionsAndDeletions
-              repos={repoDiffTargets}
-              defaultBaseRef={normalizedBaseBranch || undefined}
-              defaultHeadRef={normalizedHeadBranch || undefined}
-            />
-          </Suspense>
+          {/* Hide git diff stats for cloud/local workspaces */}
+          {!task?.isCloudWorkspace && !task?.isLocalWorkspace && (
+            <Suspense
+              fallback={
+                <div className="flex items-center gap-2 text-[11px] ml-2 shrink-0">
+                  <Skeleton className="rounded min-w-[20px] h-[14px] fade-out" />
+                  <Skeleton className="rounded min-w-[20px] h-[14px] fade-out" />
+                </div>
+              }
+            >
+              <AdditionsAndDeletions
+                repos={repoDiffTargets}
+                defaultBaseRef={normalizedBaseBranch || undefined}
+                defaultHeadRef={normalizedHeadBranch || undefined}
+              />
+            </Suspense>
+          )}
         </div>
 
         <div

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -816,7 +816,8 @@ function DashboardComponent() {
             {/* Workspace Creation Buttons */}
             <WorkspaceCreationButtons
               teamSlugOrId={teamSlugOrId}
-              projectOptions={projectOptions}
+              selectedProject={selectedProject}
+              isEnvSelected={isEnvSelected}
             />
 
             <DashboardMainCard

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -6,6 +6,7 @@ import { DashboardInputControls } from "@/components/dashboard/DashboardInputCon
 import { DashboardInputFooter } from "@/components/dashboard/DashboardInputFooter";
 import { DashboardStartTaskButton } from "@/components/dashboard/DashboardStartTaskButton";
 import { TaskList } from "@/components/dashboard/TaskList";
+import { WorkspaceCreationButtons } from "@/components/dashboard/WorkspaceCreationButtons";
 import { FloatingPane } from "@/components/floating-pane";
 import { GitHubIcon } from "@/components/icons/github";
 import { useTheme } from "@/components/theme/use-theme";
@@ -812,6 +813,12 @@ function DashboardComponent() {
         {/* Main content area */}
         <div className="flex-1 flex justify-center px-4 pt-60 pb-4">
           <div className="w-full max-w-4xl min-w-0">
+            {/* Workspace Creation Buttons */}
+            <WorkspaceCreationButtons
+              teamSlugOrId={teamSlugOrId}
+              projectOptions={projectOptions}
+            />
+
             <DashboardMainCard
               editorApiRef={editorApiRef}
               onTaskDescriptionChange={handleTaskDescriptionChange}

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -14,6 +14,8 @@ import {
   StartTaskSchema,
   CreateLocalWorkspaceSchema,
   type CreateLocalWorkspaceResponse,
+  CreateCloudWorkspaceSchema,
+  type CreateCloudWorkspaceResponse,
   type AvailableEditors,
   type FileInfo,
   isLoopbackHostname,
@@ -51,6 +53,8 @@ import { getOctokit } from "./utils/octokit";
 import { checkAllProvidersStatus } from "./utils/providerStatus";
 import { refreshGitHubData } from "./utils/refreshGitHubData";
 import { runWithAuth, runWithAuthToken } from "./utils/requestContext";
+import { getWwwClient } from "./utils/wwwClient";
+import { getWwwOpenApiModule } from "./utils/wwwOpenApiModule";
 import { DockerVSCodeInstance } from "./vscode/DockerVSCodeInstance";
 import {
   getVSCodeServeWebBaseUrl,
@@ -938,6 +942,197 @@ export function setupSocketHandlers(
               serverLogger.warn(
                 "Failed to clean up workspace after error:",
                 cleanupError
+              );
+            }
+          }
+        }
+      }
+    );
+
+    socket.on(
+      "create-cloud-workspace",
+      async (
+        rawData,
+        callback: (response: CreateCloudWorkspaceResponse) => void
+      ) => {
+        const parsed = CreateCloudWorkspaceSchema.safeParse(rawData);
+        if (!parsed.success) {
+          serverLogger.error(
+            "Invalid create-cloud-workspace payload:",
+            parsed.error
+          );
+          callback({
+            success: false,
+            error: "Invalid cloud workspace request",
+          });
+          return;
+        }
+
+        const {
+          teamSlugOrId: requestedTeamSlugOrId,
+          environmentId,
+          taskId: providedTaskId,
+        } = parsed.data;
+        const teamSlugOrId = requestedTeamSlugOrId || safeTeam;
+
+        const convex = getConvex();
+        let taskId: Id<"tasks"> = providedTaskId!;
+        let taskRunId: Id<"taskRuns"> | null = null;
+        let responded = false;
+
+        try {
+          if (!taskId) {
+            throw new Error("taskId is required for cloud workspace creation");
+          }
+
+          // Create a taskRun for the workspace
+          const now = Date.now();
+          const taskRunResult = await convex.mutation(api.taskRuns.create, {
+            teamSlugOrId,
+            taskId,
+            prompt: "Cloud Workspace",
+            agentName: "cloud-workspace",
+            environmentId,
+          });
+          taskRunId = taskRunResult.taskRunId;
+          const taskRunJwt = taskRunResult.jwt;
+
+          serverLogger.info(
+            `[create-cloud-workspace] Created taskRun ${taskRunId} for task ${taskId}`
+          );
+
+          // Update initial VSCode status
+          await convex.mutation(api.taskRuns.updateVSCodeInstance, {
+            teamSlugOrId,
+            id: taskRunId,
+            vscode: {
+              provider: "morph",
+              status: "starting",
+              startedAt: now,
+            },
+          });
+
+          await convex.mutation(api.taskRuns.updateStatusPublic, {
+            teamSlugOrId,
+            id: taskRunId,
+            status: "pending",
+          });
+
+          callback({
+            success: true,
+            pending: true,
+            taskId,
+            taskRunId,
+          });
+          responded = true;
+
+          // Spawn Morph instance via www API
+          const { postApiSandboxesStart } = await getWwwOpenApiModule();
+
+          serverLogger.info(
+            `[create-cloud-workspace] Starting Morph sandbox for environment ${environmentId}`
+          );
+
+          const startRes = await postApiSandboxesStart({
+            client: getWwwClient(),
+            body: {
+              teamSlugOrId,
+              ttlSeconds: 60 * 60,
+              metadata: {
+                instance: `cmux-workspace-${taskRunId}`,
+                agentName: "cloud-workspace",
+              },
+              taskRunId,
+              taskRunJwt,
+              environmentId,
+            },
+          });
+
+          const data = startRes.data;
+          if (!data) {
+            throw new Error("Failed to start sandbox");
+          }
+
+          const sandboxId = data.instanceId;
+          const vscodeBaseUrl = data.vscodeUrl;
+          const workspaceUrl = `${vscodeBaseUrl}?folder=/root/workspace`;
+
+          serverLogger.info(
+            `[create-cloud-workspace] Sandbox started: ${sandboxId}, VSCode: ${workspaceUrl}`
+          );
+
+          // Update taskRun with actual VSCode info
+          await convex.mutation(api.taskRuns.updateVSCodeInstance, {
+            teamSlugOrId,
+            id: taskRunId,
+            vscode: {
+              provider: "morph",
+              status: "running",
+              url: vscodeBaseUrl,
+              workspaceUrl,
+              startedAt: now,
+            },
+          });
+
+          await convex.mutation(api.taskRuns.updateStatusPublic, {
+            teamSlugOrId,
+            id: taskRunId,
+            status: "running",
+          });
+
+          await convex.mutation(api.taskRuns.updateVSCodeStatus, {
+            teamSlugOrId,
+            id: taskRunId,
+            status: "running",
+          });
+
+          // Emit vscode-spawned event to the client
+          rt.emit("vscode-spawned", {
+            instanceId: sandboxId,
+            url: vscodeBaseUrl,
+            workspaceUrl,
+            provider: "morph",
+          });
+
+          serverLogger.info(
+            `Cloud workspace created successfully: ${taskId} for environment ${environmentId}`
+          );
+        } catch (error) {
+          serverLogger.error("Error creating cloud workspace:", error);
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to create cloud workspace";
+
+          if (!responded) {
+            callback({
+              success: false,
+              error: message,
+            });
+          } else if (taskRunId) {
+            try {
+              await convex.mutation(api.taskRuns.fail, {
+                teamSlugOrId,
+                id: taskRunId,
+                errorMessage: message,
+              });
+            } catch (failError) {
+              serverLogger.error(
+                "Failed to mark task run as failed:",
+                failError
+              );
+            }
+            try {
+              await convex.mutation(api.taskRuns.updateVSCodeStatus, {
+                teamSlugOrId,
+                id: taskRunId,
+                status: "stopped",
+                stoppedAt: Date.now(),
+              });
+            } catch (statusError) {
+              serverLogger.warn(
+                "Failed to update VS Code status after failure:",
+                statusError
               );
             }
           }

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -808,11 +808,11 @@ export function setupSocketHandlers(
               }
               const message =
                 error &&
-                typeof error === "object" &&
-                "stderr" in error &&
-                typeof (error as { stderr?: unknown }).stderr === "string"
+                  typeof error === "object" &&
+                  "stderr" in error &&
+                  typeof (error as { stderr?: unknown }).stderr === "string"
                   ? (error as { stderr: string }).stderr.trim() ||
-                    (error instanceof Error ? error.message : "")
+                  (error instanceof Error ? error.message : "")
                   : error instanceof Error
                     ? error.message
                     : "Git clone failed";
@@ -841,7 +841,7 @@ export function setupSocketHandlers(
             }
           } else {
             try {
-            await fs.mkdir(resolvedWorkspacePath, { recursive: false });
+              await fs.mkdir(resolvedWorkspacePath, { recursive: false });
             } catch (error) {
               if (
                 error &&
@@ -976,7 +976,7 @@ export function setupSocketHandlers(
         const teamSlugOrId = requestedTeamSlugOrId || safeTeam;
 
         const convex = getConvex();
-        let taskId: Id<"tasks"> = providedTaskId!;
+        let taskId: Id<"tasks"> | undefined = providedTaskId;
         let taskRunId: Id<"taskRuns"> | null = null;
         let responded = false;
 
@@ -1319,26 +1319,26 @@ export function setupSocketHandlers(
           const updatedRecords: StoredPullRequestInfo[] =
             existingRecords.length > 0
               ? existingRecords.map((record) =>
-                  record.repoFullName === repoFullName
-                    ? {
-                        ...record,
-                        state: "merged",
-                        isDraft: false,
-                      }
-                    : record
-                )
-              : [
-                  {
-                    repoFullName,
-                    url:
-                      run.pullRequestUrl && run.pullRequestUrl !== "pending"
-                        ? run.pullRequestUrl
-                        : undefined,
-                    number: run.pullRequestNumber ?? undefined,
+                record.repoFullName === repoFullName
+                  ? {
+                    ...record,
                     state: "merged",
                     isDraft: false,
-                  },
-                ];
+                  }
+                  : record
+              )
+              : [
+                {
+                  repoFullName,
+                  url:
+                    run.pullRequestUrl && run.pullRequestUrl !== "pending"
+                      ? run.pullRequestUrl
+                      : undefined,
+                  number: run.pullRequestNumber ?? undefined,
+                  state: "merged",
+                  isDraft: false,
+                },
+              ];
 
           await getConvex().mutation(api.taskRuns.updatePullRequestState, {
             teamSlugOrId: safeTeam,
@@ -1787,9 +1787,8 @@ export function setupSocketHandlers(
         serverLogger.error("Error fetching repos:", error);
         callback({
           success: false,
-          error: `Failed to fetch GitHub repos: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          error: `Failed to fetch GitHub repos: ${error instanceof Error ? error.message : String(error)
+            }`,
         });
       }
     });

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -74,6 +74,56 @@ import {
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
+/**
+ * Wait for a cloud VSCode URL to become ready by polling until it responds with 2xx status.
+ * This is necessary because cloud providers (like Morph) return the VSCode URL immediately
+ * when the container starts, but the VSCode server inside hasn't finished initializing yet.
+ */
+async function waitForCloudVSCodeReady(
+  url: string,
+  timeoutMs = 60_000
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  const pollIntervalMs = 500;
+
+  serverLogger.info(
+    `[waitForCloudVSCodeReady] Polling ${url} for readiness (timeout: ${timeoutMs}ms)`
+  );
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, {
+        method: "HEAD",
+        redirect: "manual",
+        signal: AbortSignal.timeout(5000), // 5 second timeout per request
+      });
+
+      if (response.ok) {
+        serverLogger.info(
+          `[waitForCloudVSCodeReady] VSCode is ready at ${url} (status: ${response.status})`
+        );
+        return true;
+      }
+
+      serverLogger.debug?.(
+        `[waitForCloudVSCodeReady] VSCode not ready yet (status: ${response.status}), retrying...`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      serverLogger.debug?.(
+        `[waitForCloudVSCodeReady] Health check failed: ${message}, retrying...`
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  serverLogger.warn(
+    `[waitForCloudVSCodeReady] VSCode at ${url} did not become ready within ${timeoutMs}ms`
+  );
+  return false;
+}
+
 const GitSocketDiffRequestSchema = z.object({
   headRef: z.string(),
   baseRef: z.string().optional(),
@@ -1058,7 +1108,23 @@ export function setupSocketHandlers(
           const workspaceUrl = `${vscodeBaseUrl}?folder=/root/workspace`;
 
           serverLogger.info(
-            `[create-cloud-workspace] Sandbox started: ${sandboxId}, VSCode: ${workspaceUrl}`
+            `[create-cloud-workspace] Sandbox started: ${sandboxId}, VSCode URL: ${workspaceUrl}`
+          );
+
+          // Wait for VSCode to be ready before proceeding
+          serverLogger.info(
+            `[create-cloud-workspace] Waiting for VSCode to be ready at ${workspaceUrl}`
+          );
+          const isReady = await waitForCloudVSCodeReady(workspaceUrl, 60_000);
+
+          if (!isReady) {
+            throw new Error(
+              "VSCode server did not become ready within timeout (60s)"
+            );
+          }
+
+          serverLogger.info(
+            `[create-cloud-workspace] VSCode is ready, updating status to running`
           );
 
           // Update taskRun with actual VSCode info

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -5,6 +5,7 @@ import { stackServerAppJs } from "@/lib/utils/stack";
 import { verifyTeamAccess } from "@/lib/utils/team-verification";
 import { env } from "@/lib/utils/www-env";
 import { api } from "@cmux/convex/api";
+import { Id } from "@cmux/convex/dataModel";
 import { RESERVED_CMUX_PORT_SET } from "@cmux/shared/utils/reserved-cmux-ports";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
@@ -172,6 +173,20 @@ sandboxesRouter.openapi(
           ? allocateScriptIdentifiers()
           : null;
 
+      // Check if this is a cloud workspace by querying the taskRun
+      let isCloudWorkspace = false;
+      if (body.taskRunId) {
+        try {
+          const taskRun = await convex.query(api.taskRuns.get, {
+            teamSlugOrId: body.teamSlugOrId,
+            id: body.taskRunId as Id<"taskRuns">,
+          });
+          isCloudWorkspace = taskRun?.isCloudWorkspace ?? false;
+        } catch (error) {
+          console.warn("[sandboxes.start] Failed to query taskRun for isCloudWorkspace", error);
+        }
+      }
+
       const gitIdentityPromise = githubAccessTokenPromise.then(
         ({ githubAccessToken }) => {
           if (!githubAccessToken) {
@@ -314,7 +329,7 @@ sandboxesRouter.openapi(
             identifiers: scriptIdentifiers ?? undefined,
             convexUrl: env.NEXT_PUBLIC_CONVEX_URL,
             taskRunJwt: body.taskRunJwt || undefined,
-            agentName: body.metadata?.agentName || undefined,
+            isCloudWorkspace,
           });
         })().catch((error) => {
           console.error(

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -314,6 +314,7 @@ sandboxesRouter.openapi(
             identifiers: scriptIdentifiers ?? undefined,
             convexUrl: env.NEXT_PUBLIC_CONVEX_URL,
             taskRunJwt: body.taskRunJwt || undefined,
+            agentName: body.metadata?.agentName || undefined,
           });
         })().catch((error) => {
           console.error(

--- a/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
+++ b/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
@@ -140,7 +140,7 @@ const config = {
   hasDevScript: envBoolean("CMUX_ORCH_HAS_DEV_SCRIPT"),
   convexUrl: requireEnv("CMUX_ORCH_CONVEX_URL"),
   taskRunJwt: requireEnv("CMUX_ORCH_TASK_RUN_JWT"),
-  agentName: process.env.CMUX_ORCH_AGENT_NAME || "",
+  isCloudWorkspace: envBoolean("CMUX_ORCH_IS_CLOUD_WORKSPACE"),
 };
 
 async function ensureTmuxSession(): Promise<void> {
@@ -156,10 +156,8 @@ async function ensureTmuxSession(): Promise<void> {
 
   // Only create the session for cloud workspaces (no agent)
   // For regular tasks with agents, the agent spawner creates the session
-  const isCloudWorkspace = config.agentName === "cloud-workspace";
-
-  if (!isCloudWorkspace) {
-    console.log("[ORCHESTRATOR] Not a cloud workspace (agentName: " + config.agentName + "), waiting for agent to create tmux session...");
+  if (!config.isCloudWorkspace) {
+    console.log("[ORCHESTRATOR] Not a cloud workspace, waiting for agent to create tmux session...");
 
     // Wait for the agent to create the session
     for (let attempt = 0; attempt < 30; attempt++) {

--- a/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
+++ b/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
@@ -140,6 +140,7 @@ const config = {
   hasDevScript: envBoolean("CMUX_ORCH_HAS_DEV_SCRIPT"),
   convexUrl: requireEnv("CMUX_ORCH_CONVEX_URL"),
   taskRunJwt: requireEnv("CMUX_ORCH_TASK_RUN_JWT"),
+  agentName: process.env.CMUX_ORCH_AGENT_NAME || "",
 };
 
 async function ensureTmuxSession(): Promise<void> {
@@ -153,7 +154,29 @@ async function ensureTmuxSession(): Promise<void> {
     return;
   }
 
-  console.log("[ORCHESTRATOR] tmux session 'cmux' not found, creating it...");
+  // Only create the session for cloud workspaces (no agent)
+  // For regular tasks with agents, the agent spawner creates the session
+  const isCloudWorkspace = config.agentName === "cloud-workspace";
+
+  if (!isCloudWorkspace) {
+    console.log("[ORCHESTRATOR] Not a cloud workspace (agentName: " + config.agentName + "), waiting for agent to create tmux session...");
+
+    // Wait for the agent to create the session
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const result = await runCommand("tmux has-session -t cmux 2>/dev/null", {
+        throwOnError: false,
+      });
+      if (result.exitCode === 0) {
+        console.log("[ORCHESTRATOR] tmux session 'cmux' created by agent");
+        return;
+      }
+      await delay(1000);
+    }
+
+    throw new Error("Timed out waiting for agent to create tmux session 'cmux'");
+  }
+
+  console.log("[ORCHESTRATOR] Cloud workspace detected, creating tmux session...");
 
   // Create a new tmux session
   await runCommand(

--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -51,7 +51,7 @@ export async function runMaintenanceAndDevScripts({
   identifiers,
   convexUrl,
   taskRunJwt,
-  agentName,
+  isCloudWorkspace,
 }: {
   instance: MorphInstance;
   maintenanceScript?: string;
@@ -59,7 +59,7 @@ export async function runMaintenanceAndDevScripts({
   identifiers?: ScriptIdentifiers;
   convexUrl?: string;
   taskRunJwt?: string;
-  agentName?: string;
+  isCloudWorkspace?: boolean;
 }): Promise<void> {
   const ids = identifiers ?? allocateScriptIdentifiers();
 
@@ -131,7 +131,7 @@ ${devScript}
     CMUX_ORCH_HAS_DEV_SCRIPT: hasDevScript ? "1" : "0",
     CMUX_ORCH_CONVEX_URL: convexUrl,
     CMUX_ORCH_TASK_RUN_JWT: taskRunJwt,
-    CMUX_ORCH_AGENT_NAME: agentName || "",
+    CMUX_ORCH_IS_CLOUD_WORKSPACE: isCloudWorkspace ? "1" : "0",
   };
 
   const orchestratorEnvString = Object.entries(orchestratorEnvVars)

--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -51,6 +51,7 @@ export async function runMaintenanceAndDevScripts({
   identifiers,
   convexUrl,
   taskRunJwt,
+  agentName,
 }: {
   instance: MorphInstance;
   maintenanceScript?: string;
@@ -58,6 +59,7 @@ export async function runMaintenanceAndDevScripts({
   identifiers?: ScriptIdentifiers;
   convexUrl?: string;
   taskRunJwt?: string;
+  agentName?: string;
 }): Promise<void> {
   const ids = identifiers ?? allocateScriptIdentifiers();
 
@@ -129,6 +131,7 @@ ${devScript}
     CMUX_ORCH_HAS_DEV_SCRIPT: hasDevScript ? "1" : "0",
     CMUX_ORCH_CONVEX_URL: convexUrl,
     CMUX_ORCH_TASK_RUN_JWT: taskRunJwt,
+    CMUX_ORCH_AGENT_NAME: agentName || "",
   };
 
   const orchestratorEnvString = Object.entries(orchestratorEnvVars)

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -96,6 +96,7 @@ const convexSchema = defineSchema({
     isCompleted: v.boolean(),
     isArchived: v.optional(v.boolean()),
     isLocalWorkspace: v.optional(v.boolean()),
+    isCloudWorkspace: v.optional(v.boolean()),
     description: v.optional(v.string()),
     pullRequestTitle: v.optional(v.string()),
     pullRequestDescription: v.optional(v.string()),
@@ -174,6 +175,7 @@ const convexSchema = defineSchema({
       v.literal("failed")
     ),
     isLocalWorkspace: v.optional(v.boolean()),
+    isCloudWorkspace: v.optional(v.boolean()),
     // Optional log retained for backward compatibility; no longer written to.
     log: v.optional(v.string()), // CLI output log (deprecated)
     worktreePath: v.optional(v.string()), // Path to the git worktree for this run

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -244,6 +244,8 @@ export const create = authMutation({
       userId,
       teamId,
       environmentId: args.environmentId,
+      isLocalWorkspace: task.isLocalWorkspace,
+      isCloudWorkspace: task.isCloudWorkspace,
     });
     const generatedBranchName = deriveGeneratedBranchName(args.newBranch);
     if (

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -118,6 +118,7 @@ export const create = authMutation({
       ),
     ),
     environmentId: v.optional(v.id("environments")),
+    isCloudWorkspace: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
@@ -142,6 +143,7 @@ export const create = authMutation({
       userId,
       teamId,
       environmentId: args.environmentId,
+      isCloudWorkspace: args.isCloudWorkspace,
     });
 
     return taskId;

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -73,6 +73,23 @@ export const CreateLocalWorkspaceResponseSchema = z.object({
   error: z.string().optional(),
 });
 
+export const CreateCloudWorkspaceSchema = z.object({
+  teamSlugOrId: z.string(),
+  environmentId: typedZid("environments"),
+  taskId: typedZid("tasks").optional(),
+  taskRunId: typedZid("taskRuns").optional(),
+  theme: z.enum(["dark", "light", "system"]).optional(),
+});
+
+export const CreateCloudWorkspaceResponseSchema = z.object({
+  success: z.boolean(),
+  taskId: typedZid("tasks").optional(),
+  taskRunId: typedZid("taskRuns").optional(),
+  workspaceUrl: z.string().optional(),
+  pending: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
 // Server to Client Events
 export const TerminalCreatedSchema = z.object({
   terminalId: z.string(),
@@ -409,6 +426,10 @@ export type CreateLocalWorkspace = z.infer<typeof CreateLocalWorkspaceSchema>;
 export type CreateLocalWorkspaceResponse = z.infer<
   typeof CreateLocalWorkspaceResponseSchema
 >;
+export type CreateCloudWorkspace = z.infer<typeof CreateCloudWorkspaceSchema>;
+export type CreateCloudWorkspaceResponse = z.infer<
+  typeof CreateCloudWorkspaceResponseSchema
+>;
 export type TerminalCreated = z.infer<typeof TerminalCreatedSchema>;
 export type TerminalOutput = z.infer<typeof TerminalOutputSchema>;
 export type TerminalExit = z.infer<typeof TerminalExitSchema>;
@@ -468,6 +489,10 @@ export interface ClientToServerEvents {
   "create-local-workspace": (
     data: CreateLocalWorkspace,
     callback: (response: CreateLocalWorkspaceResponse) => void
+  ) => void;
+  "create-cloud-workspace": (
+    data: CreateCloudWorkspace,
+    callback: (response: CreateCloudWorkspaceResponse) => void
   ) => void;
   "git-status": (data: GitStatusRequest) => void;
   "git-diff": (


### PR DESCRIPTION
on the main page of cmux where we have the chat message to start tasks, we also want to be able to have buttons above the chat panel that allow users to create a cloud environment workspace from scratch and a local workspace from scratch as well (without starting a task)... basically need to start workspace (user selects repo or environment) and it should just start the workspace itself...