### PR TITLE
Guard atob decoding for image URLs

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -75,6 +75,40 @@ const parseStoredAgentSelection = (stored: string | null): string[] => {
   }
 };
 
+const REMOTE_IMAGE_SRC_REGEX = /^(https?:\/\/|blob:)/i;
+
+const convertBase64SourceToBlob = (source: string): Blob => {
+  const commaIndex = source.indexOf(",");
+  const metadata = commaIndex >= 0 ? source.slice(0, commaIndex) : undefined;
+  const base64Data = commaIndex >= 0 ? source.slice(commaIndex + 1) : source;
+  const normalizedBase64 = base64Data.replace(/\s/g, "");
+
+  try {
+    const byteCharacters = atob(normalizedBase64);
+    const byteArray = new Uint8Array(byteCharacters.length);
+    for (let i = 0; i < byteCharacters.length; i += 1) {
+      byteArray[i] = byteCharacters.charCodeAt(i);
+    }
+    const mimeMatch = metadata?.match(/^data:(.*?)(;base64)?$/i);
+    const mimeType = mimeMatch?.[1] ?? "image/png";
+    return new Blob([byteArray], { type: mimeType });
+  } catch (error) {
+    throw new Error("Failed to decode inline image data.");
+  }
+};
+
+const imageSourceToBlob = async (src: string): Promise<Blob> => {
+  if (src.startsWith("data:") || !REMOTE_IMAGE_SRC_REGEX.test(src)) {
+    return convertBase64SourceToBlob(src);
+  }
+
+  const response = await fetch(src);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image from ${src}: ${response.status} ${response.statusText}`);
+  }
+  return await response.blob();
+};
+
 function DashboardComponent() {
   const { teamSlugOrId } = Route.useParams();
   const searchParams = Route.useSearch() as { environmentId?: string };
@@ -422,21 +456,14 @@ function DashboardComponent() {
             fileName?: string;
             altText: string;
           }) => {
-            // Convert base64 to blob
-            const base64Data = image.src.split(",")[1] || image.src;
-            const byteCharacters = atob(base64Data);
-            const byteNumbers = new Array(byteCharacters.length);
-            for (let i = 0; i < byteCharacters.length; i++) {
-              byteNumbers[i] = byteCharacters.charCodeAt(i);
-            }
-            const byteArray = new Uint8Array(byteNumbers);
-            const blob = new Blob([byteArray], { type: "image/png" });
+            // Support both inline data URLs and remote image sources
+            const blob = await imageSourceToBlob(image.src);
             const uploadUrl = await generateUploadUrl({
               teamSlugOrId,
             });
             const result = await fetch(uploadUrl, {
               method: "POST",
-              headers: { "Content-Type": blob.type },
+              headers: { "Content-Type": blob.type || "application/octet-stream" },
               body: blob,
             });
             const { storageId } = await result.json();


### PR DESCRIPTION
Error starting task: InvalidCharacterError: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at _layout._teamSlugOrId.dashboard-BQjTm3UH.js:2034:32
    at Array.map (<anonymous>)
    at _layout._teamSlugOrId.dashboard-BQjTm3UH.js:2032:55
    at processDispatchQueue (index-p4uqDWvE.js:9478:15)
    at index-p4uqDWvE.js:9851:7
    at batchedUpdates$1 (index-p4uqDWvE.js:2083:38)
    at dispatchEventForPluginEventSystem (index-p4uqDWvE.js:9570:5)
    at dispatchEvent (index-p4uqDWvE.js:11515:9)
    at dispatchDiscreteEvent (index-p4uqDWvE.js:11496:38) when we insert images like https://private-user-images.githubusercontent.com/5871170/508380459-533cd5ef-6910-416e-9538-b3ed2e2ed7ae.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjIzMjUxODUsIm5iZiI6MTc2MjMyNDg4NSwicGF0aCI6Ii81ODcxMTcwLzUwODM4MDQ1OS01MzNjZDVlZi02OTEwLTQxNmUtOTUzOC1iM2VkMmUyZWQ3YWUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MTEwNSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTExMDVUMDY0MTI1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NzRhMTM4MWVjYWU1MDFiNzY3NTk1OTNmYTEwMjExYzVkZDlkODc3YjRmZmU2NjdlNzdlNmM0OTUyZGEzNDRhOCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.boSGZJY4jgFo98jyyiJvZDSufIFVdfz-pRI9k0dpLJc ... seems like an edge case with links and images..