### PR TITLE
Add staging build script for cmux-staging

### DIFF
--- a/apps/client/build-mac-workaround.sh
+++ b/apps/client/build-mac-workaround.sh
@@ -220,5 +220,19 @@ mv "$APP_DIR" "$OUTPUT_DIR/"
 # Clean up
 rm -rf "$TEMP_DIR"
 
-echo "Build complete! App is at $(pwd)/$OUTPUT_DIR/$APP_NAME.app"
-echo "You can run it with: open $(pwd)/$OUTPUT_DIR/$APP_NAME.app"
+APP_PATH="$(pwd)/$OUTPUT_DIR/$APP_NAME.app"
+echo "Build complete! App is at $APP_PATH"
+
+if [[ "$APP_NAME" == "cmux-staging" ]]; then
+  echo "Stopping any running cmux-staging instances before launching the new build..."
+  pkill -f "cmux-staging" >/dev/null 2>&1 || true
+fi
+
+if command -v open >/dev/null 2>&1; then
+  echo "Opening $APP_PATH"
+  if ! open "$APP_PATH"; then
+    echo "WARNING: Failed to open $APP_PATH" >&2
+  fi
+else
+  echo "Skipping automatic open: open command is unavailable."
+fi

--- a/apps/client/build-mac-workaround.sh
+++ b/apps/client/build-mac-workaround.sh
@@ -82,7 +82,7 @@ bunx electron-vite build -c electron.vite.config.ts
 
 # Create a temporary directory for packaging
 TEMP_DIR=$(mktemp -d)
-APP_NAME="cmux"
+APP_NAME="${CMUX_APP_NAME:-cmux}"
 APP_DIR="$TEMP_DIR/$APP_NAME.app"
 APP_VERSION=$(node -e "const fs = require('node:fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); if (!pkg.version) { process.exit(1); } process.stdout.write(String(pkg.version));")
 if [ -z "$APP_VERSION" ]; then

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -5,9 +5,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLIENT_DIR="$ROOT_DIR/apps/client"
 
-ENV_FILE="$ROOT_DIR/.env.production"
-if [[ ! -f "$ENV_FILE" ]]; then
-  echo "ERROR: Expected $ENV_FILE to exist so staging uses production env vars." >&2
+ENV_FILE=""
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  ENV_FILE="$ROOT_DIR/.env"
+elif [[ -f "$ROOT_DIR/.env.production" ]]; then
+  ENV_FILE="$ROOT_DIR/.env.production"
+else
+  echo "ERROR: Expected either $ROOT_DIR/.env or $ROOT_DIR/.env.production to exist so staging uses env vars." >&2
   exit 1
 fi
 

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLIENT_DIR="$ROOT_DIR/apps/client"
+
+ENV_FILE="$ROOT_DIR/.env.production"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: Expected $ENV_FILE to exist so staging uses production env vars." >&2
+  exit 1
+fi
+
+echo "==> Building cmux-staging with env file: $ENV_FILE"
+(cd "$CLIENT_DIR" && CMUX_APP_NAME="cmux-staging" bun run --env-file "$ENV_FILE" build:mac:workaround)


### PR DESCRIPTION
make ./scripts/staging.sh that will make a "production" electron build but the name of the app will be cmux-staging, but it should still use the .env.production env variables.