### PR TITLE
Make restart dialog sticky to bottom in diff view

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -270,10 +270,10 @@ const RestartTaskForm = memo(function RestartTaskForm({
   }, [isRestartingTask, overridePrompt, socket, task, trimmedFollowUp]);
 
   return (
-    <div className="sticky bottom-0 z-[var(--z-popover)] border-t border-transparent px-3.5 pb-3.5 pt-2">
+    <div className="fixed bottom-0 left-0 right-0 z-[var(--z-popover)] border-t border-transparent px-3.5 pb-3.5 pt-2 pointer-events-none">
       <form
         onSubmit={handleFormSubmit}
-        className="mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-neutral-500/15 bg-white dark:border-neutral-500/15 dark:bg-neutral-950"
+        className="mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-neutral-500/15 bg-white dark:border-neutral-500/15 dark:bg-neutral-950 pointer-events-auto"
       >
         <div className="px-3.5 pt-3.5">
           <LexicalEditor


### PR DESCRIPTION
currently the restart task dialogue in the git diff viewer does not stick to the bottom, it seems to have a certain position on the page and never moves from it even when you scroll down... we need it to be at the bottom at all times no matter what