### PR TITLE
async preload vnc iframe on panels page

### DIFF
--- a/apps/client/src/lib/preloadTaskRunIframes.ts
+++ b/apps/client/src/lib/preloadTaskRunIframes.ts
@@ -1,6 +1,9 @@
 import { PERMISSIVE_IFRAME_ALLOW, PERMISSIVE_IFRAME_SANDBOX } from "./iframePermissions";
 import { persistentIframeManager } from "./persistentIframeManager";
-import { getTaskRunPersistKey } from "./persistent-webview-keys";
+import {
+  getTaskRunBrowserPersistKey,
+  getTaskRunPersistKey,
+} from "./persistent-webview-keys";
 
 /**
  * Preload iframes for task runs
@@ -40,6 +43,20 @@ export async function preloadTaskRunIframe(
     allow: TASK_RUN_IFRAME_ALLOW,
     sandbox: TASK_RUN_IFRAME_SANDBOX,
   });
+}
+
+export async function preloadTaskRunBrowserIframe(
+  taskRunId: string,
+  url: string
+): Promise<void> {
+  await persistentIframeManager.preloadIframe(
+    getTaskRunBrowserPersistKey(taskRunId),
+    url,
+    {
+      allow: TASK_RUN_IFRAME_ALLOW,
+      sandbox: TASK_RUN_IFRAME_SANDBOX,
+    }
+  );
 }
 
 /**

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -31,6 +31,7 @@ import {
 import {
   TASK_RUN_IFRAME_ALLOW,
   TASK_RUN_IFRAME_SANDBOX,
+  preloadTaskRunBrowserIframe,
   preloadTaskRunIframes,
 } from "../lib/preloadTaskRunIframes";
 import {
@@ -126,6 +127,19 @@ export const Route = createFileRoute("/_layout/$teamSlugOrId/task/$taskId/")({
       const selectedRun = parsedRunId?.success
         ? (taskRunIndex.get(parsedRunId.data) ?? taskRuns[0])
         : taskRuns[0];
+
+      const rawBrowserUrl =
+        selectedRun?.vscode?.url ?? selectedRun?.vscode?.workspaceUrl ?? null;
+      if (selectedRun && rawBrowserUrl) {
+        const vncUrl = toMorphVncUrl(rawBrowserUrl);
+        if (vncUrl) {
+          void preloadTaskRunBrowserIframe(selectedRun._id, vncUrl).catch(
+            (error) => {
+              console.error("Failed to preload browser iframe", error);
+            }
+          );
+        }
+      }
 
       const rawWorkspaceUrl = selectedRun?.vscode?.workspaceUrl ?? null;
       if (!rawWorkspaceUrl) {


### PR DESCRIPTION
for the panels page, aka the main page, I want us to preload the vnc browser iframe with the preload iframe method we have in the tanstack router loader . do it async though so it's not blocking.