### PR TITLE
Log errors for apps/www catch blocks

### DIFF
--- a/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/_components/private-repo-prompt.tsx
+++ b/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/_components/private-repo-prompt.tsx
@@ -28,6 +28,10 @@ export function PrivateRepoPrompt({
       try {
         sessionStorage.setItem("pr_review_return_url", currentUrl);
       } catch (storageError) {
+        console.error(
+          "[PrivateRepoPrompt] Failed to persist return URL",
+          storageError,
+        );
         console.warn(
           "[PrivateRepoPrompt] Failed to persist return URL",
           storageError,

--- a/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/_components/team-onboarding-prompt.tsx
+++ b/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/_components/team-onboarding-prompt.tsx
@@ -32,9 +32,13 @@ export function TeamOnboardingPrompt({
       });
 
       if (!response.ok) {
-        const data = await response
-          .json()
-          .catch(() => ({ message: "Unknown error" }));
+        const data = await response.json().catch((jsonError) => {
+          console.error(
+            "[TeamOnboardingPrompt] Failed to parse error response",
+            jsonError,
+          );
+          return { message: "Unknown error" };
+        });
         setError(data.message ?? "Failed to create team");
         setIsCreating(false);
         return;

--- a/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/compare/[comparison]/[...segments]/page.tsx
+++ b/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/compare/[comparison]/[...segments]/page.tsx
@@ -108,6 +108,10 @@ export async function generateMetadata({
       description,
     };
   } catch (error) {
+    console.error(
+      "[ComparisonSegmentsPage] Failed to fetch comparison metadata",
+      error,
+    );
     if (isGithubApiError(error) && error.status === 404) {
       return {
         title: `${githubOwner}/${repo} · ${refs.base}…${refs.head}`,
@@ -223,6 +227,10 @@ function ComparisonHeader({
       />
     );
   } catch (error) {
+    console.error(
+      "[ComparisonSegmentsHeader] Failed to render header",
+      error,
+    );
     if (isGithubApiError(error)) {
       const message =
         error.status === 404
@@ -396,6 +404,10 @@ function ComparisonDiffSection({
       />
     );
   } catch (error) {
+    console.error(
+      "[ComparisonSegmentsDiffSection] Failed to render diff section",
+      error,
+    );
     if (isGithubApiError(error)) {
       const message =
         error.status === 404

--- a/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/compare/[comparison]/page.tsx
+++ b/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/compare/[comparison]/page.tsx
@@ -101,6 +101,10 @@ export async function generateMetadata({
       description,
     };
   } catch (error) {
+    console.error(
+      "[ComparisonPage] Failed to fetch comparison metadata",
+      error,
+    );
     if (isGithubApiError(error) && error.status === 404) {
       return {
         title: `${githubOwner}/${repo} · ${refs.base}…${refs.head}`,
@@ -210,6 +214,10 @@ function ComparisonHeader({
       />
     );
   } catch (error) {
+    console.error(
+      "[ComparisonHeader] Failed to render comparison header",
+      error,
+    );
     if (isGithubApiError(error)) {
       const message =
         error.status === 404
@@ -374,6 +382,10 @@ function ComparisonDiffSection({
       />
     );
   } catch (error) {
+    console.error(
+      "[ComparisonDiffSection] Failed to render diff section",
+      error,
+    );
     if (isGithubApiError(error)) {
       const message =
         error.status === 404

--- a/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
+++ b/apps/www/app/(home)/(pr-review)/[teamSlugOrId]/[repo]/pull/[pullNumber]/page.tsx
@@ -127,6 +127,10 @@ export async function generateMetadata({
       description: pullRequest.body?.slice(0, 160),
     };
   } catch (error) {
+    console.error(
+      "[PullRequestPage] Failed to fetch pull request metadata",
+      error,
+    );
     if (isGithubApiError(error) && error.status === 404) {
       return {
         title: `${githubOwner}/${repo} · #${pullNumber}`,
@@ -199,6 +203,11 @@ export default async function PullRequestPage({ params }: PageProps) {
       authToken: githubAccessToken,
     });
   } catch (error) {
+    console.error(
+      "[PullRequestPage] Failed to fetch pull request",
+      { githubOwner, repo, pullNumber },
+      error,
+    );
     if (isGithubApiError(error) && error.status === 404) {
       // For private repos, check if app is installed
       if (!repoIsPublic && selectedTeam) {
@@ -371,6 +380,10 @@ function scheduleCodeReviewStart({
             }
           }
         } catch (error) {
+          console.error(
+            "[code-review] Failed to get user auth info; skipping callback",
+            error,
+          );
           console.warn(
             "[code-review] Failed to get user auth info; skipping callback",
             error
@@ -462,6 +475,16 @@ function scheduleCodeReviewStart({
           await Promise.all(followUpTasks);
         }
       } catch (error) {
+        console.error(
+          "[code-review] Error while scheduling automated review",
+          {
+            teamSlugOrId,
+            githubOwner,
+            repo,
+            pullNumber,
+          },
+          error,
+        );
         const context = {
           teamSlugOrId,
           githubOwner,
@@ -504,6 +527,10 @@ function PullRequestHeader({
       />
     );
   } catch (error) {
+    console.error(
+      "[PullRequestHeader] Failed to render pull request header",
+      error,
+    );
     if (isGithubApiError(error)) {
       const message =
         error.status === 404
@@ -733,6 +760,10 @@ function PullRequestDiffSection({
       />
     );
   } catch (error) {
+    console.error(
+      "[PullRequestDiffSection] Failed to render diff section",
+      error,
+    );
     if (isGithubApiError(error)) {
       const message =
         error.status === 404

--- a/apps/www/app/(home)/handler/after-sign-in/OpenCmuxClient.tsx
+++ b/apps/www/app/(home)/handler/after-sign-in/OpenCmuxClient.tsx
@@ -9,8 +9,8 @@ export function OpenCmuxClient({ href }: { href: string }) {
   useEffect(() => {
     try {
       window.location.href = href;
-    } catch {
-      console.error("Failed to open cmux", href);
+    } catch (error) {
+      console.error("Failed to open cmux", href, error);
     }
   }, [href]);
 

--- a/apps/www/app/(home)/handler/after-sign-in/page.tsx
+++ b/apps/www/app/(home)/handler/after-sign-in/page.tsx
@@ -63,7 +63,8 @@ function buildCmuxHref(baseHref: string | null, stackRefreshToken: string | unde
     url.searchParams.set("stack_refresh", stackRefreshToken);
     url.searchParams.set("stack_access", stackAccessToken);
     return url.toString();
-  } catch {
+  } catch (error) {
+    console.error("[After Sign In] Failed to build cmux href", error);
     return `${CMUX_SCHEME}auth-callback?stack_refresh=${encodeURIComponent(stackRefreshToken)}&stack_access=${encodeURIComponent(stackAccessToken)}`;
   }
 }

--- a/apps/www/app/(pr-review)/github-install-complete/page.tsx
+++ b/apps/www/app/(pr-review)/github-install-complete/page.tsx
@@ -16,6 +16,10 @@ function GitHubInstallCompleteContent() {
     try {
       storedUrl = sessionStorage.getItem("pr_review_return_url");
     } catch (error) {
+      console.error(
+        "[GitHubInstallComplete] Failed to read return URL from storage",
+        error,
+      );
       console.warn(
         "[GitHubInstallComplete] Failed to read return URL from storage",
         error,
@@ -40,6 +44,10 @@ function GitHubInstallCompleteContent() {
         try {
           sessionStorage.removeItem("pr_review_return_url");
         } catch (error) {
+          console.error(
+            "[GitHubInstallComplete] Failed to clear return URL",
+            error,
+          );
           console.warn(
             "[GitHubInstallComplete] Failed to clear return URL",
             error,

--- a/apps/www/app/api/pr-review/simple/route.ts
+++ b/apps/www/app/api/pr-review/simple/route.ts
@@ -63,6 +63,10 @@ export async function GET(request: NextRequest) {
         githubToken = tokenResult.accessToken ?? null;
       }
     } catch (error) {
+      console.error(
+        "[simple-review][api] Failed to resolve GitHub account",
+        { error },
+      );
       console.warn("[simple-review][api] Failed to resolve GitHub account", {
         error,
       });
@@ -101,7 +105,11 @@ export async function GET(request: NextRequest) {
             controller.enqueue(
               encoder.encode(`data: ${JSON.stringify(payload)}\n\n`)
             );
-          } catch {
+          } catch (enqueueError) {
+            console.error(
+              "[simple-review][api] Failed to enqueue stream payload",
+              enqueueError,
+            );
             // Mark as closed if enqueue fails
             isClosed = true;
           }
@@ -190,11 +198,21 @@ export async function GET(request: NextRequest) {
           const isAbortError = message.includes("Stream aborted") || message.includes("aborted");
 
           if (isAuthError) {
+            console.error("[simple-review][api] Auth failed during stream", {
+              prIdentifier,
+              message,
+              error,
+            });
             console.info("[simple-review][api] Auth failed, fallback should handle", {
               prIdentifier,
               message,
             });
           } else if (isAbortError) {
+            console.error("[simple-review][api] Stream aborted", {
+              prIdentifier,
+              message,
+              error,
+            });
             // Client disconnected - this is expected, don't log as error
             console.info("[simple-review][api] Stream aborted by client", {
               prIdentifier,

--- a/apps/www/app/direct-download-macos/page.tsx
+++ b/apps/www/app/direct-download-macos/page.tsx
@@ -55,7 +55,8 @@ function DirectDownloadContent() {
         if (isMounted) {
           setReleaseInfo(info);
         }
-      } catch {
+      } catch (error) {
+        console.error("[DirectDownloadPage] Failed to load release info", error);
         if (isMounted) {
           setReleaseInfo(FALLBACK_RELEASE_INFO);
         }

--- a/apps/www/app/direct-download-macos/redirector.tsx
+++ b/apps/www/app/direct-download-macos/redirector.tsx
@@ -72,7 +72,11 @@ export function DirectDownloadRedirector({
         }
 
         followUrl(null, "async-detection-null");
-      } catch (_error) {
+      } catch (error) {
+        console.error(
+          "[DirectDownloadRedirector] Failed to detect architecture",
+          error,
+        );
         followUrl(null, "async-detection-error");
       }
     };

--- a/apps/www/components/pr/heatmap.ts
+++ b/apps/www/components/pr/heatmap.ts
@@ -824,7 +824,9 @@ function unwrapCodexPayload(value: unknown): unknown {
 
     try {
       return unwrapCodexPayload(JSON.parse(trimmed));
-    } catch {
+    } catch (error) {
+      console.error("[apps/www/components/pr/heatmap.ts] Caught error", error);
+
       return null;
     }
   }

--- a/apps/www/components/pr/pull-request-diff-viewer.tsx
+++ b/apps/www/components/pr/pull-request-diff-viewer.tsx
@@ -810,6 +810,8 @@ export function PullRequestDiffViewer({
                     console.info("[simple-review][frontend][event]", payload);
                 }
               } catch (error) {
+                console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
                 console.warn(
                   "[simple-review][frontend] Failed to parse SSE data",
                   { data, error }
@@ -1094,7 +1096,9 @@ export function PullRequestDiffViewer({
           window.focus();
           notification.close();
         };
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
         // Ignore notification errors (for example, blocked constructors)
       } finally {
         setShouldNotifyOnCompletion(false);
@@ -1134,7 +1138,9 @@ export function PullRequestDiffViewer({
       if (permission === "granted") {
         setShouldNotifyOnCompletion(true);
       }
-    } catch {
+    } catch (error) {
+      console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
       // Ignore errors while requesting permission
     } finally {
       setIsRequestingNotification(false);
@@ -1209,6 +1215,8 @@ export function PullRequestDiffViewer({
           diff: diff ?? null,
         };
       } catch (error) {
+        console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
         const message =
           error instanceof Error
             ? error.message
@@ -1635,7 +1643,9 @@ export function PullRequestDiffViewer({
 
       try {
         handleElement.focus({ preventScroll: true });
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
         handleElement.focus();
       }
 
@@ -1656,7 +1666,9 @@ export function PullRequestDiffViewer({
         if (handleElement.hasPointerCapture?.(pointerId)) {
           try {
             handleElement.releasePointerCapture(pointerId);
-          } catch {
+          } catch (error) {
+            console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
             // Ignore release failures.
           }
         }
@@ -1690,7 +1702,9 @@ export function PullRequestDiffViewer({
 
       try {
         handleElement.setPointerCapture(pointerId);
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
         // Ignore pointer capture failures (e.g., Safari).
       }
     },
@@ -2745,7 +2759,9 @@ function FileDiffCard({
           refractor: refractorAdapter,
           ...(enhancers ? { enhancers } : {}),
         });
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
         // Ignore highlight errors; fall back to default tokenization.
       }
     }
@@ -3165,7 +3181,9 @@ function _extractAutomatedReviewText(value: unknown): string | null {
 
     try {
       return JSON.stringify(value, null, 2);
-    } catch {
+    } catch (error) {
+      console.error("[apps/www/components/pr/pull-request-diff-viewer.tsx] Caught error", error);
+
       return String(value);
     }
   }

--- a/apps/www/lib/github/check-repo-visibility.ts
+++ b/apps/www/lib/github/check-repo-visibility.ts
@@ -45,6 +45,11 @@ export async function checkRepoVisibility(
 
     return visibility;
   } catch (error: unknown) {
+    console.error("[checkRepoVisibility] Failed to fetch repo visibility", {
+      owner,
+      repo,
+      error,
+    });
     // If we get a 404, the repo either doesn't exist or is private
     if (
       error &&

--- a/apps/www/lib/github/fetch-pull-request.ts
+++ b/apps/www/lib/github/fetch-pull-request.ts
@@ -118,6 +118,13 @@ export async function fetchPullRequest(
         });
         return response.data;
       } catch (error) {
+        console.error("[fetchPullRequest] Attempt failed", {
+          owner,
+          repo,
+          pullNumber,
+          usedAuthToken: Boolean(candidate),
+          error,
+        });
         lastError = error;
         if (shouldRetryWithAlternateAuth(error)) {
           continue;
@@ -151,6 +158,12 @@ export async function fetchPullRequest(
           });
           return response.data;
         } catch (appError) {
+          console.error("[fetchPullRequest] GitHub App token attempt failed", {
+            owner,
+            repo,
+            pullNumber,
+            error: appError,
+          });
           throw toGithubApiError(appError);
         }
       }
@@ -164,6 +177,12 @@ export async function fetchPullRequest(
       status: 500,
     });
   } catch (error) {
+    console.error("[fetchPullRequest] Failed to retrieve pull request", {
+      owner,
+      repo,
+      pullNumber,
+      error,
+    });
     throw toGithubApiError(error);
   }
 }
@@ -189,6 +208,13 @@ export async function fetchPullRequestFiles(
         });
         return files;
       } catch (error) {
+        console.error("[fetchPullRequestFiles] Attempt failed", {
+          owner,
+          repo,
+          pullNumber,
+          usedAuthToken: Boolean(candidate),
+          error,
+        });
         lastError = error;
         if (shouldRetryWithAlternateAuth(error)) {
           continue;
@@ -223,6 +249,15 @@ export async function fetchPullRequestFiles(
           });
           return files;
         } catch (appError) {
+          console.error(
+            "[fetchPullRequestFiles] GitHub App token attempt failed",
+            {
+              owner,
+              repo,
+              pullNumber,
+              error: appError,
+            }
+          );
           throw toGithubApiError(appError);
         }
       }
@@ -236,6 +271,12 @@ export async function fetchPullRequestFiles(
       status: 500,
     });
   } catch (error) {
+    console.error("[fetchPullRequestFiles] Failed to retrieve pull request files", {
+      owner,
+      repo,
+      pullNumber,
+      error,
+    });
     throw toGithubApiError(error);
   }
 }
@@ -282,6 +323,13 @@ export async function fetchComparison(
     });
     return response.data;
   } catch (error) {
+    console.error("[fetchComparison] Failed to retrieve comparison", {
+      owner,
+      repo,
+      baseRef,
+      headRef,
+      error,
+    });
     throw toGithubApiError(error);
   }
 }

--- a/apps/www/lib/routes/auth.anonymous.route.ts
+++ b/apps/www/lib/routes/auth.anonymous.route.ts
@@ -65,7 +65,9 @@ authAnonymousRouter.openapi(
         let errorData: { code?: string; message?: string } = {};
         try {
           errorData = JSON.parse(responseText);
-        } catch {
+        } catch (error) {
+          console.error("[apps/www/lib/routes/auth.anonymous.route.ts] Caught error", error);
+
           errorData = { message: responseText };
         }
 

--- a/apps/www/lib/routes/github.prs.code.route.ts
+++ b/apps/www/lib/routes/github.prs.code.route.ts
@@ -241,6 +241,8 @@ githubPrsCodeRouter.openapi(
             if (size !== undefined) entry.size = size;
           }
         } catch (_e) {
+          console.error("[apps/www/lib/routes/github.prs.code.route.ts] Caught error", _e);
+
           entry.truncated = true;
         }
       }
@@ -285,6 +287,8 @@ githubPrsCodeRouter.openapi(
             if (size !== undefined) entry.sizeBase = size;
           }
         } catch (_e) {
+          console.error("[apps/www/lib/routes/github.prs.code.route.ts] Caught error", _e);
+
           entry.truncatedBase = true;
         }
       }

--- a/apps/www/lib/routes/github.prs.file-contents-batch.route.ts
+++ b/apps/www/lib/routes/github.prs.file-contents-batch.route.ts
@@ -108,7 +108,9 @@ githubPrsFileContentsBatchRouter.openapi(
             map.set(e.path, { sha: e.sha, size: e.size });
           }
         }
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/lib/routes/github.prs.file-contents-batch.route.ts] Caught error", error);
+
         // ignore
       }
     }
@@ -127,7 +129,9 @@ githubPrsFileContentsBatchRouter.openapi(
           return { encoding: "base64", content: obj.content, size: obj.size };
         }
         return null;
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/lib/routes/github.prs.file-contents-batch.route.ts] Caught error", error);
+
         return null;
       }
     }

--- a/apps/www/lib/routes/github.prs.file-contents.route.ts
+++ b/apps/www/lib/routes/github.prs.file-contents.route.ts
@@ -100,7 +100,9 @@ githubPrsFileContentsRouter.openapi(
           return { truncated: true, size } as const;
         }
         return { truncated: true, size } as const;
-      } catch {
+      } catch (error) {
+        console.error("[apps/www/lib/routes/github.prs.file-contents.route.ts] Caught error", error);
+
         return { truncated: true } as const;
       }
     };

--- a/apps/www/lib/routes/github.prs.open.route.ts
+++ b/apps/www/lib/routes/github.prs.open.route.ts
@@ -331,6 +331,8 @@ githubPrsOpenRouter.openapi(
 
           return toPullRequestActionResult(repoFullName, detail);
         } catch (error) {
+          console.error("[apps/www/lib/routes/github.prs.open.route.ts] Caught error", error);
+
           const message =
             error instanceof Error ? error.message : String(error);
           return {
@@ -366,6 +368,8 @@ githubPrsOpenRouter.openapi(
         error: errors.length > 0 ? errors.join("; ") : undefined,
       });
     } catch (error) {
+      console.error("[apps/www/lib/routes/github.prs.open.route.ts] Caught error", error);
+
       const message = error instanceof Error ? error.message : String(error);
       return c.json(
         {
@@ -619,6 +623,8 @@ githubPrsOpenRouter.openapi(
               mergedDetail.merged_at ?? new Date().toISOString(),
           });
         } catch (error) {
+          console.error("[apps/www/lib/routes/github.prs.open.route.ts] Caught error", error);
+
           const message =
             error instanceof Error ? error.message : String(error);
           return {
@@ -654,6 +660,8 @@ githubPrsOpenRouter.openapi(
         error: errors.length > 0 ? errors.join("; ") : undefined,
       });
     } catch (error) {
+      console.error("[apps/www/lib/routes/github.prs.open.route.ts] Caught error", error);
+
       const message = error instanceof Error ? error.message : String(error);
       return c.json(
         {
@@ -1050,6 +1058,8 @@ async function loadPullRequestDetail({
         number,
       });
     } catch (error) {
+      console.error("[apps/www/lib/routes/github.prs.open.route.ts] Caught error", error);
+
       console.warn(
         `[github-open-pr] Failed to fetch PR detail for ${repoFullName}#${number}: ${String(error)}`,
       );
@@ -1074,6 +1084,8 @@ async function loadPullRequestDetail({
       number: pr.number,
     });
   } catch (error) {
+    console.error("[apps/www/lib/routes/github.prs.open.route.ts] Caught error", error);
+
     console.warn(
       `[github-open-pr] Failed to locate PR by branch for ${repoFullName}: ${String(error)}`,
     );

--- a/apps/www/lib/routes/github.repos.route.test.ts
+++ b/apps/www/lib/routes/github.repos.route.test.ts
@@ -59,6 +59,8 @@ describe("githubReposRouter via SDK", () => {
       console.log("conns", conns);
       installationId = conns.find((c) => c.isActive !== false)?.installationId;
     } catch (error) {
+      console.error("[apps/www/lib/routes/github.repos.route.test.ts] Caught error", error);
+
       // If convex is unreachable in this test env, skip the test
       console.log("Skipping test - Convex unreachable:", error);
       return;

--- a/apps/www/lib/routes/iframe-preflight.route.ts
+++ b/apps/www/lib/routes/iframe-preflight.route.ts
@@ -114,6 +114,8 @@ async function attemptResumeIfNeeded(
       instanceId: instanceInfo.instanceId,
     });
   } catch (error) {
+    console.error("[apps/www/lib/routes/iframe-preflight.route.ts] Caught error", error);
+
     if (isNotFoundError(error)) {
       await sendPhase("instance_not_found", {
         instanceId: instanceInfo.instanceId,
@@ -140,6 +142,8 @@ async function attemptResumeIfNeeded(
         return "forbidden";
       }
     } catch (error) {
+      console.error("[apps/www/lib/routes/iframe-preflight.route.ts] Caught error", error);
+
       await sendPhase("resume_failed", {
         instanceId: instanceInfo.instanceId,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -170,6 +174,8 @@ async function attemptResumeIfNeeded(
       });
       return "resumed";
     } catch (error) {
+      console.error("[apps/www/lib/routes/iframe-preflight.route.ts] Caught error", error);
+
       if (attempt >= MAX_RESUME_ATTEMPTS) {
         await sendPhase("resume_failed", {
           instanceId: instanceInfo.instanceId,
@@ -241,6 +247,8 @@ async function performPreflight(target: URL): Promise<IframePreflightResult> {
       error: `Request failed with status ${headResponse.status}.`,
     };
   } catch (error) {
+    console.error("[apps/www/lib/routes/iframe-preflight.route.ts] Caught error", error);
+
     return {
       ok: false,
       status: null,
@@ -501,6 +509,8 @@ iframePreflightRouter.openapi(
 
         await sendResult(preflightResult);
       } catch (error) {
+        console.error("[apps/www/lib/routes/iframe-preflight.route.ts] Caught error", error);
+
         const message =
           error instanceof Error
             ? error.message

--- a/apps/www/lib/routes/morph.route.test.ts
+++ b/apps/www/lib/routes/morph.route.test.ts
@@ -21,6 +21,8 @@ describe(
         });
         await inst.stop();
       } catch (e) {
+        console.error("[apps/www/lib/routes/morph.route.test.ts] Caught error", e);
+
         console.warn("Morph cleanup failed:", e);
       }
     });

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -139,7 +139,9 @@ sandboxesRouter.openapi(
         repoUrl: body.repoUrl,
         branch: body.branch,
       });
-    } catch {
+    } catch (error) {
+      console.error("[apps/www/lib/routes/sandboxes.route.ts] Caught error", error);
+
       /* noop */
     }
 
@@ -608,7 +610,9 @@ sandboxesRouter.openapi(
             },
           });
           environmentPorts = envDoc?.exposedPorts ?? undefined;
-        } catch {
+        } catch (error) {
+          console.error("[apps/www/lib/routes/sandboxes.route.ts] Caught error", error);
+
           // ignore lookup errors; fall back to devcontainer ports
         }
       }

--- a/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
+++ b/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
@@ -32,7 +32,9 @@ async function fileExists(path: string): Promise<boolean> {
   try {
     await access(path, fsConstants.F_OK);
     return true;
-  } catch {
+  } catch (error) {
+    console.error("[apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts] Caught error", error);
+
     return false;
   }
 }
@@ -41,6 +43,8 @@ async function removeFile(path: string): Promise<void> {
   try {
     await unlink(path);
   } catch (error) {
+    console.error("[apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts] Caught error", error);
+
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }

--- a/apps/www/lib/routes/sandboxes/hydrateRepoScript.ts
+++ b/apps/www/lib/routes/sandboxes/hydrateRepoScript.ts
@@ -46,6 +46,8 @@ function exec(command: string, options?: { cwd?: string; throwOnError?: boolean 
     });
     return { stdout, stderr: "", exitCode: 0 };
   } catch (error) {
+    console.error("[apps/www/lib/routes/sandboxes/hydrateRepoScript.ts] Caught error", error);
+
     const errorObj = error as { status?: number; stderr?: Buffer; stdout?: Buffer };
     const exitCode = errorObj.status || 1;
     const stderr = errorObj.stderr?.toString() || "";
@@ -236,6 +238,8 @@ function hydrateSubdirectories(workspacePath: string) {
       }
     }
   } catch (error) {
+    console.error("[apps/www/lib/routes/sandboxes/hydrateRepoScript.ts] Caught error", error);
+
     log(`Error checking subdirectories: ${error}`, "debug");
   }
 }

--- a/apps/www/lib/routes/teams.route.ts
+++ b/apps/www/lib/routes/teams.route.ts
@@ -167,6 +167,8 @@ teamsRouter.openapi(
     try {
       validateSlug(normalizedSlug);
     } catch (error) {
+      console.error("[apps/www/lib/routes/teams.route.ts] Caught error", error);
+
       const message = error instanceof Error ? error.message : "Invalid slug";
       return c.json({ code: 400, message }, 400);
     }
@@ -232,6 +234,8 @@ teamsRouter.openapi(
           slugSet = true;
           break;
         } catch (error) {
+          console.error("[apps/www/lib/routes/teams.route.ts] Caught error", error);
+
           lastError = error;
           if (error instanceof Error && error.message.includes("Slug is already taken")) {
             return c.json({ code: 409, message: error.message }, 409);

--- a/apps/www/lib/services/code-review/run-simple-anthropic-review.ts
+++ b/apps/www/lib/services/code-review/run-simple-anthropic-review.ts
@@ -146,7 +146,11 @@ function parseRepoSlug(prIdentifier: string): RepoSlug | null {
       }
       return null;
     }
-  } catch {
+  } catch (error) {
+    console.error("[simple-review] Failed to parse repo slug URL", {
+      prIdentifier,
+      error,
+    });
     // Not a URL, fall through to pattern checks.
   }
 
@@ -247,6 +251,10 @@ async function collectDiffsWithFallback({
         });
       }
     } catch (error) {
+      console.error(
+        "[simple-review] GitHub App check/fetch failed, will try gh CLI",
+        { owner: slug.owner, repo: slug.repo, error },
+      );
       console.warn(
         "[simple-review] GitHub App check/fetch failed, will try gh CLI",
         { owner: slug.owner, repo: slug.repo, error: error instanceof Error ? error.message : String(error) }
@@ -271,6 +279,10 @@ async function collectDiffsWithFallback({
       githubToken: normalizedToken ?? undefined,
     });
   } catch (error) {
+    console.error("[simple-review] Failed to collect PR diffs with provided token", {
+      prIdentifier,
+      error,
+    });
     throw error;
   }
 }
@@ -446,6 +458,13 @@ export async function runSimpleAnthropicReviewStream(
 
           // Don't log abort errors - client disconnected
           const isAbortError = message.includes("Stream aborted") || message.includes("aborted");
+          console.error("[simple-review] File stream encountered error", {
+            prIdentifier,
+            filePath: file.filePath,
+            message,
+            aborted: isAbortError,
+            error,
+          });
           if (!isAbortError) {
             console.error("[simple-review] File stream failed", {
               prIdentifier,

--- a/apps/www/lib/services/code-review/start-code-review.ts
+++ b/apps/www/lib/services/code-review/start-code-review.ts
@@ -143,6 +143,10 @@ export async function startCodeReviewJob({
         });
       }
     } catch (error) {
+      console.error("[code-review] Failed to verify team access", {
+        teamSlugOrId: payload.teamSlugOrId,
+        error,
+      });
       console.warn("[code-review] Failed to verify team access", {
         teamSlugOrId: payload.teamSlugOrId,
         error,

--- a/apps/www/lib/utils/auth.ts
+++ b/apps/www/lib/utils/auth.ts
@@ -9,7 +9,8 @@ export async function getAccessTokenFromRequest(
       const { accessToken } = await user.getAuthJson();
       if (accessToken) return accessToken;
     }
-  } catch (_e) {
+  } catch (error) {
+    console.error("[auth] Failed to resolve access token from request", error);
     return null;
   }
 

--- a/apps/www/lib/utils/github-app-token.ts
+++ b/apps/www/lib/utils/github-app-token.ts
@@ -153,6 +153,10 @@ export async function getInstallationForRepo(
 
     return data.id;
   } catch (error) {
+    console.error(
+      `[GitHub App] Failed to resolve installation for ${repository}`,
+      error,
+    );
     // 404 is expected when the app is not installed - not an error
     if (error && typeof error === 'object' && 'status' in error && error.status === 404) {
       console.log(`[GitHub App] No installation found for ${repository} (app not installed or no access)`);

--- a/apps/www/lib/utils/githubUserInfo.ts
+++ b/apps/www/lib/utils/githubUserInfo.ts
@@ -47,7 +47,11 @@ export async function fetchGithubUserInfoForRequest(
         canReadEmails = true;
       }
     }
-  } catch {
+  } catch (error) {
+    console.error(
+      "[githubUserInfo] Failed to fetch user emails",
+      error,
+    );
     // Ignore; token may lack scope
   }
 

--- a/apps/www/lib/utils/mac-architecture.ts
+++ b/apps/www/lib/utils/mac-architecture.ts
@@ -148,7 +148,11 @@ const detectArchitectureViaWebGL = async (): Promise<MacArchitecture | null> => 
       const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
 
       return typeof renderer === "string" ? renderer : null;
-    } catch {
+    } catch (error) {
+      console.error(
+        "[mac-architecture] Failed to read WebGL renderer",
+        error,
+      );
       return null;
     }
   };
@@ -303,7 +307,13 @@ export const detectClientMacArchitecture = async (): Promise<MacArchitecture | n
 
   const details = await uaData
     .getHighEntropyValues(["architecture"])
-    .catch(() => null);
+    .catch((error) => {
+      console.error(
+        "[mac-architecture] Failed to get high entropy user agent data",
+        error,
+      );
+      return null;
+    });
 
   if (details && typeof details === "object") {
     const maybeValue = (details as Record<string, unknown>).architecture;

--- a/apps/www/lib/utils/team-verification.ts
+++ b/apps/www/lib/utils/team-verification.ts
@@ -46,6 +46,10 @@ export async function verifyTeamAccess({
 
     return team;
   } catch (error) {
+    console.error("[team-verification] Failed to verify team access", {
+      teamSlugOrId,
+      error,
+    });
     if (error instanceof HTTPException) {
       throw error;
     }

--- a/apps/www/scripts/github-user-info.ts
+++ b/apps/www/scripts/github-user-info.ts
@@ -70,6 +70,8 @@ async function main() {
       canReadEmails = true;
     }
   } catch (_err) {
+    console.error("[apps/www/scripts/github-user-info.ts] Caught error", _err);
+
     // Token might not have user:email; ignore
   }
 

--- a/apps/www/scripts/pr-review-heatmap.ts
+++ b/apps/www/scripts/pr-review-heatmap.ts
@@ -256,6 +256,8 @@ async function mapWithConcurrency<T, R>(
         const value = await worker(items[currentIndex] as T, currentIndex);
         results[currentIndex] = { status: "fulfilled", value };
       } catch (error) {
+        console.error("[apps/www/scripts/pr-review-heatmap.ts] Caught error", error);
+
         results[currentIndex] = { status: "rejected", reason: error };
       }
     }
@@ -733,6 +735,8 @@ function parseGithubPrUrl(value: string): ParsedPrIdentifier {
   try {
     url = new URL(value);
   } catch (_error) {
+    console.error("[apps/www/scripts/pr-review-heatmap.ts] Caught error", _error);
+
     throw new Error(`Invalid PR URL: ${value}`);
   }
   const parts = url.pathname.split("/").filter(Boolean);
@@ -751,7 +755,9 @@ function parseGithubPrUrl(value: string): ParsedPrIdentifier {
 function tryParseGithubPrUrl(value: string): ParsedPrIdentifier | null {
   try {
     return parseGithubPrUrl(value);
-  } catch {
+  } catch (error) {
+    console.error("[apps/www/scripts/pr-review-heatmap.ts] Caught error", error);
+
     return null;
   }
 }
@@ -1114,6 +1120,8 @@ async function main(): Promise<void> {
           githubApiBaseUrl: options.githubApiBaseUrl ?? undefined,
         });
       } catch (error) {
+        console.error("[apps/www/scripts/pr-review-heatmap.ts] Caught error", error);
+
         if (!allowGhCliFallback) {
           throw error;
         }

--- a/apps/www/scripts/pr-review.ts
+++ b/apps/www/scripts/pr-review.ts
@@ -122,6 +122,8 @@ async function resolveCommitRef(
     }
     return commitRef;
   } catch (error) {
+    console.error("[apps/www/scripts/pr-review.ts] Caught error", error);
+
     const baseMessage = `Failed to fetch head commit for ${prIdentifier} via gh`;
     if (error instanceof Error) {
       throw new Error(`${baseMessage}: ${error.message}`, { cause: error });

--- a/apps/www/scripts/pr-review/evals/sync-dataset.ts
+++ b/apps/www/scripts/pr-review/evals/sync-dataset.ts
@@ -21,7 +21,9 @@ async function syncDataset(): Promise<void> {
         process.env.GITHUB_TOKEN = token;
         console.log("✓ Using GitHub token from gh CLI\n");
       }
-    } catch {
+    } catch (error) {
+      console.error("[apps/www/scripts/pr-review/evals/sync-dataset.ts] Caught error", error);
+
       // gh CLI not available or not authenticated
     }
   }

--- a/apps/www/scripts/pr-review/github.ts
+++ b/apps/www/scripts/pr-review/github.ts
@@ -40,6 +40,8 @@ export function parsePrUrl(prUrl: string): ParsedPrUrl {
   try {
     url = new URL(prUrl);
   } catch (_error) {
+    console.error("[apps/www/scripts/pr-review/github.ts] Caught error", _error);
+
     throw new Error(`Invalid PR URL: ${prUrl}`);
   }
 
@@ -80,6 +82,8 @@ export async function fetchPrMetadata(
     });
     data = response.data;
   } catch (error) {
+    console.error("[apps/www/scripts/pr-review/github.ts] Caught error", error);
+
     const message =
       error instanceof Error ? error.message : String(error ?? "unknown error");
     throw new Error(

--- a/apps/www/scripts/pr-review/pr-review-inject.ts
+++ b/apps/www/scripts/pr-review/pr-review-inject.ts
@@ -237,6 +237,8 @@ function parseRepoUrl(repoUrl: string): RepoIdentifier {
   try {
     url = new URL(repoUrl);
   } catch (error) {
+    console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", error);
+
     throw new Error(
       `Unable to parse repository URL (${repoUrl}): ${String(
         error instanceof Error ? error.message : error
@@ -775,7 +777,9 @@ function extractOpenAiResponseText(
   }
   try {
     return JSON.stringify(responseBody, null, 2);
-  } catch {
+  } catch (error) {
+    console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", error);
+
     return fallback;
   }
 }
@@ -818,6 +822,8 @@ async function runOpenAiResponsesInvocation({
   try {
     parsedResponse = rawResponseText ? JSON.parse(rawResponseText) : {};
   } catch (parseError) {
+    console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", parseError);
+
     const message =
       parseError instanceof Error ? parseError.message : String(parseError);
     throw new Error(
@@ -944,6 +950,8 @@ async function main(): Promise<void> {
       console.log(`[inject] Saved ${label} to ${path}`);
       return true;
     } catch (error) {
+      console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", error);
+
       const message =
         error instanceof Error
           ? error.message
@@ -969,6 +977,8 @@ async function main(): Promise<void> {
         `[inject] Linked ${symlinkPath} -> ${targetPath} for ${label}`
       );
     } catch (error) {
+      console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", error);
+
       const message =
         error instanceof Error
           ? error.message
@@ -1005,6 +1015,8 @@ async function main(): Promise<void> {
     try {
       await configureGitCredentials(githubToken);
     } catch (error) {
+      console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", error);
+
       const message =
         error instanceof Error
           ? error.message
@@ -1048,6 +1060,8 @@ async function main(): Promise<void> {
           `[inject] Linked ${logSymlinkPath} -> ${logFilePath} for log access`
         );
       } catch (error) {
+        console.error("[apps/www/scripts/pr-review/pr-review-inject.ts] Caught error", error);
+
         const message =
           error instanceof Error
             ? error.message

--- a/apps/www/scripts/pr-review/run-strategy-demo.ts
+++ b/apps/www/scripts/pr-review/run-strategy-demo.ts
@@ -21,7 +21,9 @@ async function ensureTempDiff(): Promise<string> {
   try {
     await readFile(TEMP_DIFF_PATH);
     return TEMP_DIFF_PATH;
-  } catch {
+  } catch (error) {
+    console.error("[apps/www/scripts/pr-review/run-strategy-demo.ts] Caught error", error);
+
     const res = await fetch(DIFF_URL);
     if (!res.ok) {
       throw new Error(`Failed to fetch diff: ${res.status} ${res.statusText}`);

--- a/apps/www/scripts/pr-review/strategies/inline-files.ts
+++ b/apps/www/scripts/pr-review/strategies/inline-files.ts
@@ -169,6 +169,8 @@ async function process(
   try {
     fileContent = await readFile(workspaceAbsolutePath, "utf8");
   } catch (error) {
+    console.error("[apps/www/scripts/pr-review/strategies/inline-files.ts] Caught error", error);
+
     const reason =
       error instanceof Error ? error.message : String(error ?? "unknown error");
     throw new Error(

--- a/apps/www/scripts/pr-review/strategies/inline-json.ts
+++ b/apps/www/scripts/pr-review/strategies/inline-json.ts
@@ -75,7 +75,9 @@ function parseJsonAnnotation(line: string): ParsedJsonAnnotation | null {
       phrase,
       comment,
     };
-  } catch {
+  } catch (error) {
+    console.error("[apps/www/scripts/pr-review/strategies/inline-json.ts] Caught error", error);
+
     return null;
   }
 }

--- a/apps/www/scripts/pr-review/strategies/openai-responses.ts
+++ b/apps/www/scripts/pr-review/strategies/openai-responses.ts
@@ -153,7 +153,9 @@ async function prepare(
 function parseModelResponse(rawText: string): ModelResponseShape | null {
   try {
     return JSON.parse(rawText) as ModelResponseShape;
-  } catch {
+  } catch (error) {
+    console.error("[apps/www/scripts/pr-review/strategies/openai-responses.ts] Caught error", error);
+
     return null;
   }
 }

--- a/apps/www/scripts/start-code-review.ts
+++ b/apps/www/scripts/start-code-review.ts
@@ -78,6 +78,8 @@ function parsePrUrl(prUrl: string): ParsedPrUrl {
   try {
     parsedUrl = new URL(prUrl);
   } catch (_error) {
+    console.error("[apps/www/scripts/start-code-review.ts] Caught error", _error);
+
     throw new Error(`Invalid PR URL: ${prUrl}`);
   }
 
@@ -139,6 +141,8 @@ async function fetchCommitRefs(pr: ParsedPrUrl): Promise<{
       base: baseSha && baseSha.length > 0 ? baseSha : undefined,
     };
   } catch (error) {
+    console.error("[apps/www/scripts/start-code-review.ts] Caught error", error);
+
     console.warn("[cli] Failed to fetch PR metadata for commit refs", {
       owner: pr.owner,
       repo: pr.repo,

--- a/apps/www/scripts/watch-openapi.ts
+++ b/apps/www/scripts/watch-openapi.ts
@@ -47,7 +47,9 @@ console.timeEnd("generate client");
 
 try {
   fs.unlinkSync(tmpFile);
-} catch {
+} catch (error) {
+  console.error("[apps/www/scripts/watch-openapi.ts] Caught error", error);
+
   // ignore if already removed by concurrent runs
 }
 

--- a/apps/www/src/pr-review.ts
+++ b/apps/www/src/pr-review.ts
@@ -70,6 +70,10 @@ async function getInjectScriptSource(productionMode: boolean): Promise<string> {
       try {
         return await readFile(injectScriptBundlePath, "utf8");
       } catch (error) {
+        console.error(
+          "[pr-review] Failed to read inject script bundle",
+          error,
+        );
         const maybeCode =
           typeof error === "object" &&
             error !== null &&
@@ -85,6 +89,7 @@ async function getInjectScriptSource(productionMode: boolean): Promise<string> {
         throw error;
       }
     })().catch((error) => {
+      console.error("[pr-review] Inject script preparation failed", error);
       cachedInjectScriptPromise = null;
       throw error;
     });
@@ -253,6 +258,10 @@ function getOpenVscodeBaseUrl(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : String(error ?? "unknown error");
+    console.error(
+      `[pr-review] Unable to format OpenVSCode URL for port ${OPEN_VSCODE_PORT}`,
+      error,
+    );
     console.warn(
       `Warning: unable to format OpenVSCode URL for port ${OPEN_VSCODE_PORT}: ${message}`
     );
@@ -424,6 +433,10 @@ export async function startAutomatedPrReview(
         metadataError instanceof Error
           ? metadataError.message
           : String(metadataError ?? "unknown error");
+      console.error(
+        `[pr-review] Failed to set metadata for instance ${startedInstance.id}`,
+        metadataError,
+      );
       console.warn(
         `[pr-review] Warning: failed to set metadata for instance ${startedInstance.id}: ${message}`
       );
@@ -593,6 +606,10 @@ export async function startAutomatedPrReview(
           pauseError instanceof Error
             ? pauseError.message
             : String(pauseError ?? "Unknown pause error");
+        console.error(
+          `[pr-review] Failed to pause instance ${instance.id}`,
+          pauseError,
+        );
         console.warn(
           `[pr-review] Warning: failed to pause instance ${instance.id}: ${pauseMessage}`
         );


### PR DESCRIPTION
## Summary
- add console.error handling to after-sign-in deep link helpers and prompts
- log pull request loading failures and background review issues in PR review pages
- standardize console.error logging across apps/www utilities, routes, and scripts

## Testing
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_690a66fc2ca08333ac04120ca46a2e79