### PR TITLE
In-app image slideshow for diffs

### DIFF
--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -1,5 +1,7 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { ExternalLink } from "lucide-react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { ChevronLeft, ChevronRight, Maximize2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Id } from "@cmux/convex/dataModel";
 
@@ -49,12 +51,106 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
     return null;
   }
 
+  const flattenedImages = useMemo(
+    () =>
+      screenshotSets.flatMap((set) =>
+        set.images.flatMap((image, indexInSet) =>
+          image.url
+            ? [
+                {
+                  set,
+                  image,
+                  indexInSet,
+                },
+              ]
+            : [],
+        ),
+      ),
+    [screenshotSets],
+  );
+
+  const [activeImageIndex, setActiveImageIndex] = useState<number | null>(null);
+
+  const currentEntry =
+    activeImageIndex !== null &&
+    activeImageIndex >= 0 &&
+    activeImageIndex < flattenedImages.length
+      ? flattenedImages[activeImageIndex]
+      : null;
+
   const effectiveHighlight =
     highlightedSetId ??
+    currentEntry?.set._id ??
     (screenshotSets.length > 0 ? screenshotSets[0]._id : null);
 
+  useEffect(() => {
+    if (activeImageIndex === null) {
+      return;
+    }
+    if (flattenedImages.length === 0) {
+      setActiveImageIndex(null);
+      return;
+    }
+    if (activeImageIndex >= flattenedImages.length) {
+      setActiveImageIndex(flattenedImages.length - 1);
+    }
+  }, [activeImageIndex, flattenedImages.length]);
+
+  const closeSlideshow = useCallback(() => {
+    setActiveImageIndex(null);
+  }, []);
+
+  const goNext = useCallback(() => {
+    setActiveImageIndex((prev) => {
+      if (prev === null) {
+        return prev;
+      }
+      const len = flattenedImages.length;
+      if (len <= 1) {
+        return prev;
+      }
+      return (prev + 1) % len;
+    });
+  }, [flattenedImages.length]);
+
+  const goPrev = useCallback(() => {
+    setActiveImageIndex((prev) => {
+      if (prev === null) {
+        return prev;
+      }
+      const len = flattenedImages.length;
+      if (len <= 1) {
+        return prev;
+      }
+      return (prev - 1 + len) % len;
+    });
+  }, [flattenedImages.length]);
+
+  const isSlideshowOpen = Boolean(currentEntry);
+
+  useEffect(() => {
+    if (!isSlideshowOpen) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        goNext();
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        goPrev();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [goNext, goPrev, isSlideshowOpen]);
+
+  let runningImageIndex = -1;
+
   return (
-    <section className="border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50/60 dark:bg-neutral-950/40">
+    <section className="border-b border-neutral-200 bg-neutral-50/60 dark:border-neutral-800 dark:bg-neutral-950/40">
       <div className="px-3.5 pt-3 pb-2 flex items-center justify-between gap-3">
         <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
           Screenshots
@@ -65,6 +161,84 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
         </span>
       </div>
       <div className="px-3.5 pb-4 space-y-4">
+        {currentEntry ? (
+          <Dialog.Root open={isSlideshowOpen} onOpenChange={(open) => !open && closeSlideshow()}>
+            <Dialog.Portal>
+              <Dialog.Overlay className="fixed inset-0 bg-neutral-950/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out" />
+              <Dialog.Content className="fixed inset-0 flex items-center justify-center p-6 focus:outline-none">
+                <div className="relative flex w-full max-w-5xl flex-col gap-4 rounded-2xl border border-neutral-200 bg-white/95 p-4 shadow-2xl backdrop-blur-md focus:outline-none dark:border-neutral-800 dark:bg-neutral-950/90 sm:p-6">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <Dialog.Title className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
+                        {currentEntry.image.fileName ?? "Screenshot"}
+                      </Dialog.Title>
+                      <Dialog.Description className="text-xs text-neutral-600 dark:text-neutral-400">
+                        Image {currentEntry.indexInSet + 1} of {currentEntry.set.images.length} in this capture
+                        {activeImageIndex !== null
+                          ? ` • ${activeImageIndex + 1} of ${flattenedImages.length} overall`
+                          : null}
+                      </Dialog.Description>
+                    </div>
+                    <Dialog.Close asChild>
+                      <button
+                        type="button"
+                        onClick={closeSlideshow}
+                        className="rounded-full border border-transparent bg-neutral-100/70 p-2 text-neutral-600 transition hover:bg-neutral-200 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:bg-neutral-800/60 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                        aria-label="Close slideshow"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </Dialog.Close>
+                  </div>
+                  <div className="relative flex flex-1 items-center justify-center overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
+                    <img
+                      src={currentEntry.image.url ?? undefined}
+                      alt={currentEntry.image.fileName ?? "Screenshot"}
+                      className="max-h-[70vh] w-full object-contain"
+                    />
+                    {flattenedImages.length > 1 ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={goPrev}
+                          className="group absolute left-2 top-1/2 -translate-y-1/2 rounded-full border border-neutral-200 bg-white/80 p-2 text-neutral-700 backdrop-blur transition hover:bg-white hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-950/80 dark:text-neutral-200 dark:hover:bg-neutral-900"
+                          aria-label="Previous screenshot"
+                          disabled={flattenedImages.length <= 1}
+                        >
+                          <ChevronLeft className="h-5 w-5" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={goNext}
+                          className="group absolute right-2 top-1/2 -translate-y-1/2 rounded-full border border-neutral-200 bg-white/80 p-2 text-neutral-700 backdrop-blur transition hover:bg-white hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-950/80 dark:text-neutral-200 dark:hover:bg-neutral-900"
+                          aria-label="Next screenshot"
+                          disabled={flattenedImages.length <= 1}
+                        >
+                          <ChevronRight className="h-5 w-5" />
+                        </button>
+                      </>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
+                    <span>
+                      Captured {formatDistanceToNow(new Date(currentEntry.set.capturedAt), { addSuffix: true })}
+                    </span>
+                    {currentEntry.set.commitSha ? (
+                      <>
+                        <span className="text-neutral-300 dark:text-neutral-600">•</span>
+                        <span className="font-mono uppercase text-neutral-500 dark:text-neutral-400">
+                          {currentEntry.set.commitSha.slice(0, 12)}
+                        </span>
+                      </>
+                    ) : null}
+                    <span className="text-neutral-300 dark:text-neutral-600">•</span>
+                    <span>{STATUS_LABELS[currentEntry.set.status]}</span>
+                  </div>
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        ) : null}
         {screenshotSets.map((set) => {
           const capturedAtDate = new Date(set.capturedAt);
           const relativeCapturedAt = formatDistanceToNow(capturedAtDate, {
@@ -119,42 +293,50 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
                   {set.error}
                 </p>
               )}
-              {set.images.length > 0 ? (
+                  {set.images.length > 0 ? (
                 <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
                   {set.images.map((image) => {
                     const key = `${image.storageId}-${image.fileName ?? "unnamed"}`;
+                    const displayName = image.fileName ?? "Screenshot";
                     if (!image.url) {
                       return (
                         <div
                           key={key}
-                          className="flex h-48 min-w-[200px] items-center justify-center rounded-lg border border-dashed border-neutral-300 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-900 text-xs text-neutral-500 dark:text-neutral-400"
+                          className="flex h-48 min-w-[200px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-100 text-xs text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400"
                         >
                           URL expired
                         </div>
                       );
                     }
+                    runningImageIndex += 1;
+                    const flatIndex = runningImageIndex;
 
                     return (
-                      <a
+                      <button
                         key={key}
-                        href={image.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="group relative block rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/70 hover:border-neutral-400 dark:hover:border-neutral-500 transition-colors overflow-hidden"
+                        type="button"
+                        onClick={() => setActiveImageIndex(flatIndex)}
+                        className={cn(
+                          "group relative flex w-[220px] flex-col overflow-hidden rounded-lg border border-neutral-200 bg-neutral-50 text-left transition-colors hover:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-900/70 dark:hover:border-neutral-500",
+                          activeImageIndex !== null &&
+                            flatIndex === activeImageIndex &&
+                            "border-emerald-400/70 shadow-[0_0_0_1px_rgba(16,185,129,0.25)] dark:border-emerald-400/60",
+                        )}
+                        aria-label={`Open ${displayName} in slideshow`}
                       >
                         <img
                           src={image.url}
-                          alt={image.fileName ?? "Screenshot"}
+                          alt={displayName}
                           className="h-48 w-[220px] object-contain bg-neutral-100 dark:bg-neutral-950"
                           loading="lazy"
                         />
-                        <div className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-neutral-600 opacity-0 shadow-sm transition group-hover:opacity-100 dark:bg-neutral-950/80 dark:text-neutral-300">
-                          <ExternalLink className="h-3.5 w-3.5" />
+                        <div className="absolute top-2 right-2 flex h-7 w-7 items-center justify-center rounded-full bg-white/80 text-neutral-600 opacity-0 shadow-sm transition group-hover:opacity-100 dark:bg-neutral-950/80 dark:text-neutral-300">
+                          <Maximize2 className="h-3.5 w-3.5" />
                         </div>
-                        <div className="border-t border-neutral-200 dark:border-neutral-700 px-2 py-1 text-xs text-neutral-600 dark:text-neutral-300 truncate">
-                          {image.fileName ?? "Screenshot"}
+                        <div className="border-t border-neutral-200 px-2 py-1 text-xs text-neutral-600 dark:border-neutral-700 dark:text-neutral-300 truncate">
+                          {displayName}
                         </div>
-                      </a>
+                      </button>
                     );
                   })}
                 </div>

--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -47,24 +47,6 @@ const STATUS_STYLES: Record<ScreenshotStatus, string> = {
 
 export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
   const { screenshotSets, highlightedSetId } = props;
-  if (!screenshotSets || screenshotSets.length === 0) {
-    return null;
-  }
-  return (
-    <RunScreenshotGalleryContent
-      screenshotSets={screenshotSets}
-      highlightedSetId={highlightedSetId}
-    />
-  );
-}
-
-interface RunScreenshotGalleryContentProps {
-  screenshotSets: RunScreenshotSet[];
-  highlightedSetId?: Id<"taskRunScreenshotSets"> | null;
-}
-
-function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
-  const { screenshotSets, highlightedSetId } = props;
   const sortedScreenshotSets = useMemo(
     () =>
       [...screenshotSets].sort((a, b) => {
@@ -101,6 +83,11 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
     activeImageIndex >= 0 &&
     activeImageIndex < flattenedImages.length
       ? flattenedImages[activeImageIndex]
+      : null;
+
+  const activeOverallIndex =
+    activeImageIndex !== null && activeImageIndex >= 0
+      ? activeImageIndex + 1
       : null;
 
   const effectiveHighlight =
@@ -174,6 +161,10 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
 
   let runningImageIndex = -1;
 
+  if (sortedScreenshotSets.length === 0) {
+    return null;
+  }
+
   return (
     <section className="border-b border-neutral-200 bg-neutral-50/60 dark:border-neutral-800 dark:bg-neutral-950/40">
       <div className="px-3.5 pt-3 pb-2 flex items-center justify-between gap-3">
@@ -187,21 +178,29 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
       </div>
       <div className="px-3.5 pb-4 space-y-4">
         {currentEntry ? (
-          <Dialog.Root open={isSlideshowOpen} onOpenChange={(open) => !open && closeSlideshow()}>
+          <Dialog.Root
+            open={isSlideshowOpen}
+            onOpenChange={(open) => !open && closeSlideshow()}
+            modal={false}
+          >
             <Dialog.Portal>
-              <Dialog.Overlay className="fixed inset-0 bg-neutral-950/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out" />
-              <Dialog.Content className="fixed inset-0 flex items-center justify-center p-6 focus:outline-none">
-                <div className="relative flex w-full max-w-5xl flex-col gap-4 rounded-2xl border border-neutral-200 bg-white/95 p-4 shadow-2xl backdrop-blur-md focus:outline-none dark:border-neutral-800 dark:bg-neutral-950/90 sm:p-6">
+              <Dialog.Overlay className="pointer-events-none fixed inset-0 bg-neutral-950/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out" />
+              <Dialog.Content className="pointer-events-none fixed inset-0 flex items-center justify-center p-6 focus:outline-none">
+                <div className="pointer-events-auto relative flex w-full max-w-5xl flex-col gap-4 rounded-2xl border border-neutral-200 bg-white/95 p-4 shadow-2xl backdrop-blur-md focus:outline-none dark:border-neutral-800 dark:bg-neutral-950/90 sm:p-6">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
                       <Dialog.Title className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
+                        {activeOverallIndex !== null
+                          ? `${activeOverallIndex}. `
+                          : ""}
                         {currentEntry.image.fileName ?? "Screenshot"}
                       </Dialog.Title>
                       <Dialog.Description className="text-xs text-neutral-600 dark:text-neutral-400">
-                        Image {currentEntry.indexInSet + 1} of {currentEntry.set.images.length} in this capture
-                        {activeImageIndex !== null
-                          ? ` • ${activeImageIndex + 1} of ${flattenedImages.length} overall`
-                          : null}
+                        Image {currentEntry.indexInSet + 1} of {currentEntry.set.images.length}
+                        <span className="px-1 text-neutral-400 dark:text-neutral-600">-</span>
+                        {formatDistanceToNow(new Date(currentEntry.set.capturedAt), {
+                          addSuffix: true,
+                        })}
                       </Dialog.Description>
                     </div>
                     <Dialog.Close asChild>
@@ -220,7 +219,7 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
                       <button
                         type="button"
                         onClick={goPrev}
-                        className="flex h-11 w-11 items-center justify-center rounded-full border border-neutral-300 bg-neutral-50 text-neutral-700 shadow transition hover:border-neutral-400 hover:bg-neutral-200 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
+                        className="p-1 text-neutral-600 transition hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:text-neutral-300 dark:hover:text-neutral-100"
                         aria-label="Previous screenshot"
                       >
                         <ChevronLeft className="h-5 w-5" />
@@ -237,27 +236,12 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
                       <button
                         type="button"
                         onClick={goNext}
-                        className="flex h-11 w-11 items-center justify-center rounded-full border border-neutral-300 bg-neutral-50 text-neutral-700 shadow transition hover:border-neutral-400 hover:bg-neutral-200 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
+                        className="p-1 text-neutral-600 transition hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:text-neutral-300 dark:hover:text-neutral-100"
                         aria-label="Next screenshot"
                       >
                         <ChevronRight className="h-5 w-5" />
                       </button>
                     ) : null}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
-                    <span>
-                      Captured {formatDistanceToNow(new Date(currentEntry.set.capturedAt), { addSuffix: true })}
-                    </span>
-                    {currentEntry.set.commitSha ? (
-                      <>
-                        <span className="text-neutral-300 dark:text-neutral-600">•</span>
-                        <span className="font-mono uppercase text-neutral-500 dark:text-neutral-400">
-                          {currentEntry.set.commitSha.slice(0, 12)}
-                        </span>
-                      </>
-                    ) : null}
-                    <span className="text-neutral-300 dark:text-neutral-600">•</span>
-                    <span>{STATUS_LABELS[currentEntry.set.status]}</span>
                   </div>
                 </div>
               </Dialog.Content>
@@ -335,6 +319,7 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
                     }
                     runningImageIndex += 1;
                     const flatIndex = runningImageIndex;
+                    const humanIndex = flatIndex + 1;
 
                     return (
                       <button
@@ -359,7 +344,7 @@ function RunScreenshotGalleryContent(props: RunScreenshotGalleryContentProps) {
                           <Maximize2 className="h-3.5 w-3.5" />
                         </div>
                         <div className="border-t border-neutral-200 px-2 py-1 text-xs text-neutral-600 dark:border-neutral-700 dark:text-neutral-300 truncate">
-                          {displayName}
+                          {humanIndex}. {displayName}
                         </div>
                       </button>
                     );

--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -47,9 +47,7 @@ const STATUS_STYLES: Record<ScreenshotStatus, string> = {
 
 export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
   const { screenshotSets, highlightedSetId } = props;
-  if (!screenshotSets || screenshotSets.length === 0) {
-    return null;
-  }
+  const hasScreenshots = screenshotSets.length > 0;
 
   const flattenedImages = useMemo(
     () =>
@@ -81,7 +79,7 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
   const effectiveHighlight =
     highlightedSetId ??
     currentEntry?.set._id ??
-    (screenshotSets.length > 0 ? screenshotSets[0]._id : null);
+    (hasScreenshots ? screenshotSets[0]._id : null);
 
   useEffect(() => {
     if (activeImageIndex === null) {
@@ -147,6 +145,10 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
     };
   }, [goNext, goPrev, isSlideshowOpen]);
 
+  if (!hasScreenshots) {
+    return null;
+  }
+
   let runningImageIndex = -1;
 
   return (
@@ -190,33 +192,33 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
                       </button>
                     </Dialog.Close>
                   </div>
-                  <div className="relative flex flex-1 items-center justify-center overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
-                    <img
-                      src={currentEntry.image.url ?? undefined}
-                      alt={currentEntry.image.fileName ?? "Screenshot"}
-                      className="max-h-[70vh] w-full object-contain"
-                    />
+                  <div className="flex flex-1 items-center justify-center gap-4">
                     {flattenedImages.length > 1 ? (
-                      <>
-                        <button
-                          type="button"
-                          onClick={goPrev}
-                          className="group absolute left-2 top-1/2 -translate-y-1/2 rounded-full border border-neutral-200 bg-white/80 p-2 text-neutral-700 backdrop-blur transition hover:bg-white hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-950/80 dark:text-neutral-200 dark:hover:bg-neutral-900"
-                          aria-label="Previous screenshot"
-                          disabled={flattenedImages.length <= 1}
-                        >
-                          <ChevronLeft className="h-5 w-5" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={goNext}
-                          className="group absolute right-2 top-1/2 -translate-y-1/2 rounded-full border border-neutral-200 bg-white/80 p-2 text-neutral-700 backdrop-blur transition hover:bg-white hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-950/80 dark:text-neutral-200 dark:hover:bg-neutral-900"
-                          aria-label="Next screenshot"
-                          disabled={flattenedImages.length <= 1}
-                        >
-                          <ChevronRight className="h-5 w-5" />
-                        </button>
-                      </>
+                      <button
+                        type="button"
+                        onClick={goPrev}
+                        className="flex h-11 w-11 items-center justify-center rounded-full border border-neutral-300 bg-neutral-50 text-neutral-700 shadow transition hover:border-neutral-400 hover:bg-neutral-200 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
+                        aria-label="Previous screenshot"
+                      >
+                        <ChevronLeft className="h-5 w-5" />
+                      </button>
+                    ) : null}
+                    <div className="relative flex max-h-[70vh] flex-1 items-center justify-center overflow-hidden border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-800 dark:bg-neutral-900">
+                      <img
+                        src={currentEntry.image.url ?? undefined}
+                        alt={currentEntry.image.fileName ?? "Screenshot"}
+                        className="max-h-full w-full object-contain"
+                      />
+                    </div>
+                    {flattenedImages.length > 1 ? (
+                      <button
+                        type="button"
+                        onClick={goNext}
+                        className="flex h-11 w-11 items-center justify-center rounded-full border border-neutral-300 bg-neutral-50 text-neutral-700 shadow transition hover:border-neutral-400 hover:bg-neutral-200 hover:text-neutral-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
+                        aria-label="Next screenshot"
+                      >
+                        <ChevronRight className="h-5 w-5" />
+                      </button>
                     ) : null}
                   </div>
                   <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">

--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -31,14 +31,6 @@ interface RunScreenshotGalleryProps {
   highlightedSetId?: Id<"taskRunScreenshotSets"> | null;
 }
 
-function makeImageKey(
-  setId: Id<"taskRunScreenshotSets">,
-  image: ScreenshotImage,
-  indexInSet: number,
-) {
-  return `${setId}:${image.storageId}:${indexInSet}`;
-}
-
 const STATUS_LABELS: Record<ScreenshotStatus, string> = {
   completed: "Completed",
   failed: "Failed",
@@ -83,7 +75,7 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
           set,
           image,
           indexInSet,
-          key: makeImageKey(set._id, image, indexInSet),
+          key: image.url as string,
           globalIndex: entries.length,
         });
       });
@@ -326,18 +318,19 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
                   {set.images.length > 0 ? (
                 <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
                   {set.images.map((image, indexInSet) => {
-                    const imageKey = makeImageKey(set._id, image, indexInSet);
                     const displayName = image.fileName ?? "Screenshot";
                     if (!image.url) {
+                      const placeholderKey = `${set._id}:${image.storageId}:${indexInSet}`;
                       return (
                         <div
-                          key={imageKey}
+                          key={placeholderKey}
                           className="flex h-48 min-w-[200px] items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-100 text-xs text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400"
                         >
                           URL expired
                         </div>
                       );
                     }
+                    const imageKey = image.url;
                     const flatIndex = globalIndexByKey.get(imageKey) ?? -1;
                     const humanIndex = flatIndex >= 0 ? flatIndex + 1 : null;
 

--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -203,11 +203,11 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
                         <ChevronLeft className="h-5 w-5" />
                       </button>
                     ) : null}
-                    <div className="relative flex max-h-[70vh] flex-1 items-center justify-center overflow-hidden border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-800 dark:bg-neutral-900">
+                    <div className="relative flex max-h-[70vh] flex-1 items-center justify-center border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900">
                       <img
                         src={currentEntry.image.url ?? undefined}
                         alt={currentEntry.image.fileName ?? "Screenshot"}
-                        className="max-h-full w-full object-contain"
+                        className="max-h-[calc(70vh-2rem)] max-w-full object-contain"
                       />
                     </div>
                     {flattenedImages.length > 1 ? (


### PR DESCRIPTION
make the images in the screenshots of the git diff viewer in the view of a slideshow rather than linking to somewhere external site. we want to click on one and use the arrow keys to go between them on the electron app itself instead...