### PR TITLE
Enable es2022 lib to support Array.at

### DIFF
--- a/packages/shared/src/utils/morph-instance.ts
+++ b/packages/shared/src/utils/morph-instance.ts
@@ -86,8 +86,8 @@ function parseCmuxProxyHost(hostname: string): MorphInstanceInfo | null {
         return null;
       }
 
-      const portSegment = segments.at(-1);
-      const rawMorphId = segments.at(0);
+      const portSegment = segments[segments.length - 1];
+      const rawMorphId = segments[0];
       if (!portSegment || !rawMorphId) {
         return null;
       }


### PR DESCRIPTION
$ bun run scripts/check.ts❌ Typecheck failures:- @cmux/convex  ../shared/src/utils/morph-instance.ts(89,36): error TS2550: Property 'at' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.  ../shared/src/utils/morph-instance.ts(90,35): error TS2550: Property 'at' does not exist on type 'string[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.try to reproduce the above and then fix it