### PR TITLE
Auto expand task in layout and scroll into view

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -666,7 +666,7 @@ function TaskTreeInner({
 
   return (
     <TaskRunExpansionContext.Provider value={expansionContextValue}>
-      <div className="select-none flex flex-col">
+      <div className="select-none flex flex-col" data-task-id={task._id}>
         <ContextMenu.Root>
           <ContextMenu.Trigger>
             <Link
@@ -1289,7 +1289,7 @@ function TaskRunTreeInner({
   }, []);
 
   return (
-    <div className={clsx({ hidden: run.isArchived })}>
+    <div className={clsx({ hidden: run.isArchived })} data-task-run-id={run._id}>
       <ContextMenu.Root>
         <ContextMenu.Trigger>
           <Link

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
@@ -93,6 +93,35 @@ function TaskRunComponent() {
     setIframeStatus("loading");
   }, [workspaceUrl]);
 
+  // Expand and scroll to this taskRun in the sidebar
+  useEffect(() => {
+    // First ensure the task is expanded
+    const taskElement = document.querySelector(`[data-task-id="${taskId}"]`);
+    if (taskElement) {
+      const taskLink = taskElement.querySelector("a");
+      const isTaskExpanded = taskElement.querySelector(
+        '[data-task-run-id]'
+      );
+
+      // If task runs aren't visible, click to expand the task
+      if (taskLink && !isTaskExpanded) {
+        taskLink.click();
+      }
+    }
+
+    // Small delay to allow the task to expand before scrolling to the run
+    const timeoutId = setTimeout(() => {
+      const taskRunElement = document.querySelector(
+        `[data-task-run-id="${taskRunId}"]`
+      );
+      if (taskRunElement) {
+        taskRunElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      }
+    }, 100);
+
+    return () => clearTimeout(timeoutId);
+  }, [taskRunId, taskId]);
+
   const onLoad = useCallback(() => {
     console.log(`Workspace view loaded for task run ${taskRunId}`);
   }, [taskRunId]);


### PR DESCRIPTION
in layout page of a taskRun, add a useEffect that runs once that will expand the task/taskrun + scrollintoview the taskRun in the sidebar. add a data- attribute to the relevant element(s) to make the query selector unambiguous.