### PR TITLE
Add resizable VSCode and Browser VNC split view

### DIFF
--- a/apps/client/src/components/EnvironmentConfiguration.tsx
+++ b/apps/client/src/components/EnvironmentConfiguration.tsx
@@ -645,10 +645,10 @@ export function EnvironmentConfiguration({
         ? null
         : {
             title: instanceId
-              ? "Waiting for browser VNC"
+              ? "Waiting for browser"
               : "Browser preview unavailable",
             description: instanceId
-              ? "We'll embed the browser VNC session as soon as the environment exposes it."
+              ? "We'll embed the browser session as soon as the environment exposes it."
               : "Launch an environment so the browser agent can handle screenshots and authentication flows.",
           },
     [browserUrl, instanceId]
@@ -803,7 +803,7 @@ export function EnvironmentConfiguration({
             }}
             title="Resize panels"
           >
-            <div className="absolute left-0 right-0 h-px bg-transparent group-hover:bg-neutral-400 dark:group-hover:bg-neutral-600 group-active:bg-neutral-500 dark:group-active:bg-neutral-500 transition-colors" style={{ top: "calc(50% + 2px)" }} />
+            <div className="absolute left-0 right-0 h-px bg-transparent group-hover:bg-neutral-400 dark:group-hover:bg-neutral-600 group-active:bg-neutral-500 dark:group-active:bg-neutral-500 transition-colors" style={{ top: "50%", transform: "translateY(-50%)" }} />
           </div>
         )}
         {expandedPanelInSplit && <div className="h-0" />}
