### PR TITLE
Gracefully restart cmux-staging before staging build

### DIFF
--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -4,6 +4,64 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLIENT_DIR="$ROOT_DIR/apps/client"
+APP_PROCESS_PATTERN="cmux-staging"
+APP_BUNDLE_ID="com.cmux.app"
+
+wait_for_process_exit() {
+  local pattern="$1"
+  local timeout="${2:-10}"
+  local deadline=$((SECONDS + timeout))
+
+  while pgrep -f "$pattern" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      return 1
+    fi
+    sleep 0.5
+  done
+
+  return 0
+}
+
+stop_staging_app_instances() {
+  local pattern="$1"
+  local bundle_id="$2"
+
+  if ! pgrep -f "$pattern" >/dev/null 2>&1; then
+    echo "==> No running $pattern instances detected."
+    return 0
+  fi
+
+  echo "==> Attempting graceful shutdown for existing $pattern..."
+  local graceful_shutdown=0
+  if command -v osascript >/dev/null 2>&1; then
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
+      if wait_for_process_exit "$pattern" 5; then
+        echo "==> $pattern exited after AppleScript quit request."
+        graceful_shutdown=1
+      fi
+    fi
+  fi
+
+  if (( graceful_shutdown == 0 )); then
+    echo "==> Sending SIGTERM to $pattern..."
+    pkill -TERM -f "$pattern" >/dev/null 2>&1 || true
+    if wait_for_process_exit "$pattern" 10; then
+      echo "==> $pattern terminated after SIGTERM."
+      graceful_shutdown=1
+    fi
+  fi
+
+  if (( graceful_shutdown == 0 )); then
+    echo "==> Forcing SIGKILL for remaining $pattern processes..." >&2
+    pkill -KILL -f "$pattern" >/dev/null 2>&1 || true
+    if ! wait_for_process_exit "$pattern" 5; then
+      echo "WARNING: $pattern processes still running after SIGKILL." >&2
+      return 1
+    fi
+  fi
+
+  return 0
+}
 
 ENV_FILE=""
 if [[ -f "$ROOT_DIR/.env" ]]; then
@@ -14,6 +72,8 @@ else
   echo "ERROR: Expected either $ROOT_DIR/.env or $ROOT_DIR/.env.production to exist so staging uses env vars." >&2
   exit 1
 fi
+
+stop_staging_app_instances "$APP_PROCESS_PATTERN" "$APP_BUNDLE_ID"
 
 echo "==> Building cmux-staging with env file: $ENV_FILE"
 (cd "$CLIENT_DIR" && CMUX_APP_NAME="cmux-staging" bun run --env-file "$ENV_FILE" build:mac:workaround)


### PR DESCRIPTION
## Summary
- add graceful shutdown helpers to scripts/staging.sh so existing cmux-staging instances quit before rebuilding
- ensure we wait between osascript, SIGTERM, and SIGKILL so renderer/GPU processes are gone before relaunch

## Testing
- PATH="/Users/lawrencechen/.bun/bin:/Users/lawrencechen/Library/Application Support/edgedb/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/usr/local/share/dotnet:~/.dotnet/tools:/Users/lawrencechen/.cargo/bin:/var/folders/_7/1q5mz8f11fz39jq6hj395wzm0000gn/T/.tmpePUEXP:/Users/lawrencechen/.vscode/cli/serve-web/7d842fb85a0275a4a8e4d7e040d2625abbf7f084/bin/remote-cli:/Users/lawrencechen/.vscode-server/extensions/openai.chatgpt-0.4.37-darwin-arm64/bin/macos-aarch64:/Users/lawrencechen/cs61b-software/bin:/Users/lawrencechen/.orbstack/bin:/Users/lawrencechen/.local/bin" bun run check # fails: missing CMUX_GITHUB_APP_ID, CMUX_GITHUB_APP_PRIVATE_KEY, ANTHROPIC_API_KEY