### PR TITLE
Fix CI build failure due to SIGKILL

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -394,7 +394,7 @@ jobs:
         working-directory: apps/server/native/core
         shell: bash
         env:
-          CARGO_BUILD_JOBS: 2
+          CARGO_BUILD_JOBS: 3
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: |
           set -euo pipefail

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -246,6 +246,12 @@ jobs:
           toolchain: stable
           profile: minimal
           targets: aarch64-apple-darwin
+      - name: Clean Rust build artifacts
+        working-directory: apps/server/native/core
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf target || true
       - name: Install dependencies (bun)
         run: bun install --frozen-lockfile
       - name: Install app deps in apps/client (bun)
@@ -264,6 +270,9 @@ jobs:
       - name: Build native Rust addon
         working-directory: apps/server/native/core
         shell: bash
+        env:
+          CARGO_BUILD_JOBS: 2
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: bunx --bun @napi-rs/cli build --platform --release
       - name: Build, sign, and notarize (arm64) via publish script
         env:
@@ -372,17 +381,21 @@ jobs:
           NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
           EOF
 
-      - name: Remove stale macOS native binaries
+      - name: Clean Rust build artifacts
         working-directory: apps/server/native/core
         shell: bash
         run: |
           set -euo pipefail
+          rm -rf target || true
           rm -f cmux_native_core.darwin-*.node
 
       # Prebuild the Rust N-API addon for both slices so electron-builder can pick them up.
       - name: Build native Rust addon (arm64 + x64)
         working-directory: apps/server/native/core
         shell: bash
+        env:
+          CARGO_BUILD_JOBS: 2
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: |
           set -euo pipefail
           rustup target add x86_64-apple-darwin aarch64-apple-darwin || true

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -271,7 +271,7 @@ jobs:
         working-directory: apps/server/native/core
         shell: bash
         env:
-          CARGO_BUILD_JOBS: 2
+          CARGO_BUILD_JOBS: 3
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: bunx --bun @napi-rs/cli build --platform --release
       - name: Build, sign, and notarize (arm64) via publish script

--- a/apps/server/native/core/.cargo/config.toml
+++ b/apps/server/native/core/.cargo/config.toml
@@ -1,3 +1,7 @@
+[build]
+# Limit parallel jobs to reduce memory pressure on CI runners
+jobs = 2
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
 

--- a/apps/server/native/core/.cargo/config.toml
+++ b/apps/server/native/core/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
 # Limit parallel jobs to reduce memory pressure on CI runners
-jobs = 2
+jobs = 3
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]


### PR DESCRIPTION
we keep getting this issue from @.github/workflows/release-updates.yml Caused by:
  process didn't exit successfully: `/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/server/native/core/target/release/build/getrandom-ae03af96b4d2a5ff/build-script-build` (signal: 9, SIGKILL: kill)warning: build failed, waiting for other jobs to finish...Internal Error: Build failed with exit code 101    at <anonymous> (/private/tmp/bunx-501-@napi-rs/cli@latest/node_modules/@napi-rs/cli/dist/cli.js:1436:40)    at emit (node:events:98:22)    at #handleOnExit (node:child_process:520:14)    at processTicksAndRejections (native:7:39)Error: Process completed with exit code 1.