@@ -1176,26 +1176,6 @@ export function EnvironmentConfiguration({
           </AccordionItem>
 
           <AccordionItem
-            key="browser-vnc"
-            aria-label="Browser VNC setup"
-            title="Browser VNC setup"
-          >
-            <div className="space-y-2 pb-4 text-xs text-neutral-600 dark:text-neutral-400">
-              <p>
-                Prepare the embedded browser so the Browser Agent can capture screenshots, finish authentication flows, and verify previews before you save this environment.
-              </p>
-              <ul className="list-disc space-y-1 pl-5">
-                <li>Sign in to SaaS tools or dashboards that require persistent sessions.</li>
-                <li>Clear cookie banners, popups, or MFA prompts that could block automation.</li>
-                <li>Load staging URLs and confirm pages render without certificate or CSP warnings.</li>
-              </ul>
-              <p className="text-[11px] text-neutral-500 dark:text-neutral-500">
-                Tip: the split-view toggle (first icon above the preview) keeps VS Code and the browser visible side-by-side while you configure things.
-              </p>
-            </div>
-          </AccordionItem>
-
-          <AccordionItem
             key="install-dependencies"
             aria-label="Install dependencies"
             title="Install dependencies"
@@ -1264,6 +1244,26 @@ export function EnvironmentConfiguration({
                   <p className="text-xs text-red-500">{portsError}</p>
                 )}
               </div>
+            </div>
+          </AccordionItem>
+
+          <AccordionItem
+            key="browser-vnc"
+            aria-label="Browser setup"
+            title="Browser setup"
+          >
+            <div className="space-y-2 pb-4 text-xs text-neutral-600 dark:text-neutral-400">
+              <p>
+                Prepare the embedded browser so the browser agent can capture screenshots, finish authentication flows, and verify previews before you save this environment.
+              </p>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Sign in to SaaS tools or dashboards that require persistent sessions.</li>
+                <li>Clear cookie banners, popups, or MFA prompts that could block automation.</li>
+                <li>Load staging URLs and confirm pages render without certificate or CSP warnings.</li>
+              </ul>
+              <p className="text-[11px] text-neutral-500 dark:text-neutral-500">
+                Tip: the split-view toggle (first icon above the preview) keeps VS Code and the browser visible side-by-side while you configure things.
+              </p>
             </div>
           </AccordionItem>
         </Accordion>

--- a/apps/client/src/components/EnvironmentConfiguration.tsx
+++ b/apps/client/src/components/EnvironmentConfiguration.tsx
@@ -4,6 +4,7 @@ import { WorkspaceLoadingIndicator } from "@/components/workspace-loading-indica
 import { ScriptTextareaField } from "@/components/ScriptTextareaField";
 import { SCRIPT_COPY } from "@/components/scriptCopy";
 import { ResizableColumns } from "@/components/ResizableColumns";
+import { RenderPanel } from "@/components/TaskPanelFactory";
 import { parseEnvBlock } from "@/lib/parseEnvBlock";
 import {
   TASK_RUN_IFRAME_ALLOW,
@@ -27,7 +28,6 @@ import { useMutation as useRQMutation } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { Id } from "@cmux/convex/dataModel";
 import clsx from "clsx";
-import type { PersistentIframeStatus } from "@/components/persistent-iframe";
 import {
   ArrowLeft,
   Code2,
@@ -36,7 +36,7 @@ import {
   Monitor,
   Plus,
   Settings,
-  X,
+  SquareSplitHorizontal,
 } from "lucide-react";
 import {
   useCallback,
@@ -48,6 +48,8 @@ import {
 } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { toast } from "sonner";
+
+type PreviewMode = "split" | "vscode" | "browser";
 
 export function EnvironmentConfiguration({
   selectedRepos,
@@ -168,15 +170,29 @@ export function EnvironmentConfiguration({
     null
   );
   const lastSubmittedEnvContent = useRef<string | null>(null);
-  const [activePreview, setActivePreview] = useState<"vscode" | "browser">(
-    "vscode"
-  );
-  const [vscodeStatus, setVscodeStatus] =
-    useState<PersistentIframeStatus>("loading");
-  const [vscodeError, setVscodeError] = useState<string | null>(null);
-  const [browserStatus, setBrowserStatus] =
-    useState<PersistentIframeStatus>("loading");
-  const [browserError, setBrowserError] = useState<string | null>(null);
+  const [previewMode, setPreviewMode] = useState<PreviewMode>(() => {
+    if (typeof window === "undefined") {
+      return "split";
+    }
+    const stored = window.localStorage.getItem("env-preview-mode");
+    if (stored === "split" || stored === "vscode" || stored === "browser") {
+      return stored;
+    }
+    return "split";
+  });
+  const [splitRatio, setSplitRatio] = useState(() => {
+    if (typeof window === "undefined") {
+      return 0.5;
+    }
+    const stored = window.localStorage.getItem("env-preview-split");
+    const parsed = stored ? Number.parseFloat(stored) : 0.5;
+    if (Number.isNaN(parsed)) {
+      return 0.5;
+    }
+    return Math.min(Math.max(parsed, 0.2), 0.8);
+  });
+  const splitContainerRef = useRef<HTMLDivElement | null>(null);
+  const splitDragRafRef = useRef<number | null>(null);
   const basePersistKey = useMemo(() => {
     if (instanceId) return `env-config:${instanceId}`;
     if (vscodeUrl) return `env-config:${vscodeUrl}`;
@@ -185,21 +201,146 @@ export function EnvironmentConfiguration({
   }, [browserUrl, instanceId, vscodeUrl]);
   const vscodePersistKey = `${basePersistKey}:vscode`;
   const browserPersistKey = `${basePersistKey}:browser`;
+
   useEffect(() => {
-    if (!browserUrl && activePreview === "browser") {
-      setActivePreview("vscode");
+    if (typeof window === "undefined") {
+      return;
     }
-  }, [activePreview, browserUrl]);
+    window.localStorage.setItem("env-preview-mode", previewMode);
+  }, [previewMode]);
 
   useEffect(() => {
-    setVscodeStatus("loading");
-    setVscodeError(null);
-  }, [vscodeUrl]);
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem("env-preview-split", String(splitRatio));
+  }, [splitRatio]);
 
   useEffect(() => {
-    setBrowserStatus("loading");
-    setBrowserError(null);
-  }, [browserUrl]);
+    if (previewMode === "browser" && !browserUrl) {
+      setPreviewMode("vscode");
+    }
+  }, [browserUrl, previewMode]);
+
+  const clampSplitRatio = useCallback(
+    (value: number) => Math.min(Math.max(value, 0.2), 0.8),
+    []
+  );
+
+  const disableIframePointerEvents = useCallback(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const iframes = document.querySelectorAll("iframe");
+    for (const node of Array.from(iframes)) {
+      if (!(node instanceof HTMLIFrameElement)) {
+        continue;
+      }
+      const current = node.style.pointerEvents;
+      node.dataset.prevPointerEvents = current ? current : "__unset__";
+      node.style.pointerEvents = "none";
+    }
+  }, []);
+
+  const restoreIframePointerEvents = useCallback(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const iframes = document.querySelectorAll("iframe");
+    for (const node of Array.from(iframes)) {
+      if (!(node instanceof HTMLIFrameElement)) {
+        continue;
+      }
+      const prev = node.dataset.prevPointerEvents;
+      if (prev !== undefined) {
+        if (prev === "__unset__") {
+          node.style.removeProperty("pointer-events");
+        } else {
+          node.style.pointerEvents = prev;
+        }
+        delete node.dataset.prevPointerEvents;
+      } else {
+        node.style.removeProperty("pointer-events");
+      }
+    }
+  }, []);
+
+  const updateSplitFromEvent = useCallback(
+    (event: MouseEvent) => {
+      const container = splitContainerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      if (rect.height <= 0) return;
+      const offset = (event.clientY - rect.top) / rect.height;
+      setSplitRatio(clampSplitRatio(offset));
+    },
+    [clampSplitRatio]
+  );
+
+  const handleSplitDragMove = useCallback(
+    (event: MouseEvent) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+      if (splitDragRafRef.current != null) {
+        return;
+      }
+      splitDragRafRef.current = window.requestAnimationFrame(() => {
+        splitDragRafRef.current = null;
+        updateSplitFromEvent(event);
+      });
+    },
+    [updateSplitFromEvent]
+  );
+
+  const stopSplitDragging = useCallback(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+    if (splitDragRafRef.current != null) {
+      cancelAnimationFrame(splitDragRafRef.current);
+      splitDragRafRef.current = null;
+    }
+    document.body.style.cursor = "";
+    document.body.classList.remove("select-none");
+    restoreIframePointerEvents();
+    window.removeEventListener("mousemove", handleSplitDragMove);
+    window.removeEventListener("mouseup", stopSplitDragging);
+  }, [handleSplitDragMove, restoreIframePointerEvents]);
+
+  const startSplitDragging = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (previewMode !== "split") {
+        return;
+      }
+      if (typeof window === "undefined" || typeof document === "undefined") {
+        return;
+      }
+      event.preventDefault();
+      document.body.style.cursor = "row-resize";
+      document.body.classList.add("select-none");
+      disableIframePointerEvents();
+      window.addEventListener("mousemove", handleSplitDragMove);
+      window.addEventListener("mouseup", stopSplitDragging);
+    },
+    [disableIframePointerEvents, handleSplitDragMove, previewMode, stopSplitDragging]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined" && splitDragRafRef.current != null) {
+        cancelAnimationFrame(splitDragRafRef.current);
+        splitDragRafRef.current = null;
+        window.removeEventListener("mousemove", handleSplitDragMove);
+        window.removeEventListener("mouseup", stopSplitDragging);
+      }
+      if (typeof document !== "undefined") {
+        document.body.style.cursor = "";
+        document.body.classList.remove("select-none");
+      }
+      restoreIframePointerEvents();
+    };
+  }, [handleSplitDragMove, restoreIframePointerEvents, stopSplitDragging]);
 
   const createEnvironmentMutation = useRQMutation(
     postApiEnvironmentsMutation()
@@ -228,42 +369,6 @@ export function EnvironmentConfiguration({
       }
     }
   }, [pendingFocusIndex, envVars]);
