### PR TITLE
Enable header double-click to maximize panels

### DIFF
--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -379,11 +379,6 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
-      onDoubleClick={() => {
-        if (onToggleExpand) {
-          onToggleExpand(position);
-        }
-      }}
     >
       {renderDropOverlay()}
       <div
@@ -448,11 +443,6 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          onDoubleClick={() => {
-            if (onToggleExpand) {
-              onToggleExpand(position);
-            }
-          }}
         >
           {renderDropOverlay()}
           <TaskRunChatPane


### PR DESCRIPTION
for the panels page, we need to double click the header to maximize it. double clicking the body should NOT maximize it.