### PR TITLE
Implement silent token refresh on expiry

### DIFF
--- a/apps/client/src/contexts/convex/authJsonQueryOptions.ts
+++ b/apps/client/src/contexts/convex/authJsonQueryOptions.ts
@@ -8,8 +8,10 @@ export interface StackUserLike {
   getAuthJson: () => Promise<{ accessToken: string | null }>;
 }
 
-// Refresh every 9 minutes to beat the ~10 minute Stack access token expiry window
-export const defaultAuthJsonRefreshInterval = 9 * 60 * 1000;
+// Refresh every 5 minutes to ensure we always have a fresh token
+// Stack access tokens typically expire after 10 minutes, so refreshing at 5 minutes
+// provides a good safety margin and prevents token expiration issues
+export const defaultAuthJsonRefreshInterval = 5 * 60 * 1000;
 
 export function authJsonQueryOptions() {
   return queryOptions<AuthJson>({
@@ -22,5 +24,7 @@ export function authJsonQueryOptions() {
     },
     refetchInterval: defaultAuthJsonRefreshInterval,
     refetchIntervalInBackground: true,
+    staleTime: 4 * 60 * 1000, // Consider data stale after 4 minutes
+    gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes
   });
 }

--- a/apps/client/src/contexts/socket/socket-provider.tsx
+++ b/apps/client/src/contexts/socket/socket-provider.tsx
@@ -51,6 +51,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({
       console.warn("[Socket] No auth token yet; delaying connect");
       return;
     }
+    console.log("[Socket] Connecting with fresh auth token");
     let disposed = false;
     let createdSocket: MainServerSocket | null = null;
     (async () => {
@@ -99,6 +100,16 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({
             ? (err as Error).message
             : String(err);
         console.error("[Socket] connect_error", errorMessage);
+
+        // Check if this is a token expiration error
+        if (
+          errorMessage.includes("Token expired") ||
+          errorMessage.includes("InvalidAuthHeader")
+        ) {
+          console.log(
+            "[Socket] Token expired, will reconnect with fresh token on next auth refresh"
+          );
+        }
       });
 
       newSocket.on("available-editors", (data: AvailableEditors) => {


### PR DESCRIPTION
if i stay on cmux app for a long time and inactive, it seems like I run into this issue: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 362 seconds ago"}...