### PR TITLE
Add left-side dismiss button to environment setup

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -123,6 +123,8 @@ function DashboardComponent() {
     const stored = localStorage.getItem("isCloudMode");
     return stored ? JSON.parse(stored) : true;
   });
+  const [hasDismissedCloudRepoOnboarding, setHasDismissedCloudRepoOnboarding] =
+    useState(false);
 
   const [, setDockerReady] = useState<boolean | null>(null);
   const [providerStatus, setProviderStatus] =
@@ -651,6 +653,10 @@ function DashboardComponent() {
     return selectedProject[0];
   }, [selectedProject, isEnvSelected]);
 
+  useEffect(() => {
+    setHasDismissedCloudRepoOnboarding(false);
+  }, [selectedRepoFullName]);
+
   const selectedRepoInfo = useMemo(() => {
     if (!selectedRepoFullName) return null;
     for (const repos of Object.values(reposByOrg || {})) {
@@ -663,7 +669,10 @@ function DashboardComponent() {
   }, [selectedRepoFullName, reposByOrg]);
 
   const shouldShowCloudRepoOnboarding =
-    !!selectedRepoFullName && isCloudMode && !isEnvSelected;
+    !!selectedRepoFullName &&
+    isCloudMode &&
+    !isEnvSelected &&
+    !hasDismissedCloudRepoOnboarding;
 
   const createEnvironmentSearch = useMemo<
     EnvironmentNewSearchParams | undefined
@@ -908,6 +917,13 @@ function DashboardComponent() {
                     Environments let you preconfigure development and maintenance scripts, pre-install packages, and environment variables so cloud workspaces are ready to go the moment they start.
                   </p>
                   <div className="flex gap-2 justify-end">
+                    <button
+                      type="button"
+                      onClick={() => setHasDismissedCloudRepoOnboarding(true)}
+                      className="inline-flex items-center rounded-md border border-blue-200/60 bg-white/80 px-2 py-1 text-xs font-medium text-blue-900/70 hover:bg-white dark:border-blue-500/30 dark:bg-blue-500/5 dark:text-blue-100/80 dark:hover:bg-blue-500/15"
+                    >
+                      Dismiss
+                    </button>
                     <Link
                       to="/$teamSlugOrId/environments/new"
                       params={{ teamSlugOrId }}


### PR DESCRIPTION
add a dismiss button for the set up an environment dialog that occurs in cloud repos... it should be right to the left of create environment and should be a dismiss button, make it in good taste, maybe not the same color