### PR TITLE
Hide branch names and subtitles in left sidebar

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -67,29 +67,6 @@ type TaskWithGeneratedBranch = Doc<"tasks"> & {
   generatedBranchName?: string | null;
 };
 
-function sanitizeBranchName(input?: string | null): string | null {
-  if (!input) return null;
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  let normalized = trimmed;
-  if (normalized.startsWith("cmux/")) {
-    normalized = normalized.slice("cmux/".length).trim();
-    if (!normalized) return null;
-  }
-  const idx = normalized.lastIndexOf("-");
-  if (idx <= 0) return normalized;
-  const candidate = normalized.slice(0, idx);
-  return candidate || normalized;
-}
-
-function getTaskBranch(task: TaskWithGeneratedBranch): string | null {
-  const fromGenerated = sanitizeBranchName(task.generatedBranchName);
-  if (fromGenerated) {
-    return fromGenerated;
-  }
-  return sanitizeBranchName(task.baseBranch);
-}
-
 interface TaskTreeProps {
   task: TaskWithGeneratedBranch;
   level?: number;
@@ -215,16 +192,6 @@ function TaskTreeInner({
   const handleUnarchive = useCallback(() => {
     unarchive(task._id);
   }, [unarchive, task._id]);
-
-  const inferredBranch = getTaskBranch(task);
-  const taskSecondaryParts: string[] = [];
-  if (inferredBranch) {
-    taskSecondaryParts.push(inferredBranch);
-  }
-  if (task.projectFullName) {
-    taskSecondaryParts.push(task.projectFullName);
-  }
-  const taskSecondary = taskSecondaryParts.join(" • ");
 
   const canExpand = true;
   const isCrownEvaluating = task.crownEvaluationStatus === "in_progress";
@@ -362,7 +329,6 @@ function TaskTreeInner({
                 }}
                 title={task.pullRequestTitle || task.text}
                 titleClassName="text-[13px] text-neutral-900 dark:text-neutral-100"
-                secondary={taskSecondary || undefined}
                 meta={taskLeadingIcon || undefined}
               />
             </Link>

--- a/apps/client/src/components/sidebar/SidebarListItem.tsx
+++ b/apps/client/src/components/sidebar/SidebarListItem.tsx
@@ -5,8 +5,6 @@ import { SidebarToggleButton } from "../SidebarToggleButton";
 interface SidebarListItemProps {
   title: ReactNode;
   titleClassName?: string;
-  secondary?: ReactNode;
-  secondaryClassName?: string;
   meta?: ReactNode;
   leading?: ReactNode;
   trailing?: ReactNode;
@@ -27,8 +25,6 @@ interface SidebarListItemProps {
 export function SidebarListItem({
   title,
   titleClassName,
-  secondary,
-  secondaryClassName,
   meta,
   leading,
   trailing,
@@ -87,16 +83,6 @@ export function SidebarListItem({
               <span className="ml-auto flex-shrink-0">{meta}</span>
             ) : null}
           </div>
-          {secondary ? (
-            <div
-              className={clsx(
-                "truncate text-[10px] text-neutral-600 dark:text-neutral-400",
-                secondaryClassName
-              )}
-            >
-              {secondary}
-            </div>
-          ) : null}
         </div>
       </div>
 

--- a/apps/client/src/components/sidebar/SidebarPullRequestList.tsx
+++ b/apps/client/src/components/sidebar/SidebarPullRequestList.tsx
@@ -78,16 +78,6 @@ function PullRequestListItem({ pr, teamSlugOrId, expanded, setExpanded }: PullRe
   const [owner = "", repo = ""] = pr.repoFullName?.split("/", 2) ?? ["", ""];
   const key = `${pr.repoFullName}#${pr.number}`;
   const isExpanded = expanded[key] ?? false;
-  const branchLabel = pr.headRef;
-
-  const secondaryParts = [
-    branchLabel,
-    `${pr.repoFullName}#${pr.number}`,
-    pr.authorLogin,
-  ]
-    .filter(Boolean)
-    .map(String);
-  const secondary = secondaryParts.join(" • ");
   const leadingIcon = pr.merged ? (
     <GitMerge className="w-3 h-3 text-purple-500" />
   ) : pr.state === "closed" ? (
@@ -140,7 +130,6 @@ function PullRequestListItem({ pr, teamSlugOrId, expanded, setExpanded }: PullRe
           }}
           title={pr.title}
           titleClassName="text-[13px] text-neutral-950 dark:text-neutral-100"
-          secondary={secondary || undefined}
           meta={leadingIcon}
         />
       </Link>


### PR DESCRIPTION
in left sidebar get rid of all raw git branch names like the task tree, the element with classname: truncate text-[10px] text-neutral-600 dark:text-neutral-400like not just the branch name lowkey, but the entire subtitle row