### PR TITLE
Update terminal messages to Cloud-based runs

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
@@ -402,13 +402,13 @@ function TaskRunTerminals() {
   const renderTerminalArea = () => {
     if (!isMorphProvider) {
       return renderMessage(
-        "Terminals are only available for Morph-based runs."
+        "Terminals are only available for Cloud-based runs."
       );
     }
 
     if (!xtermBaseUrl) {
       return renderMessage(
-        "Waiting for Morph workspace to expose the terminal backend..."
+        "Waiting for Cloud workspace to expose the terminal backend..."
       );
     }
 


### PR DESCRIPTION
change from  const renderTerminalArea = () => {
    if (!isMorphProvider) {
      return renderMessage(
        "Terminals are only available for Morph-based runs."
      );
    }


    if (!xtermBaseUrl) {
      return renderMessage(
        "Waiting for Morph workspace to expose the terminal backend..."
      );
    }to   if (!isMorphProvider) {      return renderMessage(        "Terminals are only available for Cloud-based runs."      );    }    if (!xtermBaseUrl) {      return renderMessage(        "Waiting for Cloud workspace to expose the terminal backend..."      );    }