### PR TITLE
Fix Archive tooltip label and z-index in base tooltip

### DIFF
--- a/apps/client/src/components/RepositoryPicker.tsx
+++ b/apps/client/src/components/RepositoryPicker.tsx
@@ -700,7 +700,7 @@ function RepositoryConnectionsSection({
                                       <Settings className="w-3 h-3 text-neutral-600 dark:text-neutral-300" />
                                     </button>
                                   </TooltipTrigger>
-                                  <TooltipContent className="z-[var(--z-tooltip)]">
+                                  <TooltipContent>
                                     Add Repos
                                   </TooltipContent>
                                 </Tooltip>

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -657,7 +657,7 @@ function TaskTreeInner({
   const taskMetaIcon = shouldShowTaskArchiveOverlay ? (
     <SidebarArchiveOverlay
       icon={taskLeadingIcon}
-      label="Archive task"
+      label="Archive"
       onArchive={handleArchive}
     />
   ) : (
@@ -1194,7 +1194,7 @@ function TaskRunTreeInner({
   const runMetaIcon = shouldShowRunArchiveOverlay ? (
     <SidebarArchiveOverlay
       icon={runLeadingIcon}
-      label="Archive task run"
+      label="Archive"
       onArchive={handleArchiveRun}
     />
   ) : (

--- a/apps/client/src/components/ui/tooltip.tsx
+++ b/apps/client/src/components/ui/tooltip.tsx
@@ -35,7 +35,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         style={{ "--primary": "black" } as React.CSSProperties}
         className={cn(
-          "bg-primary text-primary-foreground z-[var(--z-modal)] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance pointer-events-none select-none will-change-[transform,opacity]",
+          "bg-primary text-primary-foreground z-[var(--z-tooltip)] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance pointer-events-none select-none will-change-[transform,opacity]",
           // enter on delayed-open
           "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
           // instant-open should not animate or transition
@@ -49,7 +49,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-[var(--z-modal)] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] pointer-events-none select-none" />
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-[var(--z-tooltip)] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] pointer-events-none select-none" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );


### PR DESCRIPTION
archive task/task run tooltip in sidebar should be renamed just "Archive". also it needs higher z index, see the z index we use for other tooltips and use it.fix this for all tooltips by modifying the base tooltip component shadcn ui components file with the tooltip, and remove the classame where it won't be needed anymore