### PR TITLE
Increase diff viewer modal size and enable zoom

### DIFF
--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -541,7 +541,7 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
                   {hasMultipleImages ? (
                     <div className="space-y-2">
                       <div className="flex items-center justify-between text-xs font-medium text-neutral-500 dark:text-neutral-400">
-                        <span>All screenshots</span>
+                        <span className="sr-only">All screenshots</span>
                         <span className="tabular-nums text-neutral-600 dark:text-neutral-300">
                           {activeOverallIndex ?? "–"} / {flattenedImages.length}
                         </span>


### PR DESCRIPTION
for screenshots in the diff viewer page, we should make the dialog/modal a lot bigger. dont blur the background. support zooming in/out when user uses the mouse wheel or touchpad, make it feel very intuitive. it should take up most of the screen as well. if the user clicks outside the dialog, we should close the dialog.