### PR TITLE
Graceful config loading when auth backend is down

### DIFF
--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -5,6 +5,7 @@ import {
   getApiWorkspaceConfigsOptions,
   postApiWorkspaceConfigsMutation,
 } from "@cmux/www-openapi-client/react-query";
+import type { PostApiWorkspaceConfigsData } from "@cmux/www-openapi-client";
 import { useQuery, useMutation as useRQMutation } from "@tanstack/react-query";
 import { AlertTriangle, ChevronDown, ChevronRight, Minus, Plus } from "lucide-react";
 import {
@@ -77,31 +78,41 @@ export function WorkspaceSetupPanel({
     if (configQuery.isPending) return;
     if (configQuery.error) return;
     if (configQuery.data === undefined) return;
+
     const data = configQuery.data;
     const nextScript = (data?.maintenanceScript ?? "").toString();
-    const envContent = data?.envVarsContent ?? "";
-    const parsedEnvVars =
-      envContent.trim().length > 0
-        ? parseEnvBlock(envContent).map((row) => ({
-          name: row.name,
-          value: row.value,
-          isSecret: true,
-        }))
-        : [];
-    const normalizedEnvContent = formatEnvVarsContent(
-      parsedEnvVars
-        .filter(
-          (row) => row.name.trim().length > 0 || row.value.trim().length > 0,
-        )
-        .map((row) => ({ name: row.name, value: row.value })),
-    );
-
     setMaintenanceScript(nextScript);
-    setEnvVars(ensureInitialEnvVars(parsedEnvVars));
-    originalConfigRef.current = {
-      script: nextScript.trim(),
-      envContent: normalizedEnvContent,
-    };
+
+    if (!data || data.envVarsLoadError) {
+      setEnvVars(ensureInitialEnvVars());
+      originalConfigRef.current = {
+        script: nextScript.trim(),
+        envContent: "",
+      };
+    } else {
+      const envContent = data.envVarsContent ?? "";
+      const parsedEnvVars =
+        envContent.trim().length > 0
+          ? parseEnvBlock(envContent).map((row) => ({
+            name: row.name,
+            value: row.value,
+            isSecret: true,
+          }))
+          : [];
+      const normalizedEnvContent = formatEnvVarsContent(
+        parsedEnvVars
+          .filter(
+            (row) => row.name.trim().length > 0 || row.value.trim().length > 0,
+          )
+          .map((row) => ({ name: row.name, value: row.value })),
+      );
+
+      setEnvVars(ensureInitialEnvVars(parsedEnvVars));
+      originalConfigRef.current = {
+        script: nextScript.trim(),
+        envContent: normalizedEnvContent,
+      };
+    }
 
     if (!hasInitializedFromServerRef.current) {
       hasInitializedFromServerRef.current = true;
@@ -141,9 +152,13 @@ export function WorkspaceSetupPanel({
     normalizedScript !== originalConfigRef.current.script ||
     currentEnvContent !== originalConfigRef.current.envContent;
 
+  const envVarsLoadError = Boolean(configQuery.data?.envVarsLoadError);
+  const hasStoredEnvVars = Boolean(configQuery.data?.hasEnvVars);
+
   const isConfigured =
     originalConfigRef.current.script.length > 0 ||
-    originalConfigRef.current.envContent.length > 0;
+    originalConfigRef.current.envContent.length > 0 ||
+    hasStoredEnvVars;
   const shouldShowSetupWarning = !configQuery.isPending && !isConfigured;
 
   const handleSave = useCallback(() => {
@@ -153,20 +168,25 @@ export function WorkspaceSetupPanel({
       ? normalizedScript
       : undefined;
 
+    const body: PostApiWorkspaceConfigsData["body"] = {
+      teamSlugOrId,
+      projectFullName,
+      maintenanceScript: scriptToSave,
+    };
+
+    if (!envVarsLoadError) {
+      body.envVarsContent = currentEnvContent;
+    }
+
     saveMutation.mutate(
       {
-        body: {
-          teamSlugOrId,
-          projectFullName,
-          maintenanceScript: scriptToSave,
-          envVarsContent: currentEnvContent,
-        },
+        body,
       },
       {
         onSuccess: () => {
           originalConfigRef.current = {
             script: normalizedScript,
-            envContent: currentEnvContent,
+            envContent: envVarsLoadError ? "" : currentEnvContent,
           };
           toast.success("Workspace setup saved");
         },
@@ -178,6 +198,7 @@ export function WorkspaceSetupPanel({
     );
   }, [
     currentEnvContent,
+    envVarsLoadError,
     normalizedScript,
     projectFullName,
     saveMutation,
@@ -316,6 +337,15 @@ export function WorkspaceSetupPanel({
 
                 {/* Environment Variables Section */}
                 <div className="space-y-1 pt-1" onPasteCapture={handleEnvPaste}>
+                  {envVarsLoadError ? (
+                    <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+                      <AlertTriangle className="h-3 w-3 shrink-0 mt-0.5" />
+                      <span>
+                        We couldn’t reach Stack Auth to load your saved environment variables.
+                        They are still stored securely and will remain unchanged if you save updates now.
+                      </span>
+                    </div>
+                  ) : null}
                   <div className="flex flex-col gap-0.5">
                     <p className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
                       Environment variables
@@ -326,7 +356,9 @@ export function WorkspaceSetupPanel({
                     </p>
                   </div>
 
-                  <div className="space-y-1.5">
+                  <div
+                    className={`space-y-1.5 ${envVarsLoadError ? "opacity-60 pointer-events-none select-none" : ""}`}
+                  >
                     <div
                       className="grid gap-2 text-[11px] font-medium text-neutral-600 dark:text-neutral-400 items-center"
                       style={{ gridTemplateColumns: "3fr 7fr 36px" }}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
@@ -120,7 +120,11 @@ function NewSnapshotVersionPage() {
     throw new Error("Environment not found");
   }
 
+  const envVarsLoadError = Boolean(environmentVarsQuery.data?.envVarsLoadError);
   const initialEnvVars = useMemo(() => {
+    if (envVarsLoadError) {
+      return [];
+    }
     const content = environmentVarsQuery.data?.envVarsContent;
     if (!content) {
       return [];
@@ -130,7 +134,7 @@ function NewSnapshotVersionPage() {
       value: entry.value,
       isSecret: true,
     }));
-  }, [environmentVarsQuery.data?.envVarsContent]);
+  }, [envVarsLoadError, environmentVarsQuery.data?.envVarsContent]);
 
   const activeSnapshotScripts = useMemo(() => {
     const snapshots = snapshotVersionsQuery.data ?? [];
@@ -181,6 +185,7 @@ function NewSnapshotVersionPage() {
                 : ""
             }
             initialEnvVars={initialEnvVars}
+            initialEnvVarsLoadError={envVarsLoadError}
             onHeaderControlsChange={setHeaderActions}
             onEnvironmentSaved={handleEnvironmentSaved}
           />

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -231,25 +231,33 @@ export async function spawnAgent(
           path: { id: String(options.environmentId) },
           query: { teamSlugOrId },
         });
-        const envContent = envRes.data?.envVarsContent;
-        if (envContent && envContent.trim().length > 0) {
-          const parsed = parseDotenv(envContent);
-          if (Object.keys(parsed).length > 0) {
-            const preserved = {
-              CMUX_PROMPT: envVars.CMUX_PROMPT,
-              CMUX_TASK_RUN_ID: envVars.CMUX_TASK_RUN_ID,
-              PROMPT: envVars.PROMPT,
-            };
-            envVars = {
-              ...envVars,
-              ...parsed,
-              ...preserved,
-            };
-            serverLogger.info(
-              `[AgentSpawner] Injected ${Object.keys(parsed).length} env vars from environment ${String(
-                options.environmentId
-              )}`
-            );
+        if (envRes.data?.envVarsLoadError) {
+          serverLogger.warn(
+            `[AgentSpawner] Environment env vars unavailable (Stack offline?) for ${String(
+              options.environmentId
+            )}; continuing without them`
+          );
+        } else {
+          const envContent = envRes.data?.envVarsContent;
+          if (envContent && envContent.trim().length > 0) {
+            const parsed = parseDotenv(envContent);
+            if (Object.keys(parsed).length > 0) {
+              const preserved = {
+                CMUX_PROMPT: envVars.CMUX_PROMPT,
+                CMUX_TASK_RUN_ID: envVars.CMUX_TASK_RUN_ID,
+                PROMPT: envVars.PROMPT,
+              };
+              envVars = {
+                ...envVars,
+                ...parsed,
+                ...preserved,
+              };
+              serverLogger.info(
+                `[AgentSpawner] Injected ${Object.keys(parsed).length} env vars from environment ${String(
+                  options.environmentId
+                )}`
+              );
+            }
           }
         }
       } catch (error) {

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -783,6 +783,17 @@ export function setupSocketHandlers(
               return {};
             }
 
+            if (workspaceConfig.envVarsLoadError) {
+              serverLogger.warn(
+                "[create-local-workspace] Workspace env vars unavailable; skipping injection to avoid overwrites",
+                {
+                  projectFullName,
+                  hasEnvVars: workspaceConfig.hasEnvVars,
+                }
+              );
+              return {};
+            }
+
             const envVarsContent = workspaceConfig.envVarsContent ?? "";
             const trimmedEnvVars = envVarsContent.trim();
             let parsedEnvVars: Record<string, string> = {};

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -400,6 +400,8 @@ export type ListEnvironmentsResponse = Array<GetEnvironmentResponse>;
 
 export type GetEnvironmentVarsResponse = {
     envVarsContent: string;
+    envVarsLoadError?: boolean;
+    hasEnvVars?: boolean;
 };
 
 export type UpdateEnvironmentBody = {
@@ -613,6 +615,8 @@ export type WorkspaceConfigResponse = {
     projectFullName: string;
     maintenanceScript?: string;
     envVarsContent: string;
+    envVarsLoadError?: boolean;
+    hasEnvVars?: boolean;
     updatedAt?: number;
 } | null;
 


### PR DESCRIPTION
add more graceful error handling for configuration environment variables and setup scripts (loading those) in the case that stack auth or something is down, it doesnt break everything