### PR TITLE
Always cd into /root/workspace before scripts

### DIFF
--- a/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
+++ b/apps/www/lib/routes/sandboxes/devAndMaintenanceOrchestratorScript.ts
@@ -239,7 +239,7 @@ async function runMaintenanceScript(): Promise<MaintenanceResult> {
     console.log("[MAINTENANCE] Starting maintenance script...");
 
     await runCommand(
-      `tmux send-keys -t cmux:${config.maintenanceWindowName} "zsh '${config.maintenanceScriptPath}' 2>&1 | tee '${config.maintenanceErrorLogPath}'; echo \\\${pipestatus[1]} > '${config.maintenanceExitCodePath}'; exec zsh" C-m`,
+      `tmux send-keys -t cmux:${config.maintenanceWindowName} "cd '${config.workspaceRoot}' && { zsh '${config.maintenanceScriptPath}' 2>&1 | tee '${config.maintenanceErrorLogPath}'; echo \\\${pipestatus[1]} > '${config.maintenanceExitCodePath}'; exec zsh; }" C-m`,
     );
 
     await delay(2000);
@@ -307,7 +307,7 @@ async function startDevScript(): Promise<DevResult> {
     console.log("[DEV] Starting dev script...");
 
     await runCommand(
-      `tmux send-keys -t cmux:${config.devWindowName} "zsh '${config.devScriptPath}' 2>&1 | tee '${config.devErrorLogPath}'; echo \\\${pipestatus[1]} > '${config.devExitCodePath}'" C-m`,
+      `tmux send-keys -t cmux:${config.devWindowName} "cd '${config.workspaceRoot}' && { zsh '${config.devScriptPath}' 2>&1 | tee '${config.devErrorLogPath}'; echo \\\${pipestatus[1]} > '${config.devExitCodePath}'; }" C-m`,
     );
 
     await delay(2000);


### PR DESCRIPTION
when we run maintenance script and dev script in the vms, we should cd into /root/workspace first and then execute the script, so if any script exits, we will end up in /root/workspace which is more convenient.