-
-  const handlePreviewSelect = useCallback(
-    (view: "vscode" | "browser") => {
-      if (view === "browser" && !browserUrl) {
-        return;
-      }
-      setActivePreview(view);
-    },
-    [browserUrl]
-  );
-
-  const handleVscodeLoad = useCallback(() => {
-    setVscodeError(null);
-    setVscodeStatus("loaded");
-  }, []);
-
-  const handleVscodeError = useCallback((error: Error) => {
-    console.error("Failed to load VS Code workspace iframe", error);
-    setVscodeError(
-      "We couldn’t load VS Code. Try reloading or restarting the environment."
-    );
-    setVscodeStatus("error");
-  }, []);
-
-  const handleBrowserLoad = useCallback(() => {
-    setBrowserError(null);
-    setBrowserStatus("loaded");
-  }, []);
-
-  const handleBrowserError = useCallback((error: Error) => {
-    console.error("Failed to load browser workspace iframe", error);
-    setBrowserError(
-      "We couldn’t load the browser. Try reloading or restarting the environment."
-    );
-    setBrowserStatus("error");
-  }, []);
 
   // no-op placeholder removed; using onSnapshot instead
 
@@ -440,150 +545,131 @@ export function EnvironmentConfiguration({
   };
 
   const isBrowserAvailable = Boolean(browserUrl);
-  const showVscodeOverlay =
-    vscodeStatus !== "loaded" || vscodeError !== null;
-  const showBrowserOverlay =
-    browserStatus !== "loaded" || browserError !== null;
-  const browserLoadingFallback = useMemo(
-    () => <WorkspaceLoadingIndicator variant="browser" status="loading" />,
-    []
+  const workspacePlaceholder = useMemo(
+    () =>
+      vscodeUrl
+        ? null
+        : {
+            title: instanceId
+              ? "Waiting for VS Code"
+              : "VS Code workspace not ready",
+            description: instanceId
+              ? "The editor opens automatically once the environment finishes booting."
+              : "Select a repository and launch an environment to open VS Code.",
+          },
+    [instanceId, vscodeUrl]
   );
-  const browserErrorFallback = useMemo(
-    () => <WorkspaceLoadingIndicator variant="browser" status="error" />,
-    []
+  const browserPlaceholder = useMemo(
+    () =>
+      browserUrl
+        ? null
+        : {
+            title: instanceId
+              ? "Waiting for browser VNC"
+              : "Browser preview unavailable",
+            description: instanceId
+              ? "We'll embed the browser VNC session as soon as the environment exposes it."
+              : "Launch an environment so the browser agent can handle screenshots and authentication flows.",
+          },
+    [browserUrl, instanceId]
   );
 
-  const renderVscodePreview = () => {
-    if (!vscodeUrl) {
-      return (
-        <div className="flex h-full items-center justify-center px-6 text-center">
-          <div className="space-y-3">
-            <Loader2 className="w-6 h-6 mx-auto animate-spin text-neutral-500 dark:text-neutral-400" />
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">
-              Waiting for the VS Code workspace URL...
-            </p>
-          </div>
-        </div>
-      );
-    }
+  const workspacePanel = (
+    <RenderPanel
+      key={`env-workspace-${vscodePersistKey}`}
+      type="workspace"
+      position="topLeft"
+      workspaceUrl={vscodeUrl ?? null}
+      workspacePersistKey={vscodePersistKey}
+      PersistentWebView={PersistentWebView}
+      WorkspaceLoadingIndicator={WorkspaceLoadingIndicator}
+      TASK_RUN_IFRAME_ALLOW={TASK_RUN_IFRAME_ALLOW}
+      TASK_RUN_IFRAME_SANDBOX={TASK_RUN_IFRAME_SANDBOX}
+      workspacePlaceholder={workspacePlaceholder}
+      editorLoadingFallback={
+        <WorkspaceLoadingIndicator variant="vscode" status="loading" />
+      }
+      editorErrorFallback={
+        <WorkspaceLoadingIndicator variant="vscode" status="error" />
+      }
+      isExpanded={previewMode === "vscode"}
+      isAnyPanelExpanded={previewMode !== "split"}
+    />
+  );
 
-    return (
-      <div className="relative h-full" aria-busy={showVscodeOverlay}>
+  const browserPanel = (
+    <RenderPanel
+      key={`env-browser-${browserPersistKey}`}
+      type="browser"
+      position="bottomLeft"
+      browserUrl={browserUrl ?? null}
+      browserPersistKey={browserPersistKey}
+      PersistentWebView={PersistentWebView}
+      WorkspaceLoadingIndicator={WorkspaceLoadingIndicator}
+      TASK_RUN_IFRAME_ALLOW={TASK_RUN_IFRAME_ALLOW}
+      TASK_RUN_IFRAME_SANDBOX={TASK_RUN_IFRAME_SANDBOX}
+      browserPlaceholder={browserPlaceholder}
+      isExpanded={previewMode === "browser"}
+      isAnyPanelExpanded={previewMode !== "split"}
+    />
+  );
+
+  const workspacePanelNode = (
+    <div className="h-full min-h-0">{workspacePanel}</div>
+  );
+  const browserPanelNode = <div className="h-full min-h-0">{browserPanel}</div>;
+  const previewContent =
+    previewMode === "split" ? (
+      <div
+        ref={splitContainerRef}
+        className="grid h-full min-h-0"
+        style={{
+          gridTemplateRows: `minmax(160px, ${splitRatio}fr) 12px minmax(160px, ${
+            1 - splitRatio
+          }fr)`,
+          gap: "8px",
+        }}
+      >
+        <div className="min-h-0">{workspacePanelNode}</div>
         <div
-          aria-hidden={!showVscodeOverlay}
-          className={clsx(
-            "absolute inset-0 z-[var(--z-low)] flex items-center justify-center backdrop-blur-sm transition-opacity duration-300",
-            "bg-white/60 dark:bg-neutral-950/60",
-            showVscodeOverlay
-              ? "opacity-100 pointer-events-auto"
-              : "opacity-0 pointer-events-none"
-          )}
+          role="separator"
+          aria-label="Resize preview panels"
+          aria-orientation="horizontal"
+          onMouseDown={startSplitDragging}
+          className="group flex items-center justify-center rounded-full cursor-row-resize select-none bg-transparent"
         >
-          {vscodeError ? (
-            <div className="text-center max-w-sm px-6">
-              <X className="w-8 h-8 mx-auto mb-3 text-red-500" />
-              <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                {vscodeError}
-              </p>
-            </div>
-          ) : (
-            <div className="text-center">
-              <Loader2 className="w-6 h-6 mx-auto mb-3 animate-spin text-neutral-500 dark:text-neutral-400" />
-              <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                Loading VS Code...
-              </p>
-            </div>
-          )}
+          <div className="h-1.5 w-16 rounded-full bg-neutral-200 transition-colors group-hover:bg-neutral-400 dark:bg-neutral-800 dark:group-hover:bg-neutral-500" />
         </div>
-        <PersistentWebView
-          persistKey={vscodePersistKey}
-          src={vscodeUrl}
-          className="absolute inset-0"
-          iframeClassName="w-full h-full border-0"
-          allow={TASK_RUN_IFRAME_ALLOW}
-          sandbox={TASK_RUN_IFRAME_SANDBOX}
-          retainOnUnmount
-          onLoad={handleVscodeLoad}
-          onError={handleVscodeError}
-          onStatusChange={setVscodeStatus}
-          loadTimeoutMs={60_000}
-          fallbackClassName="bg-neutral-50 dark:bg-neutral-950"
-          errorFallbackClassName="bg-neutral-50 dark:bg-neutral-950"
-        />
+        <div className="min-h-0">{browserPanelNode}</div>
       </div>
+    ) : previewMode === "browser" ? (
+      browserPanelNode
+    ) : (
+      workspacePanelNode
     );
-  };
-
-  const renderBrowserPreview = () => {
-    if (!browserUrl) {
-      return (
-        <div className="flex h-full items-center justify-center px-6 text-center">
-          <div className="space-y-3">
-            <Loader2 className="w-6 h-6 mx-auto animate-spin text-neutral-500 dark:text-neutral-400" />
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">
-              Waiting for the workspace browser to be ready...
-            </p>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div className="relative h-full" aria-busy={showBrowserOverlay}>
-        <PersistentWebView
-          persistKey={browserPersistKey}
-          src={browserUrl}
-          className="absolute inset-0"
-          iframeClassName="w-full h-full border-0"
-          allow={TASK_RUN_IFRAME_ALLOW}
-          sandbox={TASK_RUN_IFRAME_SANDBOX}
-          retainOnUnmount
-          onLoad={handleBrowserLoad}
-          onError={handleBrowserError}
-          onStatusChange={setBrowserStatus}
-          fallback={browserLoadingFallback}
-          fallbackClassName="bg-neutral-50 dark:bg-neutral-950"
-          errorFallback={browserErrorFallback}
-          errorFallbackClassName="bg-neutral-50/95 dark:bg-neutral-950/95"
-          loadTimeoutMs={60_000}
-        />
-        <div
-          aria-hidden={!showBrowserOverlay}
-          className={clsx(
-            "absolute inset-0 z-[var(--z-low)] flex items-center justify-center backdrop-blur-sm transition-opacity duration-300",
-            "bg-white/60 dark:bg-neutral-950/60",
-            showBrowserOverlay
-              ? "opacity-100 pointer-events-auto"
-              : "opacity-0 pointer-events-none"
-          )}
-        >
-          {browserError ? (
-            <div className="text-center max-w-sm px-6">
-              <X className="w-8 h-8 mx-auto mb-3 text-red-500" />
-              <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                {browserError}
-              </p>
-            </div>
-          ) : (
-            <WorkspaceLoadingIndicator variant="browser" status="loading" />
-          )}
-        </div>
-      </div>
-    );
-  };
 
   const previewButtonClass = useCallback(
-    (view: "vscode" | "browser", disabled: boolean) =>
+    (view: PreviewMode, disabled: boolean) =>
       clsx(
-        "inline-flex h-7 w-7 items-center justify-center focus:outline-none text-neutral-600 dark:text-neutral-300",
+        "inline-flex h-7 w-7 items-center justify-center rounded focus:outline-none text-neutral-500 transition-colors dark:text-neutral-400",
         disabled
-          ? "opacity-50 cursor-not-allowed"
+          ? "opacity-40 cursor-not-allowed"
           : "cursor-pointer hover:text-neutral-900 dark:hover:text-neutral-100",
-        view === activePreview && !disabled
+        previewMode === view && !disabled
           ? "text-neutral-900 dark:text-neutral-100"
           : undefined
       ),
-    [activePreview]
+    [previewMode]
+  );
+
+  const handlePreviewModeChange = useCallback(
+    (mode: PreviewMode) => {
+      if (mode === "browser" && !isBrowserAvailable) {
+        return;
+      }
+      setPreviewMode(mode);
+    },
+    [isBrowserAvailable]
   );
 
   const headerControls = useMemo(() => {
@@ -595,19 +681,29 @@ export function EnvironmentConfiguration({
       <div className="flex items-center gap-1.5">
         <button
           type="button"
-          onClick={() => handlePreviewSelect("vscode")}
+          onClick={() => handlePreviewModeChange("split")}
+          className={previewButtonClass("split", false)}
+          aria-pressed={previewMode === "split"}
+          aria-label="Split VS Code and browser"
+          title="Split VS Code and browser"
+        >
+          <SquareSplitHorizontal className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => handlePreviewModeChange("vscode")}
           className={previewButtonClass("vscode", false)}
-          aria-pressed={activePreview === "vscode"}
-          aria-label="Show VS Code workspace"
+          aria-pressed={previewMode === "vscode"}
+          aria-label="Focus VS Code workspace"
           title="Show VS Code workspace"
         >
           <Code2 className="h-3.5 w-3.5" />
         </button>
         <button
           type="button"
-          onClick={() => handlePreviewSelect("browser")}
+          onClick={() => handlePreviewModeChange("browser")}
           className={previewButtonClass("browser", !isBrowserAvailable)}
-          aria-pressed={activePreview === "browser"}
+          aria-pressed={previewMode === "browser"}
           aria-label="Show browser preview"
           title="Show browser preview"
           disabled={!isBrowserAvailable}
@@ -617,11 +713,11 @@ export function EnvironmentConfiguration({
       </div>
     );
   }, [
-    activePreview,
-    handlePreviewSelect,
+    handlePreviewModeChange,
     isBrowserAvailable,
     isProvisioning,
     previewButtonClass,
+    previewMode,
   ]);
 
   useEffect(() => {
@@ -905,6 +1001,26 @@ export function EnvironmentConfiguration({
           </AccordionItem>
 
           <AccordionItem
+            key="browser-vnc"
+            aria-label="Browser VNC setup"
+            title="Browser VNC setup"
+          >
+            <div className="space-y-2 pb-4 text-xs text-neutral-600 dark:text-neutral-400">
+              <p>
+                Prepare the embedded browser so the Browser Agent can capture screenshots, finish authentication flows, and verify previews before you save this environment.
+              </p>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Sign in to SaaS tools or dashboards that require persistent sessions.</li>
+                <li>Clear cookie banners, popups, or MFA prompts that could block automation.</li>
+                <li>Load staging URLs and confirm pages render without certificate or CSP warnings.</li>
+              </ul>
+              <p className="text-[11px] text-neutral-500 dark:text-neutral-500">
+                Tip: the split-view toggle (first icon above the preview) keeps VS Code and the browser visible side-by-side while you configure things.
+              </p>
+            </div>
+          </AccordionItem>
+
+          <AccordionItem
             key="install-dependencies"
             aria-label="Install dependencies"
             title="Install dependencies"
@@ -1028,11 +1144,7 @@ export function EnvironmentConfiguration({
         </div>
       ) : (
         <div className="flex h-full flex-col">
-          <div className="flex-1 min-h-0">
-            {activePreview === "browser"
-              ? renderBrowserPreview()
-              : renderVscodePreview()}
-          </div>
+          <div className="flex-1 min-h-0">{previewContent}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
in environment setup add another section about browser VNC setup (tell users to setup the browser for browser agent to take screenshots / authentication etc.)... make the side for the environment setup split horizontally between vscode instance (top) and browser vnc (bottom)... make it 50-50 and resizable via dragging the two, keep the icons on the top right corner to make each full screen (the focused one is brighter and other icons are darker if they are not active)... but default view is resizable, add the split view there somewhere as well (third icon, put it in the first one out of the three)... we should reuse the @manaflow-ai/cmux/apps/client/src/components/TaskPanelFactory.tsx but only have the browser and vscode available...