### PR TITLE
Show toast on open PR with button

### DIFF
--- a/apps/client/src/components/task-detail-header.tsx
+++ b/apps/client/src/components/task-detail-header.tsx
@@ -703,11 +703,11 @@ function SocketActions({
     },
     onSuccess: (response, _variables, context) => {
       const actionable = response.results.filter(
-        (result) => result.url && !result.error,
+        (result) =>
+          !result.error &&
+          Boolean(result.repoFullName?.trim()) &&
+          Boolean(result.number),
       );
-      if (actionable.length > 0) {
-        navigateToPrs(actionable);
-      }
       toast.success(openedLabel, {
         id: context?.toastId,
         description: summarizeResults(response.results),


### PR DESCRIPTION
after pressing open PR, we shouldn't navigate to the PR page, but we should show a toast (we might already show one) and the toast should have a button that will take us to the PR page.