### PR TITLE
Enable hover archive for workspace items

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -650,16 +650,19 @@ function TaskTreeInner({
     );
   })();
 
-  const taskMetaIcon =
-    !task.isArchived && taskLeadingIcon ? (
-      <SidebarArchiveOverlay
-        icon={taskLeadingIcon}
-        label="Archive task"
-        onArchive={handleArchive}
-      />
-    ) : (
-      taskLeadingIcon
-    );
+  const shouldShowTaskArchiveOverlay =
+    !task.isArchived &&
+    (Boolean(taskLeadingIcon) || isLocalWorkspace || isCloudWorkspace);
+
+  const taskMetaIcon = shouldShowTaskArchiveOverlay ? (
+    <SidebarArchiveOverlay
+      icon={taskLeadingIcon}
+      label="Archive task"
+      onArchive={handleArchive}
+    />
+  ) : (
+    taskLeadingIcon
+  );
 
   return (
     <TaskRunExpansionContext.Provider value={expansionContextValue}>
@@ -1182,16 +1185,21 @@ function TaskRunTreeInner({
 
   const runLeadingIcon = pullRequestIcon ?? statusIconWithTooltip;
 
-  const runMetaIcon =
-    !run.isArchived && runLeadingIcon ? (
-      <SidebarArchiveOverlay
-        icon={runLeadingIcon}
-        label="Archive task run"
-        onArchive={handleArchiveRun}
-      />
-    ) : (
-      runLeadingIcon
-    );
+  const shouldShowRunArchiveOverlay =
+    !run.isArchived &&
+    (Boolean(runLeadingIcon) ||
+      isLocalWorkspaceRunEntry ||
+      isCloudWorkspaceRunEntry);
+
+  const runMetaIcon = shouldShowRunArchiveOverlay ? (
+    <SidebarArchiveOverlay
+      icon={runLeadingIcon}
+      label="Archive task run"
+      onArchive={handleArchiveRun}
+    />
+  ) : (
+    runLeadingIcon
+  );
 
   const crownIcon = run.isCrowned ? (
     <Tooltip delayDuration={0}>


### PR DESCRIPTION
make it possible to archive workspace tasks/workspace taskruns in the sidebar on hover (not just right click). (for both cloud and local workspaces)