### PR TITLE
Hide branch names and subtitles in left sidebar

### DIFF
--- a/apps/client/src/components/sidebar/SidebarListItem.tsx
+++ b/apps/client/src/components/sidebar/SidebarListItem.tsx
@@ -87,16 +87,6 @@ export function SidebarListItem({
               <span className="ml-auto flex-shrink-0">{meta}</span>
             ) : null}
           </div>
-          {secondary ? (
-            <div
-              className={clsx(
-                "truncate text-[10px] text-neutral-600 dark:text-neutral-400",
-                secondaryClassName
-              )}
-            >
-              {secondary}
-            </div>
-          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
in left sidebar get rid of all raw git branch names like the task tree, the element with classname: truncate text-[10px] text-neutral-600 dark:text-neutral-400like not just the branch name lowkey, but the entire subtitle row