### PR TITLE
Make diff header filenames semibold sans

### DIFF
--- a/apps/client/src/components/file-diff-header.tsx
+++ b/apps/client/src/components/file-diff-header.tsx
@@ -67,10 +67,10 @@ export function FileDiffHeader({
       onClick={onToggle}
       className={cn(
         "w-full pl-3 pr-2.5 py-1.5 flex items-center hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-y border-neutral-200 dark:border-neutral-800 sticky z-[var(--z-sticky-low)]",
-        className,
+        className
       )}
     >
-      <div className="flex items-center" style={{ width: '20px' }}>
+      <div className="flex items-center" style={{ width: "20px" }}>
         <div className="text-neutral-400 dark:text-neutral-500 group-hover:text-neutral-600 dark:group-hover:text-neutral-400">
           {isExpanded ? (
             <ChevronDown className="w-3.5 h-3.5" />
@@ -79,18 +79,18 @@ export function FileDiffHeader({
           )}
         </div>
       </div>
-      <div className="flex items-center" style={{ width: '20px' }}>
+      <div className="flex items-center" style={{ width: "20px" }}>
         <div className={cn("flex-shrink-0", getStatusColor(status))}>
           {getStatusIcon(status)}
         </div>
       </div>
-      <div className="flex-1 min-w-0 flex items-start justify-between gap-3">
+      <div className="flex-1 min-w-0 flex items-center justify-between gap-3">
         <div className="min-w-0 flex flex-col">
-          <span className="font-sans font-semibold text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
+          <span className="font-sans font-medium text-[13px] text-neutral-700 dark:text-neutral-300 truncate select-none">
             {filePath}
           </span>
           {status === "renamed" && oldPath ? (
-            <span className="font-sans text-[10px] text-neutral-500 dark:text-neutral-400 truncate select-none">
+            <span className="font-sans text-[11px] font-medium text-neutral-500 dark:text-neutral-400 truncate select-none">
               Renamed from {oldPath}
             </span>
           ) : null}

--- a/apps/client/src/components/file-diff-header.tsx
+++ b/apps/client/src/components/file-diff-header.tsx
@@ -86,11 +86,11 @@ export function FileDiffHeader({
       </div>
       <div className="flex-1 min-w-0 flex items-start justify-between gap-3">
         <div className="min-w-0 flex flex-col">
-          <span className="font-mono text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
+          <span className="font-sans font-semibold text-xs text-neutral-700 dark:text-neutral-300 truncate select-none">
             {filePath}
           </span>
           {status === "renamed" && oldPath ? (
-            <span className="font-mono text-[10px] text-neutral-500 dark:text-neutral-400 truncate select-none">
+            <span className="font-sans text-[10px] text-neutral-500 dark:text-neutral-400 truncate select-none">
               Renamed from {oldPath}
             </span>
           ) : null}


### PR DESCRIPTION
for the filenames in the diff viewer (like monaco, codemirror), make the header/filename semibold and font-sans (not mono)