### PR TITLE
Make archive button hover-only; respect focus-visible

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -59,6 +59,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type FocusEvent,
   type MouseEvent,
   type ReactElement,
   type ReactNode,
@@ -117,15 +118,12 @@ function SidebarArchiveOverlay({
 }: SidebarArchiveOverlayProps) {
   return (
     <div className="relative flex h-4 w-4 items-center justify-center">
-      <div className="flex items-center justify-center group-hover:pointer-events-none group-hover:opacity-0 group-focus-within:pointer-events-none group-focus-within:opacity-0">
-        {icon}
-      </div>
       <Tooltip delayDuration={0}>
         <TooltipTrigger asChild>
           <button
             type="button"
             aria-label={label}
-            className="absolute inset-0 flex items-center justify-center rounded-sm text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-50 opacity-0 focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 pointer-events-none group-hover:pointer-events-auto group-focus-within:pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-400 dark:focus-visible:outline-neutral-500"
+            className="peer absolute inset-0 flex items-center justify-center rounded-sm text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-50 opacity-0 pointer-events-none focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:opacity-100 group-hover:pointer-events-auto group-data-[focus-visible=true]:opacity-100 group-data-[focus-visible=true]:pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-400 dark:focus-visible:outline-neutral-500"
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -137,6 +135,9 @@ function SidebarArchiveOverlay({
         </TooltipTrigger>
         <TooltipContent side="right">{label}</TooltipContent>
       </Tooltip>
+      <div className="flex items-center justify-center group-hover:pointer-events-none group-hover:opacity-0 group-data-[focus-visible=true]:pointer-events-none group-data-[focus-visible=true]:opacity-0 peer-focus-visible:pointer-events-none peer-focus-visible:opacity-0">
+        {icon}
+      </div>
     </div>
   );
 }
@@ -449,6 +450,17 @@ function TaskTreeInner({
   const handlePrefetch = useCallback(() => {
     prefetchTaskRuns();
   }, [prefetchTaskRuns]);
+  const [isTaskLinkFocusVisible, setIsTaskLinkFocusVisible] = useState(false);
+  const handleTaskLinkFocus = useCallback(
+    (event: FocusEvent<HTMLAnchorElement>) => {
+      handlePrefetch();
+      setIsTaskLinkFocusVisible(event.currentTarget.matches(":focus-visible"));
+    },
+    [handlePrefetch]
+  );
+  const handleTaskLinkBlur = useCallback(() => {
+    setIsTaskLinkFocusVisible(false);
+  }, []);
 
   const { archiveWithUndo, unarchive } = useArchiveTask(teamSlugOrId);
 
@@ -660,8 +672,10 @@ function TaskTreeInner({
               search={{ runId: undefined }}
               activeOptions={{ exact: true }}
               className="group block"
+              data-focus-visible={isTaskLinkFocusVisible ? "true" : undefined}
               onMouseEnter={handlePrefetch}
-              onFocus={handlePrefetch}
+              onFocus={handleTaskLinkFocus}
+              onBlur={handleTaskLinkBlur}
               onClick={(event) => {
                 if (
                   event.defaultPrevented ||
@@ -1258,6 +1272,16 @@ function TaskRunTreeInner({
     shouldRenderTerminalLink ||
     shouldRenderPullRequestLink ||
     shouldRenderPreviewLink;
+  const [isRunLinkFocusVisible, setIsRunLinkFocusVisible] = useState(false);
+  const handleRunLinkFocus = useCallback(
+    (event: FocusEvent<HTMLAnchorElement>) => {
+      setIsRunLinkFocusVisible(event.currentTarget.matches(":focus-visible"));
+    },
+    []
+  );
+  const handleRunLinkBlur = useCallback(() => {
+    setIsRunLinkFocusVisible(false);
+  }, []);
 
   return (
     <div className={clsx({ hidden: run.isArchived })}>
@@ -1274,7 +1298,10 @@ function TaskRunTreeInner({
               runId: run._id,
             })}
             className="group block"
+            data-focus-visible={isRunLinkFocusVisible ? "true" : undefined}
             activeOptions={{ exact: false }}
+            onFocus={handleRunLinkFocus}
+            onBlur={handleRunLinkBlur}
             onClick={(event) => {
               if (
                 event.defaultPrevented ||


### PR DESCRIPTION
when focused on a taskrun, the archive button is currently default visible, make it so that it is only visible on user hover. currently, when focused, the archive button is still visible. though on focus-visible, it should still be visible, ie if user is using keyboard shortcuts. just not on mouse focus.