### PR TITLE
Default client base URL from VITE_VERCEL_URL

### DIFF
--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -16,10 +16,7 @@ export const env = createEnv({
     NEXT_PUBLIC_WWW_ORIGIN: z
       .string()
       .min(1)
-      .refine((s) => {
-        if (s) {
-          return s;
-        }
+      .default(() => {
         const vercelUrl = import.meta.env.VITE_VERCEL_URL;
         console.log("vercelUrl", vercelUrl);
         console.log("all import.meta.env", import.meta.env);

--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -27,7 +27,9 @@ export const env = createEnv({
     NEXT_PUBLIC_WWW_ORIGIN:
       import.meta.env.NEXT_PUBLIC_WWW_ORIGIN ||
       (import.meta.env.VITE_VERCEL_URL
-        ? `https://${import.meta.env.VITE_VERCEL_URL}`
+        ? import.meta.env.VITE_VERCEL_URL.startsWith("http")
+          ? import.meta.env.VITE_VERCEL_URL
+          : `https://${import.meta.env.VITE_VERCEL_URL}`
         : undefined),
   },
 

--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -21,6 +21,8 @@ export const env = createEnv({
           return s;
         }
         const vercelUrl = import.meta.env.VITE_VERCEL_URL;
+        console.log("vercelUrl", vercelUrl);
+        console.log("all import.meta.env", import.meta.env);
         if (!vercelUrl) {
           return undefined;
         }

--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -35,9 +35,7 @@ export const env = createEnv({
    * What object holds the environment variables at runtime. This is usually
    * `process.env` or `import.meta.env`.
    */
-  runtimeEnv: {
-    ...import.meta.env,
-  },
+  runtimeEnv: import.meta.env,
 
   /**
    * By default, this library will feed the environment variables directly to

--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -13,7 +13,18 @@ export const env = createEnv({
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
     NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: z.string().min(1),
     NEXT_PUBLIC_GITHUB_APP_SLUG: z.string().optional(),
-    NEXT_PUBLIC_WWW_ORIGIN: z.string().min(1),
+    NEXT_PUBLIC_WWW_ORIGIN: z
+      .string()
+      .min(1)
+      .default(() => {
+        const vercelUrl = import.meta.env.VITE_VERCEL_URL;
+        if (!vercelUrl) {
+          return undefined;
+        }
+        return vercelUrl.startsWith("http")
+          ? vercelUrl
+          : `https://${vercelUrl}`;
+      }),
     NEXT_PUBLIC_SERVER_ORIGIN: z.string().optional(),
   },
 
@@ -23,14 +34,6 @@ export const env = createEnv({
    */
   runtimeEnv: {
     ...import.meta.env,
-    // Default NEXT_PUBLIC_WWW_ORIGIN to VITE_VERCEL_URL if not set
-    NEXT_PUBLIC_WWW_ORIGIN:
-      import.meta.env.NEXT_PUBLIC_WWW_ORIGIN ||
-      (import.meta.env.VITE_VERCEL_URL
-        ? import.meta.env.VITE_VERCEL_URL.startsWith("http")
-          ? import.meta.env.VITE_VERCEL_URL
-          : `https://${import.meta.env.VITE_VERCEL_URL}`
-        : undefined),
   },
 
   /**

--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -16,7 +16,10 @@ export const env = createEnv({
     NEXT_PUBLIC_WWW_ORIGIN: z
       .string()
       .min(1)
-      .default(() => {
+      .refine((s) => {
+        if (s) {
+          return s;
+        }
         const vercelUrl = import.meta.env.VITE_VERCEL_URL;
         if (!vercelUrl) {
           return undefined;

--- a/apps/client/src/client-env.ts
+++ b/apps/client/src/client-env.ts
@@ -21,7 +21,15 @@ export const env = createEnv({
    * What object holds the environment variables at runtime. This is usually
    * `process.env` or `import.meta.env`.
    */
-  runtimeEnv: import.meta.env,
+  runtimeEnv: {
+    ...import.meta.env,
+    // Default NEXT_PUBLIC_WWW_ORIGIN to VITE_VERCEL_URL if not set
+    NEXT_PUBLIC_WWW_ORIGIN:
+      import.meta.env.NEXT_PUBLIC_WWW_ORIGIN ||
+      (import.meta.env.VITE_VERCEL_URL
+        ? `https://${import.meta.env.VITE_VERCEL_URL}`
+        : undefined),
+  },
 
   /**
    * By default, this library will feed the environment variables directly to


### PR DESCRIPTION
for apps/client where do we get the base url? make it default to import.meta.env.VITE_VERCEL_URL if it exists.