### PR TITLE
unset VSCODE_IPC_HOOK_CLI when spawning serve-web

### DIFF
--- a/apps/server/src/vscode/serveWeb.ts
+++ b/apps/server/src/vscode/serveWeb.ts
@@ -90,6 +90,11 @@ export async function ensureVSCodeServeWeb(
       {
         detached: false,
         stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          // Make sure VS Code CLI does not inherit our existing IPC hook.
+          VSCODE_IPC_HOOK_CLI: undefined,
+        },
       }
     );
 


### PR DESCRIPTION
where we spawn code serve-web set env variable VSCODE_IPC_HOOK_CLI to undefined making sure to override existing env vars