### PR TITLE
First-time onboarding for cloud repos

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -642,6 +642,17 @@ function DashboardComponent() {
     return selectedProject[0];
   }, [selectedProject, isEnvSelected]);
 
+  const selectedRepoInfo = useMemo(() => {
+    if (!selectedRepoFullName) return null;
+    for (const repos of Object.values(reposByOrg || {})) {
+      const match = repos.find((repo) => repo.fullName === selectedRepoFullName);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }, [selectedRepoFullName, reposByOrg]);
+
   const shouldShowCloudRepoOnboarding =
     !!selectedRepoFullName && isCloudMode && !isEnvSelected;
 
@@ -652,12 +663,15 @@ function DashboardComponent() {
             step: "select" as const,
             selectedRepos: [selectedRepoFullName],
             instanceId: undefined,
-            connectionLogin: undefined,
+            connectionLogin:
+              selectedRepoInfo?.org ??
+              selectedRepoInfo?.ownerLogin ??
+              undefined,
             repoSearch: undefined,
             snapshotId: undefined,
           })
         : undefined,
-    [selectedRepoFullName],
+    [selectedRepoFullName, selectedRepoInfo],
   );
 
   const handleStartEnvironmentSetup = useCallback(() => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -25,7 +25,7 @@ import { branchesQueryOptions } from "@/queries/branches";
 import { clearEnvironmentDraft } from "@/state/environment-draft-store";
 import { api } from "@cmux/convex/api";
 import type { Doc, Id } from "@cmux/convex/dataModel";
-import type { ProviderStatusResponse, TaskAcknowledged, TaskError, TaskStarted } from "@cmux/shared";
+import type { MorphSnapshotId, ProviderStatusResponse, TaskAcknowledged, TaskError, TaskStarted } from "@cmux/shared";
 import { AGENT_CONFIGS } from "@cmux/shared/agentConfig";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
@@ -39,6 +39,15 @@ import { z } from "zod";
 export const Route = createFileRoute("/_layout/$teamSlugOrId/dashboard")({
   component: DashboardComponent,
 });
+
+type EnvironmentNewSearchParams = {
+  step: "select" | "configure" | undefined;
+  selectedRepos: string[] | undefined;
+  instanceId: string | undefined;
+  connectionLogin: string | undefined;
+  repoSearch: string | undefined;
+  snapshotId: MorphSnapshotId | undefined;
+};
 
 // Default agents (not persisted to localStorage)
 const DEFAULT_AGENTS = [
@@ -656,20 +665,20 @@ function DashboardComponent() {
   const shouldShowCloudRepoOnboarding =
     !!selectedRepoFullName && isCloudMode && !isEnvSelected;
 
-  const createEnvironmentSearch = useMemo(
+  const createEnvironmentSearch = useMemo<
+    EnvironmentNewSearchParams | undefined
+  >(
     () =>
       selectedRepoFullName
-        ? ({
-            step: "select" as const,
+        ? {
+            step: "select",
             selectedRepos: [selectedRepoFullName],
             instanceId: undefined,
             connectionLogin:
-              selectedRepoInfo?.org ??
-              selectedRepoInfo?.ownerLogin ??
-              undefined,
+              selectedRepoInfo?.org ?? selectedRepoInfo?.ownerLogin ?? undefined,
             repoSearch: undefined,
             snapshotId: undefined,
-          })
+          }
         : undefined,
     [selectedRepoFullName, selectedRepoInfo],
   );


### PR DESCRIPTION
when a user is using a repo is cloud mode, we should have an onboarding thing that alerts the user about the existence of environments to set up their env variables and setup scripts... we should have a way to handhold them in this manner (only do it the first time they use cloud mode with repos though) only do it for the first time the user is using that repo (and only do it if the user did not set up the environment with that repo)