### PR TITLE
Surface GitHub token error with toast and connect flow

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -1,3 +1,4 @@
+import { env as clientEnv } from "@/client-env";
 import {
   DashboardInput,
   type EditorApi,
@@ -55,6 +56,11 @@ const AGENT_SELECTION_SCHEMA = z.array(z.string());
 
 const filterKnownAgents = (agents: string[]): string[] =>
   agents.filter((agent) => KNOWN_AGENT_NAMES.has(agent));
+
+type PendingPromptSnapshot = {
+  text: string;
+  imageCount: number;
+};
 
 const parseStoredAgentSelection = (stored: string | null): string[] => {
   if (!stored) {
@@ -124,6 +130,9 @@ function DashboardComponent() {
 
   // Ref to access editor API
   const editorApiRef = useRef<EditorApi | null>(null);
+  const pendingPromptSnapshotsRef = useRef<
+    Map<Id<"tasks">, PendingPromptSnapshot>
+  >(new Map());
 
   const persistAgentSelection = useCallback((agents: string[]) => {
     try {
@@ -159,6 +168,38 @@ function DashboardComponent() {
   const handleTaskDescriptionChange = useCallback((value: string) => {
     setTaskDescription(value);
   }, []);
+
+  const applyPromptSnapshot = useCallback(
+    (snapshot: PendingPromptSnapshot) => {
+      if (!snapshot.text) {
+        return;
+      }
+      requestAnimationFrame(() => {
+        editorApiRef.current?.clear?.();
+        editorApiRef.current?.insertText?.(snapshot.text);
+        setTaskDescription(snapshot.text);
+        editorApiRef.current?.focus?.();
+      });
+      if (snapshot.imageCount > 0) {
+        toast.info(
+          `Reattach the ${snapshot.imageCount} image${snapshot.imageCount > 1 ? "s" : ""} you included before retrying.`,
+        );
+      }
+    },
+    [setTaskDescription],
+  );
+
+  const restorePromptFromPending = useCallback(
+    (taskId: Id<"tasks">) => {
+      const pendingSnapshot = pendingPromptSnapshotsRef.current.get(taskId);
+      if (!pendingSnapshot) {
+        return;
+      }
+      pendingPromptSnapshotsRef.current.delete(taskId);
+      applyPromptSnapshot(pendingSnapshot);
+    },
+    [applyPromptSnapshot],
+  );
 
   // Fetch branches for selected repo from Convex
   const isEnvSelected = useMemo(
@@ -349,6 +390,57 @@ function DashboardComponent() {
   );
   const generateUploadUrl = useMutation(api.storage.generateUploadUrl);
   const addManualRepo = useAction(api.github_http.addManualRepo);
+  const mintGithubInstallState = useMutation(
+    api.github_app.mintInstallState,
+  );
+
+  const openGithubInstall = useCallback(async () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (!clientEnv.NEXT_PUBLIC_GITHUB_APP_SLUG) {
+      toast.info("Ask a team admin to connect the GitHub app in Settings.");
+      return;
+    }
+    try {
+      const { state } = await mintGithubInstallState({ teamSlugOrId });
+      const baseUrl = `https://github.com/apps/${clientEnv.NEXT_PUBLIC_GITHUB_APP_SLUG}/installations/new`;
+      const sep = baseUrl.includes("?") ? "&" : "?";
+      const targetUrl = `${baseUrl}${sep}state=${encodeURIComponent(state)}`;
+      window.open(targetUrl, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      console.error("Failed to open GitHub install page", error);
+      toast.error(
+        "Failed to open the GitHub install page. Try again from Settings.",
+      );
+    }
+  }, [mintGithubInstallState, teamSlugOrId]);
+
+  const handleTaskFailure = useCallback(
+    (taskId: Id<"tasks">, message: string, code?: string) => {
+      const normalizedMessage =
+        message || "Task failed to start. Please try again.";
+      if (code === "GITHUB_TOKEN_MISSING") {
+        restorePromptFromPending(taskId);
+        toast.error(normalizedMessage, {
+          description:
+            "Connect your GitHub account so cmux can access your repositories.",
+          action: clientEnv.NEXT_PUBLIC_GITHUB_APP_SLUG
+            ? {
+                label: "Connect GitHub",
+                onClick: () => {
+                  void openGithubInstall();
+                },
+              }
+            : undefined,
+        });
+        return;
+      }
+      pendingPromptSnapshotsRef.current.delete(taskId);
+      toast.error(`Task failed to start: ${normalizedMessage}`);
+    },
+    [openGithubInstall, restorePromptFromPending],
+  );
 
   const effectiveSelectedBranch = useMemo(() => {
     if (selectedBranch.length > 0) {
@@ -413,15 +505,23 @@ function DashboardComponent() {
     const environmentId = envSelected
       ? (projectFullName.replace(/^env:/, "") as Id<"environments">)
       : undefined;
+    const content = editorApiRef.current?.getContent();
+    const promptImages = content?.images || [];
+    const promptTextFromEditor = content?.text ?? "";
+    const promptText =
+      promptTextFromEditor.trim().length > 0
+        ? promptTextFromEditor
+        : taskDescription;
+    const promptSnapshot: PendingPromptSnapshot = {
+      text: promptText,
+      imageCount: promptImages.length,
+    };
+    let createdTaskId: Id<"tasks"> | null = null;
 
     try {
-      // Extract content including images from the editor
-      const content = editorApiRef.current?.getContent();
-      const images = content?.images || [];
-
       // Upload images to Convex storage first
       const uploadedImages = await Promise.all(
-        images.map(
+        promptImages.map(
           async (image: {
             src: string;
             fileName?: string;
@@ -466,12 +566,20 @@ function DashboardComponent() {
       // Create task in Convex with storage IDs
       const taskId = await createTask({
         teamSlugOrId,
-        text: content?.text || taskDescription, // Use content.text which includes image references
+        text: promptText, // Use content text which includes image references
         projectFullName: envSelected ? undefined : projectFullName,
         baseBranch: envSelected ? undefined : branch,
         images: uploadedImages.length > 0 ? uploadedImages : undefined,
         environmentId,
       });
+      createdTaskId = taskId;
+
+      if (
+        promptSnapshot.text.trim().length > 0 ||
+        promptSnapshot.imageCount > 0
+      ) {
+        pendingPromptSnapshotsRef.current.set(taskId, promptSnapshot);
+      }
 
       // Hint the sidebar to auto-expand this task once it appears
       addTaskToExpand(taskId);
@@ -484,16 +592,17 @@ function DashboardComponent() {
       const handleStartTaskAck = (response: TaskAcknowledged | TaskStarted | TaskError) => {
         if ("error" in response) {
           console.error("Task start error:", response.error);
-          toast.error(`Task start error: ${JSON.stringify(response.error)}`);
+          handleTaskFailure(response.taskId, response.error, response.code);
           return;
         }
 
         attachTaskLifecycleListeners(socket, response.taskId, {
           onStarted: (payload) => {
             console.log("Task started:", payload);
+            pendingPromptSnapshotsRef.current.delete(payload.taskId);
           },
           onFailed: (payload) => {
-            toast.error(`Task failed to start: ${payload.error}`);
+            handleTaskFailure(payload.taskId, payload.error, payload.code);
           },
         });
         console.log("Task acknowledged:", response);
@@ -504,14 +613,14 @@ function DashboardComponent() {
         {
           ...(repoUrl ? { repoUrl } : {}),
           ...(envSelected ? {} : { branch }),
-          taskDescription: content?.text || taskDescription, // Use content.text which includes image references
+          taskDescription: promptText, // Use content text which includes image references
           projectFullName,
           taskId,
           selectedAgents:
             selectedAgents.length > 0 ? selectedAgents : undefined,
           isCloudMode: envSelected ? true : isCloudMode,
           ...(environmentId ? { environmentId } : {}),
-          images: images.length > 0 ? images : undefined,
+          images: promptImages.length > 0 ? promptImages : undefined,
           theme,
         },
         handleStartTaskAck
@@ -519,6 +628,9 @@ function DashboardComponent() {
       console.log("Task created:", taskId);
     } catch (error) {
       console.error("Error starting task:", error);
+      if (!createdTaskId) {
+        applyPromptSnapshot(promptSnapshot);
+      }
     }
   }, [
     selectedProject,
@@ -534,6 +646,8 @@ function DashboardComponent() {
     isEnvSelected,
     theme,
     generateUploadUrl,
+    handleTaskFailure,
+    applyPromptSnapshot,
   ]);
 
   // Fetch repos on mount if none exist

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -24,6 +24,7 @@ import {
   getAuthToken,
   runWithAuth,
 } from "./utils/requestContext";
+import { GithubConnectionRequiredError } from "./errors/GithubConnectionRequiredError";
 import { getEditorSettingsUpload } from "./utils/editorSettings";
 import { env } from "./utils/server-env";
 import { getWwwClient } from "./utils/wwwClient";
@@ -47,6 +48,7 @@ export interface AgentSpawnResult {
   vscodeUrl?: string;
   success: boolean;
   error?: string;
+  errorCode?: string;
 }
 
 export async function spawnAgent(
@@ -930,6 +932,8 @@ exit $EXIT_CODE
       worktreePath: "",
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
+      errorCode:
+        error instanceof GithubConnectionRequiredError ? error.code : undefined,
     };
   }
 }

--- a/apps/server/src/errors/GithubConnectionRequiredError.ts
+++ b/apps/server/src/errors/GithubConnectionRequiredError.ts
@@ -1,0 +1,47 @@
+const DEFAULT_GITHUB_CONNECTION_MESSAGE =
+  "Connect GitHub to start a CMUX cloud workspace.";
+
+export interface GithubCredentialErrorPayload {
+  error?: string;
+  detail?: string;
+  code?: string;
+  requiresGithubConnection?: boolean;
+}
+
+export class GithubConnectionRequiredError extends Error {
+  public readonly code = "GITHUB_TOKEN_MISSING" as const;
+
+  constructor(message: string = DEFAULT_GITHUB_CONNECTION_MESSAGE) {
+    super(message);
+    this.name = "GithubConnectionRequiredError";
+  }
+}
+
+export const isGithubCredentialErrorPayload = (
+  payload: unknown,
+): payload is GithubCredentialErrorPayload => {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+  const candidate = payload as GithubCredentialErrorPayload;
+  return (
+    candidate.requiresGithubConnection === true ||
+    candidate.code === "github_token_missing"
+  );
+};
+
+export const getGithubCredentialErrorMessage = (
+  payload?: GithubCredentialErrorPayload | string,
+): string => {
+  if (!payload) {
+    return DEFAULT_GITHUB_CONNECTION_MESSAGE;
+  }
+  if (typeof payload === "string") {
+    return payload || DEFAULT_GITHUB_CONNECTION_MESSAGE;
+  }
+  return (
+    payload.detail ||
+    payload.error ||
+    DEFAULT_GITHUB_CONNECTION_MESSAGE
+  );
+};

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -57,6 +57,11 @@ import { refreshGitHubData } from "./utils/refreshGitHubData";
 import { runWithAuth, runWithAuthToken } from "./utils/requestContext";
 import { getWwwClient } from "./utils/wwwClient";
 import { getWwwOpenApiModule } from "./utils/wwwOpenApiModule";
+import {
+  GithubConnectionRequiredError,
+  getGithubCredentialErrorMessage,
+  isGithubCredentialErrorPayload,
+} from "./errors/GithubConnectionRequiredError";
 import { DockerVSCodeInstance } from "./vscode/DockerVSCodeInstance";
 import {
   getVSCodeServeWebBaseUrl,
@@ -526,9 +531,13 @@ export function setupSocketHandlers(
                 `Failed to spawn any agents for task ${taskId}:`,
                 errors
               );
+              const codedError = agentResults.find(
+                (result) => !result.success && result.errorCode,
+              );
               rt.emit("task-failed", {
                 taskId,
-                error: errors || "Failed to spawn any agents",
+                error: codedError?.error || errors || "Failed to spawn any agents",
+                code: codedError?.errorCode,
               });
               return;
             }
@@ -598,6 +607,10 @@ export function setupSocketHandlers(
             rt.emit("task-failed", {
               taskId,
               error: error instanceof Error ? error.message : "Unknown error",
+              code:
+                error instanceof GithubConnectionRequiredError
+                  ? error.code
+                  : undefined,
             });
           }
         })();
@@ -606,6 +619,9 @@ export function setupSocketHandlers(
         callback({
           taskId,
           error: error instanceof Error ? error.message : "Unknown error",
+          ...(error instanceof GithubConnectionRequiredError
+            ? { code: error.code }
+            : {}),
         });
       }
     });
@@ -1210,9 +1226,23 @@ export function setupSocketHandlers(
             },
           });
 
-          const data = startRes.data;
+          const { data, error, response } = startRes;
           if (!data) {
-            throw new Error("Failed to start sandbox");
+            if (response?.status === 401 && isGithubCredentialErrorPayload(error)) {
+              throw new GithubConnectionRequiredError(
+                getGithubCredentialErrorMessage(error),
+              );
+            }
+            const fallbackMessage =
+              typeof error === "string"
+                ? error
+                : (error &&
+                    typeof error === "object" &&
+                    "error" in error &&
+                    typeof (error as { error?: unknown }).error === "string" &&
+                    ((error as { error?: string }).error as string)) ||
+                  "Failed to start sandbox";
+            throw new Error(fallbackMessage);
           }
 
           const sandboxId = data.instanceId;

--- a/apps/www/lib/routes/morph.route.ts
+++ b/apps/www/lib/routes/morph.route.ts
@@ -191,7 +191,15 @@ morphRouter.openapi(
         console.error(
           `[sandboxes.start] GitHub access token error: ${githubAccessTokenError}`
         );
-        return c.text("Failed to resolve GitHub credentials", 401);
+        return c.json(
+          {
+            error: "GitHub connection required to start a sandbox",
+            detail: githubAccessTokenError,
+            code: "github_token_missing",
+            requiresGithubConnection: true,
+          },
+          401
+        );
       }
       await configureGithubAccess(instance, githubAccessToken);
 

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -300,7 +300,15 @@ sandboxesRouter.openapi(
         console.error(
           `[sandboxes.start] GitHub access token error: ${githubAccessTokenError}`,
         );
-        return c.text("Failed to resolve GitHub credentials", 401);
+        return c.json(
+          {
+            error: "GitHub connection required to start a sandbox",
+            detail: githubAccessTokenError,
+            code: "github_token_missing",
+            requiresGithubConnection: true,
+          },
+          401,
+        );
       }
 
       // Sandboxes run as the requesting user, so prefer their OAuth scope over GitHub App installation tokens.

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -139,6 +139,7 @@ export const TaskAcknowledgedSchema = z.object({
 export const TaskErrorSchema = z.object({
   taskId: typedZid("tasks"),
   error: z.string(),
+  code: z.string().optional(),
 });
 
 // Git diff events


### PR DESCRIPTION
# Error: GitHub access token not found

**Issue ID:** 6998097054
**Project:** cmux-www
**Date:** 11/10/2025, 1:39:47 PM
## Issue Summary
Setup Failure: Missing GitHub Token During Instance Creation
**What's wrong:** POST to **/api/morph/setup-instance** failed due to **"GitHub access token not found"** error.
**In the trace:** The error occurred during instance setup, following a **successful Convex query** call.
**Possible cause:** The **GitHub token retrieval logic** within the promise chain **failed to resolve** a token.

## Tags

- **environment:** vercel-production
- **handled:** no
- **level:** error
- **mechanism:** auto.node.onunhandledrejection
- **os:** Linux
- **os.name:** Linux
- **release:** 9c2fd80883f94eb18c5bf15ca0776187771cf884
- **runtime:** node v22.18.0
- **runtime.name:** node
- **server_name:** 169.254.18.233
- **transaction:** POST /api/sandboxes/start
- **turbopack:** True
- **url:** https://www.cmux.dev/api/sandboxes/start
- **user:** ip:127.0.0.1

## Exception

### Exception 1
**Type:** Error
**Value:** GitHub access token not found

#### Stacktrace

```
 Unknown function in app:///_next/server/chunks/[root-of-the-server]__fe44f43e._.js [Line 81] (In app)
  echo "[ORCHESTRATOR] Started successfully in background (PID: $ORCHESTRATOR_PID)"
else
  echo "[ORCHESTRATOR] ERROR: Process failed to start or exited immediately" >&2
  exit 1
fi
{snip} ers)():null,T=n.then(({githubAccessToken:e})=>{if(!e)throw Error("GitHub access token not found");return(0,b.fetchGitIdentityInputs)(o,e)}), {snip}  <-- SUSPECT LINE
CMUX_TASK_RUN_ID="${a.taskRunId}"`),a.taskRunJwt&&($+=`
{snip} rl:p.z.string().optional(),provider:p.z.enum(["morph"]).optional()})}},description:"Sandbox status"},401:{description:"Unauthorized"},500:{d {snip}
{snip} Symbol.for(D),H=class e extends m{constructor({value:e,cause:t}){super({name:M,message:`Type validation failed: Value: ${JSON.stringify(e)}.
{snip} X,onRetry:n=X,onComment:s}=e,i="",o=!0,a,l="",c="";function u(e){if(""===e)return void(l.length>0&&t({id:a,event:c||void 0,data:l.endsWith(`
{snip} .slice(0,r),n=" "===e[r+1]?2:1;d(t,e.slice(r+n),e);return}d(e,"",e)}function d(e,t,s){switch(e){case"event":c=t;break;case"data":l=`${l}${t}
 process.processTicksAndRejections in node:internal/process/task_queues [Line 105] (Not in app)
```
fix this error by providing better handling so that error is surfaced to the user in the form of a toast, and user will be prompted to make a github connection, and the user's prompt will be able to be restored to the dashboardinput.