### PR TITLE
Return to environments after snapshot and show toast

### DIFF
--- a/apps/client/src/components/EnvironmentConfiguration.tsx
+++ b/apps/client/src/components/EnvironmentConfiguration.tsx
@@ -47,6 +47,7 @@ import {
   type ReactNode,
 } from "react";
 import TextareaAutosize from "react-textarea-autosize";
+import { toast } from "sonner";
 
 export function EnvironmentConfiguration({
   selectedRepos,
@@ -376,24 +377,23 @@ export function EnvironmentConfiguration({
         {
           onSuccess: async () => {
             onEnvironmentSaved?.();
+            toast.success("Environment snapshot created successfully");
             await navigate({
-              to: "/$teamSlugOrId/environments/$environmentId",
-              params: {
-                teamSlugOrId,
-                environmentId: sourceEnvironmentId,
-              },
-              search: () => ({
+              to: "/$teamSlugOrId/environments",
+              params: { teamSlugOrId },
+              search: {
                 step: undefined,
                 selectedRepos: undefined,
                 connectionLogin: undefined,
                 repoSearch: undefined,
                 instanceId: undefined,
                 snapshotId: undefined,
-              }),
+              },
             });
           },
           onError: (err) => {
             console.error("Failed to create snapshot version:", err);
+            toast.error("Failed to create snapshot version");
           },
         }
       );

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
@@ -3,6 +3,7 @@ import { FloatingPane } from "@/components/floating-pane";
 import { TitleBar } from "@/components/TitleBar";
 import { parseEnvBlock } from "@/lib/parseEnvBlock";
 import { toMorphVncUrl } from "@/lib/toProxyWorkspaceUrl";
+import { clearEnvironmentDraft } from "@/state/environment-draft-store";
 import type { Id } from "@cmux/convex/dataModel";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import {
@@ -13,7 +14,7 @@ import {
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { z } from "zod";
 
 const searchSchema = z.object({
@@ -144,6 +145,11 @@ function NewSnapshotVersionPage() {
 
   const effectiveVscodeUrl = urlVscodeUrl ?? derivedVscodeUrl;
 
+  const handleEnvironmentSaved = useCallback(() => {
+    clearEnvironmentDraft(teamSlugOrId);
+    setHeaderActions(null);
+  }, [teamSlugOrId]);
+
   return (
     <FloatingPane
       header={<TitleBar title="New Snapshot Version" actions={headerActions} />}
@@ -177,6 +183,7 @@ function NewSnapshotVersionPage() {
             }
             initialEnvVars={initialEnvVars}
             onHeaderControlsChange={setHeaderActions}
+            onEnvironmentSaved={handleEnvironmentSaved}
           />
         )}
       </div>


### PR DESCRIPTION
currently when i snapshot environment, there is a bug where it doesn't return me to the main environments page where i can see all of the environments, it stays on the configure environment page wiht the vscode thing but it makes everyhting blank... this is weird unexpected behavior, after we press create snapshot it should load until the snapshot is created and then return back to the default environment page (no pending environments)... after we create the snapshot, it should be removed from the storage as a pending environment and that means we just go to the original environments page before snapshot creation... we need to show a toast showing that the environment snapshot was created successfully as well. it doesnt ever seem to get to that point, it like does it correctly but refreshes to an empty configure environment page for some reason