### PR TITLE
Investigate and fix sticky filenames in diff panels

### DIFF
--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -625,7 +625,7 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
       return panelWrapper(
         <GitCompare className="size-3" aria-hidden />,
         PANEL_LABELS.gitDiff,
-        <div className="flex-1 overflow-auto">
+        <div className="relative flex-1 min-h-0 overflow-auto">
           <TaskRunGitDiffPanel key={selectedRun?._id} task={task} selectedRun={selectedRun} />
         </div>
       );

--- a/apps/client/src/components/TaskRunGitDiffPanel.tsx
+++ b/apps/client/src/components/TaskRunGitDiffPanel.tsx
@@ -96,7 +96,7 @@ export function TaskRunGitDiffPanel({ task, selectedRun }: TaskRunGitDiffPanelPr
   }
 
   return (
-    <div className="h-full overflow-auto">
+    <div className="relative h-full min-h-0 overflow-auto">
       <MonacoGitDiffViewer diffs={allDiffs} />
     </div>
   );

--- a/apps/client/src/components/file-diff-header.tsx
+++ b/apps/client/src/components/file-diff-header.tsx
@@ -66,7 +66,7 @@ export function FileDiffHeader({
     <button
       onClick={onToggle}
       className={cn(
-        "w-full pl-3 pr-2.5 py-1.5 flex items-center hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-y border-neutral-200 dark:border-neutral-800 sticky z-[var(--z-sticky-low)]",
+        "w-full pl-3 pr-2.5 py-1.5 flex items-center hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-y border-neutral-200 dark:border-neutral-800 sticky top-0 z-[var(--z-sticky-low)]",
         className
       )}
     >


### PR DESCRIPTION
when git diff is rendered inside the panels view, we need to make sure the filenames are sticky by making sure there's a relative around the scroll container? not sure if that's the fix, I want you to figure out why the filename's not sticking to the top when I scroll down.