### PR TITLE
Hide dashboard checkmark; add tooltip to warning sign

### DIFF
--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -144,6 +144,7 @@ export function WorkspaceSetupPanel({
   const isConfigured =
     originalConfigRef.current.script.length > 0 ||
     originalConfigRef.current.envContent.length > 0;
+  const shouldShowSetupWarning = !configQuery.isPending && !isConfigured;
 
   const handleSave = useCallback(() => {
     if (!projectFullName) return;
@@ -253,10 +254,10 @@ export function WorkspaceSetupPanel({
             Configure workspace for{" "}
             <span className="font-semibold">{projectFullName}</span>
           </span>
-          {!isConfigured ? (
+          {shouldShowSetupWarning ? (
             <Tooltip delayDuration={0}>
               <TooltipTrigger asChild>
-                <span className="inline-flex">
+                <span className="inline-flex animate-in fade-in-0 duration-300">
                   <AlertTriangle
                     className="w-3.5 h-3.5 text-orange-600 dark:text-orange-500"
                     aria-label="Workspace setup incomplete"

--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -6,7 +6,7 @@ import {
   postApiWorkspaceConfigsMutation,
 } from "@cmux/www-openapi-client/react-query";
 import { useQuery, useMutation as useRQMutation } from "@tanstack/react-query";
-import { AlertTriangle, Check, ChevronDown, ChevronRight, Minus, Plus } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, Minus, Plus } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -17,6 +17,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { Button } from "./ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type WorkspaceSetupPanelProps = {
   teamSlugOrId: string;
@@ -252,11 +253,21 @@ export function WorkspaceSetupPanel({
             Configure workspace for{" "}
             <span className="font-semibold">{projectFullName}</span>
           </span>
-          {isConfigured ? (
-            <Check className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-400" />
-          ) : (
-            <AlertTriangle className="w-3.5 h-3.5 text-orange-600 dark:text-orange-500" />
-          )}
+          {!isConfigured ? (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <AlertTriangle
+                    className="w-3.5 h-3.5 text-orange-600 dark:text-orange-500"
+                    aria-label="Workspace setup incomplete"
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent sideOffset={6}>
+                Configure maintenance scripts and environment variables for this workspace.
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
         </div>
       </button>
 


### PR DESCRIPTION
if a workspace is set up alr, dont show the checkmark. on /dashboard page. for the warning sign, add a tooltip describing what it does.