### PR TITLE
Surface startup errors; handle morph failures; run crown eval

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -524,6 +524,12 @@ function DashboardComponent() {
       console.log("Task created:", taskId);
     } catch (error) {
       console.error("Error starting task:", error);
+      // Surface error to user instead of silently failing
+      toast.error(
+        `Failed to start task: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   }, [
     selectedProject,

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -68,6 +68,9 @@ export async function spawnAgent(
   },
   teamSlugOrId: string
 ): Promise<AgentSpawnResult> {
+  // Declare taskRunId outside try block so it's accessible in catch
+  let taskRunId: Id<"taskRuns"> | string = "";
+
   try {
     // Capture the current auth token and header JSON from AsyncLocalStorage so we can
     // re-enter the auth context inside async event handlers later.
@@ -84,7 +87,7 @@ export async function spawnAgent(
     );
 
     // Create a task run for this specific agent
-    const { taskRunId, jwt: taskRunJwt } = await getConvex().mutation(
+    const taskRunResult = await getConvex().mutation(
       api.taskRuns.create,
       {
         teamSlugOrId,
@@ -95,6 +98,8 @@ export async function spawnAgent(
         environmentId: options.environmentId,
       }
     );
+    taskRunId = taskRunResult.taskRunId;
+    const taskRunJwt = taskRunResult.jwt;
 
     // Fetch the task to get image storage IDs
     const task = await getConvex().query(api.tasks.getById, {
@@ -445,14 +450,31 @@ export async function spawnAgent(
 
     if (options.isCloudMode && vscodeInstance instanceof CmuxVSCodeInstance) {
       console.log("[AgentSpawner] [isCloudMode] Setting up devcontainer");
+      // Run devcontainer setup in background but log errors prominently
       void vscodeInstance
         .setupDevcontainer()
-        .catch((err) =>
+        .catch(async (err) => {
           serverLogger.error(
-            "[AgentSpawner] setupDevcontainer encountered an error",
+            `[AgentSpawner] setupDevcontainer failed for agent ${agent.name}. This may cause networking issues.`,
             err
-          )
-        );
+          );
+          // Update taskRun with a warning about devcontainer setup failure
+          try {
+            await getConvex().mutation(api.taskRuns.updateStatus, {
+              teamSlugOrId,
+              id: taskRunId as Id<"taskRuns">,
+              status: "running",
+              metadata: {
+                warning: "Devcontainer setup failed - networking may be affected",
+              },
+            });
+          } catch (convexError) {
+            serverLogger.error(
+              "Failed to update taskRun with devcontainer warning:",
+              convexError
+            );
+          }
+        });
     }
 
     // Start file watching for real-time diff updates
@@ -922,14 +944,33 @@ exit $EXIT_CODE
       success: true,
     };
   } catch (error) {
-    serverLogger.error("Error spawning agent", error);
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    serverLogger.error(`Error spawning agent ${agent.name}:`, error);
+
+    // If taskRunId was created before the error, mark it as failed in Convex
+    if (taskRunId) {
+      try {
+        await getConvex().mutation(api.taskRuns.fail, {
+          teamSlugOrId,
+          id: taskRunId as Id<"taskRuns">,
+          error: errorMessage,
+        });
+        serverLogger.info(`Marked taskRun ${taskRunId} as failed in Convex`);
+      } catch (convexError) {
+        serverLogger.error(
+          `Failed to mark taskRun ${taskRunId} as failed in Convex:`,
+          convexError
+        );
+      }
+    }
+
     return {
       agentName: agent.name,
       terminalId: "",
-      taskRunId: "",
+      taskRunId: taskRunId as string,
       worktreePath: "",
       success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
+      error: errorMessage,
     };
   }
 }

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -479,6 +479,7 @@ export function setupSocketHandlers(
                 `[Server] Failed generating/saving early PR title:`,
                 e
               );
+              // Non-fatal - continue with agent spawning
             }
 
             // Spawn all agents in parallel (each will create its own taskRun)
@@ -511,6 +512,23 @@ export function setupSocketHandlers(
                 `Failed to spawn any agents for task ${taskId}:`,
                 errors
               );
+
+              // Mark all failed taskRuns in Convex
+              for (const result of agentResults.filter(r => !r.success && r.taskRunId)) {
+                try {
+                  await getConvex().mutation(api.taskRuns.fail, {
+                    teamSlugOrId: safeTeam,
+                    id: result.taskRunId,
+                    error: result.error || "Failed to spawn agent",
+                  });
+                } catch (convexError) {
+                  serverLogger.error(
+                    `Failed to mark taskRun ${result.taskRunId} as failed in Convex:`,
+                    convexError
+                  );
+                }
+              }
+
               rt.emit("task-failed", {
                 taskId,
                 error: errors || "Failed to spawn any agents",

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -322,11 +322,31 @@ sandboxesRouter.openapi(
             taskRunJwt: body.taskRunJwt || undefined,
             isCloudWorkspace,
           });
-        })().catch((error) => {
+        })().catch(async (error) => {
           console.error(
             "[sandboxes.start] Background script execution failed:",
             error,
           );
+          // If we have a taskRunJwt, try to report this failure to Convex
+          if (body.taskRunJwt && body.taskRunId) {
+            try {
+              await getConvex().mutation(api.taskRuns.updateStatus, {
+                teamSlugOrId: body.teamSlugOrId,
+                id: body.taskRunId,
+                status: "running",
+                metadata: {
+                  warning: `Background script execution failed: ${
+                    error instanceof Error ? error.message : "Unknown error"
+                  }`,
+                },
+              });
+            } catch (convexError) {
+              console.error(
+                "[sandboxes.start] Failed to report script failure to Convex:",
+                convexError,
+              );
+            }
+          }
         });
       }
 

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -668,14 +668,19 @@ export const checkAndEvaluateCrown = authMutation({
     if (taskRuns.length === 1) {
       console.log(`[CheckCrown] Single agent scenario - marking task complete`);
 
-      // Mark the task as completed
+      const singleRun = taskRuns[0];
+
+      // Mark the task as completed (success or failure)
       await ctx.db.patch(args.taskId, {
         isCompleted: true,
+        crownEvaluationStatus:
+          singleRun.status === "failed" ? "skipped" : undefined,
+        crownEvaluationError:
+          singleRun.status === "failed" ? "Single task run failed" : undefined,
         updatedAt: Date.now(),
       });
 
       // If the single run was successful, return it as the "winner" for potential auto-PR
-      const singleRun = taskRuns[0];
       if (singleRun.status === "completed") {
         console.log(
           `[CheckCrown] Single agent completed successfully: ${singleRun._id}`,
@@ -683,6 +688,7 @@ export const checkAndEvaluateCrown = authMutation({
         return singleRun._id;
       }
 
+      console.log(`[CheckCrown] Single agent failed: ${singleRun._id}`);
       return null;
     }
 
@@ -724,11 +730,44 @@ export const checkAndEvaluateCrown = authMutation({
     );
 
     // Only evaluate if we have at least 2 completed runs
+    // But also check if all runs failed - in that case mark task as complete without crown
     const completedRuns = taskRuns.filter((run) => run.status === "completed");
+    const failedRuns = taskRuns.filter((run) => run.status === "failed");
+
     if (completedRuns.length < 2) {
       console.log(
         `[CheckCrown] Not enough completed runs (${completedRuns.length} < 2)`,
       );
+
+      // If all runs are done (completed or failed), mark task as completed
+      if (completedRuns.length === 0 && failedRuns.length === taskRuns.length) {
+        // All runs failed
+        console.log(
+          `[CheckCrown] All ${failedRuns.length} runs failed - marking task as completed without crown`,
+        );
+        await ctx.db.patch(args.taskId, {
+          isCompleted: true,
+          crownEvaluationStatus: "skipped",
+          crownEvaluationError: "All task runs failed",
+          updatedAt: Date.now(),
+        });
+      } else if (completedRuns.length === 1 && taskRuns.length >= 2) {
+        // Only 1 completed, rest failed - crown the single successful one
+        console.log(
+          `[CheckCrown] Only 1 completed run out of ${taskRuns.length} - crowning the successful one`,
+        );
+        await ctx.db.patch(completedRuns[0]._id, {
+          isCrowned: true,
+          crownReason: "Only one model successfully completed the task",
+        });
+        await ctx.db.patch(args.taskId, {
+          isCompleted: true,
+          crownEvaluationStatus: "completed",
+          updatedAt: Date.now(),
+        });
+        return completedRuns[0]._id;
+      }
+
       return null;
     }
 


### PR DESCRIPTION
implement better error handling for tasks that fail to start somehow. have better error handling/surfacing in the entire flow starting from when user presses "Star task" and it goes through server etc... if we have any suppressed try/catch then we need to fix it to surface it to the user. if morph fails, then we need to update convex taskruns state to indicate that it failed. and crown evaluation stuff needs to kick off even if some tasks have ultimately failed.