### PR TITLE
Add pinning for tasks and taskruns in UI

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -273,31 +273,6 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
             ))}
           </ul>
 
-          {/* Pinned Items Section - only show if there are pinned items */}
-          {pinnedData && (pinnedData.tasks.length > 0 || pinnedData.taskRuns.length > 0) && (
-            <div className="mt-4 flex flex-col">
-              <SidebarSectionLink
-                to="/$teamSlugOrId/dashboard"
-                params={{ teamSlugOrId }}
-                exact={false}
-              >
-                Pinned
-              </SidebarSectionLink>
-              <div className="ml-2 pt-px">
-                <div className="space-y-px">
-                  {pinnedData.tasks.map((task) => (
-                    <TaskTree
-                      key={task._id}
-                      task={task}
-                      defaultExpanded={expandTaskIds?.includes(task._id) ?? false}
-                      teamSlugOrId={teamSlugOrId}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-          )}
-
           <div className="mt-4 flex flex-col">
             <SidebarSectionLink
               to="/$teamSlugOrId/prs"
@@ -326,16 +301,37 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
               {tasks === undefined ? (
                 <TaskTreeSkeleton count={5} />
               ) : tasks && tasks.length > 0 ? (
-                tasks
-                  .filter((task) => !task.pinned) // Filter out pinned tasks to avoid duplicates
-                  .map((task) => (
-                    <TaskTree
-                      key={task._id}
-                      task={task}
-                      defaultExpanded={expandTaskIds?.includes(task._id) ?? false}
-                      teamSlugOrId={teamSlugOrId}
-                    />
-                  ))
+                <>
+                  {/* Pinned items at the top */}
+                  {pinnedData && pinnedData.length > 0 && (
+                    <>
+                      {pinnedData.map((task) => (
+                        <TaskTree
+                          key={task._id}
+                          task={task}
+                          defaultExpanded={expandTaskIds?.includes(task._id) ?? false}
+                          teamSlugOrId={teamSlugOrId}
+                        />
+                      ))}
+                      {/* Horizontal divider after pinned items */}
+                      <hr className="mx-2 border-t border-neutral-200 dark:border-neutral-800" />
+                    </>
+                  )}
+                  {/* Regular (non-pinned) tasks */}
+                  {tasks
+                    .filter((task) => {
+                      // Only filter out directly pinned tasks
+                      return !task.pinned;
+                    })
+                    .map((task) => (
+                      <TaskTree
+                        key={task._id}
+                        task={task}
+                        defaultExpanded={expandTaskIds?.includes(task._id) ?? false}
+                        teamSlugOrId={teamSlugOrId}
+                      />
+                    ))}
+                </>
               ) : (
                 <p className="pl-2 pr-3 py-1.5 text-xs text-neutral-500 dark:text-neutral-400 select-none">
                   No recent tasks

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -45,6 +45,8 @@ import {
   Globe,
   Monitor,
   Pencil,
+  Pin,
+  PinOff,
   TerminalSquare,
   Loader2,
   XCircle,
@@ -517,6 +519,24 @@ function TaskTreeInner({
     unarchive(task._id);
   }, [unarchive, task._id]);
 
+  // Mutations for pinning/unpinning tasks
+  const pinTask = useMutation(api.tasks.pin);
+  const unpinTask = useMutation(api.tasks.unpin);
+
+  const handlePin = useCallback(() => {
+    pinTask({
+      teamSlugOrId,
+      id: task._id,
+    });
+  }, [pinTask, teamSlugOrId, task._id]);
+
+  const handleUnpin = useCallback(() => {
+    unpinTask({
+      teamSlugOrId,
+      id: task._id,
+    });
+  }, [unpinTask, teamSlugOrId, task._id]);
+
   const inferredBranch = getTaskBranch(task);
   const trimmedTaskText = (task.text ?? "").trim();
   const trimmedPullRequestTitle = task.pullRequestTitle?.trim();
@@ -760,6 +780,23 @@ function TaskTreeInner({
                     <span>Rename Task</span>
                   </ContextMenu.Item>
                 ) : null}
+                {task.pinned ? (
+                  <ContextMenu.Item
+                    className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
+                    onClick={handleUnpin}
+                  >
+                    <PinOff className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
+                    <span>Unpin Task</span>
+                  </ContextMenu.Item>
+                ) : (
+                  <ContextMenu.Item
+                    className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
+                    onClick={handlePin}
+                  >
+                    <Pin className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
+                    <span>Pin Task</span>
+                  </ContextMenu.Item>
+                )}
                 <ContextMenu.SubmenuRoot>
                   <ContextMenu.SubmenuTrigger className="flex items-center gap-2 cursor-default py-1.5 pr-4 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700">
                     <ArchiveIcon className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
@@ -1105,6 +1142,24 @@ function TaskRunTreeInner({
     onArchiveToggle(run._id, true);
   }, [onArchiveToggle, run._id]);
 
+  // Mutations for pinning/unpinning task runs
+  const pinTaskRun = useMutation(api.taskRuns.pin);
+  const unpinTaskRun = useMutation(api.taskRuns.unpin);
+
+  const handlePinRun = useCallback(() => {
+    pinTaskRun({
+      teamSlugOrId,
+      id: run._id,
+    });
+  }, [pinTaskRun, teamSlugOrId, run._id]);
+
+  const handleUnpinRun = useCallback(() => {
+    unpinTaskRun({
+      teamSlugOrId,
+      id: run._id,
+    });
+  }, [unpinTaskRun, teamSlugOrId, run._id]);
+
   const isLocalWorkspaceRunEntry = run.isLocalWorkspace;
   const isCloudWorkspaceRunEntry = run.isCloudWorkspace;
 
@@ -1424,6 +1479,23 @@ function TaskRunTreeInner({
                   </ContextMenu.Positioner>
                 </ContextMenu.SubmenuRoot>
               ) : null}
+              {run.pinned ? (
+                <ContextMenu.Item
+                  className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
+                  onClick={handleUnpinRun}
+                >
+                  <PinOff className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
+                  <span>Unpin Run</span>
+                </ContextMenu.Item>
+              ) : (
+                <ContextMenu.Item
+                  className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
+                  onClick={handlePinRun}
+                >
+                  <Pin className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
+                  <span>Pin Run</span>
+                </ContextMenu.Item>
+              )}
               <ContextMenu.Item
                 className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
                 onClick={handleArchiveRun}

--- a/apps/client/src/components/dashboard/TaskItem.tsx
+++ b/apps/client/src/components/dashboard/TaskItem.tsx
@@ -25,6 +25,7 @@ import {
   GitMerge,
   Pencil,
   Pin,
+  PinOff,
 } from "lucide-react";
 import { memo, useCallback, useMemo } from "react";
 import { EnvironmentName } from "./EnvironmentName";
@@ -72,6 +73,10 @@ export const TaskItem = memo(function TaskItem({
 
   // Mutation for toggling keep-alive status
   const toggleKeepAlive = useMutation(api.taskRuns.toggleKeepAlive);
+
+  // Mutations for pinning/unpinning tasks
+  const pinTask = useMutation(api.tasks.pin);
+  const unpinTask = useMutation(api.tasks.unpin);
 
   // Find the latest task run with a VSCode instance
   const getLatestVSCodeInstance = useCallback(() => {
@@ -188,6 +193,20 @@ export const TaskItem = memo(function TaskItem({
     },
     [unarchive, task._id]
   );
+
+  const handlePinFromMenu = useCallback(() => {
+    pinTask({
+      teamSlugOrId,
+      id: task._id,
+    });
+  }, [pinTask, teamSlugOrId, task._id]);
+
+  const handleUnpinFromMenu = useCallback(() => {
+    unpinTask({
+      teamSlugOrId,
+      id: task._id,
+    });
+  }, [unpinTask, teamSlugOrId, task._id]);
 
   return (
     <div className="relative group w-full">
@@ -347,6 +366,23 @@ export const TaskItem = memo(function TaskItem({
                   <span>Rename Task</span>
                 </ContextMenu.Item>
               ) : null}
+              {task.pinned ? (
+                <ContextMenu.Item
+                  className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
+                  onClick={handleUnpinFromMenu}
+                >
+                  <PinOff className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
+                  <span>Unpin Task</span>
+                </ContextMenu.Item>
+              ) : (
+                <ContextMenu.Item
+                  className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"
+                  onClick={handlePinFromMenu}
+                >
+                  <Pin className="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300" />
+                  <span>Pin Task</span>
+                </ContextMenu.Item>
+              )}
               {task.isArchived ? (
                 <ContextMenu.Item
                   className="flex items-center gap-2 cursor-default py-1.5 pr-8 pl-3 text-[13px] leading-5 outline-none select-none data-[highlighted]:relative data-[highlighted]:z-0 data-[highlighted]:text-white data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0 data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm data-[highlighted]:before:bg-neutral-900 dark:data-[highlighted]:before:bg-neutral-700"

--- a/apps/client/src/components/dashboard/TaskList.tsx
+++ b/apps/client/src/components/dashboard/TaskList.tsx
@@ -125,23 +125,17 @@ export const TaskList = memo(function TaskList({
   const categorizedTasks = useMemo(() => {
     const categorized = categorizeTasks(allTasks);
     if (categorized && pinnedData) {
-      // Add pinned tasks to the pinned category
-      // Filter out pinned tasks from other categories to avoid duplicates
-      const pinnedTaskIds = new Set(pinnedData.tasks.map(t => t._id));
-      const pinnedRunTaskIds = new Set(pinnedData.taskRuns.map(r => r.taskId));
-
-      // Combine pinned tasks and tasks from pinned runs
-      const allPinnedTaskIds = new Set([...pinnedTaskIds, ...pinnedRunTaskIds]);
-
       // Filter pinned tasks out from other categories
+      const pinnedTaskIds = new Set(pinnedData.map(t => t._id));
+
       for (const key of CATEGORY_ORDER) {
         if (key !== 'pinned') {
-          categorized[key] = categorized[key].filter(t => !allPinnedTaskIds.has(t._id));
+          categorized[key] = categorized[key].filter(t => !pinnedTaskIds.has(t._id));
         }
       }
 
-      // Add all pinned tasks to the pinned category
-      categorized.pinned = pinnedData.tasks;
+      // Add pinned tasks to the pinned category (already sorted by the API)
+      categorized.pinned = pinnedData;
     }
     return categorized;
   }, [allTasks, pinnedData]);

--- a/apps/client/src/components/dashboard/TaskList.tsx
+++ b/apps/client/src/components/dashboard/TaskList.tsx
@@ -8,12 +8,14 @@ import { TaskItem } from "./TaskItem";
 import { ChevronRight } from "lucide-react";
 
 type TaskCategoryKey =
+  | "pinned"
   | "workspaces"
   | "ready_to_review"
   | "in_progress"
   | "merged";
 
 const CATEGORY_ORDER: TaskCategoryKey[] = [
+  "pinned",
   "workspaces",
   "ready_to_review",
   "in_progress",
@@ -24,6 +26,10 @@ const CATEGORY_META: Record<
   TaskCategoryKey,
   { title: string; emptyLabel: string }
 > = {
+  pinned: {
+    title: "Pinned",
+    emptyLabel: "No pinned items.",
+  },
   workspaces: {
     title: "Workspaces",
     emptyLabel: "No workspace sessions yet.",
@@ -46,6 +52,7 @@ const createEmptyCategoryBuckets = (): Record<
   TaskCategoryKey,
   Doc<"tasks">[]
 > => ({
+  pinned: [],
   workspaces: [],
   ready_to_review: [],
   in_progress: [],
@@ -95,6 +102,7 @@ const categorizeTasks = (
 const createCollapsedCategoryState = (
   defaultValue = false
 ): Record<TaskCategoryKey, boolean> => ({
+  pinned: defaultValue,
   workspaces: defaultValue,
   ready_to_review: defaultValue,
   in_progress: defaultValue,
@@ -111,9 +119,32 @@ export const TaskList = memo(function TaskList({
     teamSlugOrId,
     archived: true,
   });
+  const pinnedData = useQuery(api.tasks.getPinned, { teamSlugOrId });
   const [tab, setTab] = useState<"all" | "archived">("all");
 
-  const categorizedTasks = useMemo(() => categorizeTasks(allTasks), [allTasks]);
+  const categorizedTasks = useMemo(() => {
+    const categorized = categorizeTasks(allTasks);
+    if (categorized && pinnedData) {
+      // Add pinned tasks to the pinned category
+      // Filter out pinned tasks from other categories to avoid duplicates
+      const pinnedTaskIds = new Set(pinnedData.tasks.map(t => t._id));
+      const pinnedRunTaskIds = new Set(pinnedData.taskRuns.map(r => r.taskId));
+
+      // Combine pinned tasks and tasks from pinned runs
+      const allPinnedTaskIds = new Set([...pinnedTaskIds, ...pinnedRunTaskIds]);
+
+      // Filter pinned tasks out from other categories
+      for (const key of CATEGORY_ORDER) {
+        if (key !== 'pinned') {
+          categorized[key] = categorized[key].filter(t => !allPinnedTaskIds.has(t._id));
+        }
+      }
+
+      // Add all pinned tasks to the pinned category
+      categorized.pinned = pinnedData.tasks;
+    }
+    return categorized;
+  }, [allTasks, pinnedData]);
   const categoryBuckets = categorizedTasks ?? createEmptyCategoryBuckets();
   const collapsedStorageKey = useMemo(
     () => `dashboard-collapsed-categories-${teamSlugOrId}`,
@@ -193,16 +224,22 @@ export const TaskList = memo(function TaskList({
           </div>
         ) : (
           <div className="mt-1 w-full flex flex-col space-y-[-1px] transform -translate-y-px">
-            {CATEGORY_ORDER.map((categoryKey) => (
-              <TaskCategorySection
-                key={categoryKey}
-                categoryKey={categoryKey}
-                tasks={categoryBuckets[categoryKey]}
-                teamSlugOrId={teamSlugOrId}
-                collapsed={Boolean(collapsedCategories[categoryKey])}
-                onToggle={toggleCategoryCollapse}
-              />
-            ))}
+            {CATEGORY_ORDER.map((categoryKey) => {
+              // Don't render the pinned category if it's empty
+              if (categoryKey === 'pinned' && categoryBuckets[categoryKey].length === 0) {
+                return null;
+              }
+              return (
+                <TaskCategorySection
+                  key={categoryKey}
+                  categoryKey={categoryKey}
+                  tasks={categoryBuckets[categoryKey]}
+                  teamSlugOrId={teamSlugOrId}
+                  collapsed={Boolean(collapsedCategories[categoryKey])}
+                  onToggle={toggleCategoryCollapse}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -177,7 +177,6 @@ const convexSchema = defineSchema({
       v.literal("failed")
     ),
     isArchived: v.optional(v.boolean()), // Whether this run is hidden from default views
-    pinned: v.optional(v.boolean()), // Whether this run is pinned
     isLocalWorkspace: v.optional(v.boolean()),
     isCloudWorkspace: v.optional(v.boolean()),
     // Optional log retained for backward compatibility; no longer written to.
@@ -291,8 +290,7 @@ const convexSchema = defineSchema({
     .index("by_vscode_status", ["vscode.status"])
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
-    .index("by_team_user", ["teamId", "userId"])
-    .index("by_pinned", ["pinned", "teamId", "userId"]),
+    .index("by_team_user", ["teamId", "userId"]),
   taskRunScreenshotSets: defineTable({
     taskId: v.id("tasks"),
     runId: v.id("taskRuns"),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -95,6 +95,7 @@ const convexSchema = defineSchema({
     text: v.string(),
     isCompleted: v.boolean(),
     isArchived: v.optional(v.boolean()),
+    pinned: v.optional(v.boolean()),
     isLocalWorkspace: v.optional(v.boolean()),
     isCloudWorkspace: v.optional(v.boolean()),
     description: v.optional(v.string()),
@@ -160,7 +161,8 @@ const convexSchema = defineSchema({
   })
     .index("by_created", ["createdAt"])
     .index("by_user", ["userId", "createdAt"])
-    .index("by_team_user", ["teamId", "userId"]),
+    .index("by_team_user", ["teamId", "userId"])
+    .index("by_pinned", ["pinned", "teamId", "userId"]),
 
   taskRuns: defineTable({
     taskId: v.id("tasks"),
@@ -175,6 +177,7 @@ const convexSchema = defineSchema({
       v.literal("failed")
     ),
     isArchived: v.optional(v.boolean()), // Whether this run is hidden from default views
+    pinned: v.optional(v.boolean()), // Whether this run is pinned
     isLocalWorkspace: v.optional(v.boolean()),
     isCloudWorkspace: v.optional(v.boolean()),
     // Optional log retained for backward compatibility; no longer written to.
@@ -288,7 +291,8 @@ const convexSchema = defineSchema({
     .index("by_vscode_status", ["vscode.status"])
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
-    .index("by_team_user", ["teamId", "userId"]),
+    .index("by_team_user", ["teamId", "userId"])
+    .index("by_pinned", ["pinned", "teamId", "userId"]),
   taskRunScreenshotSets: defineTable({
     taskId: v.id("tasks"),
     runId: v.id("taskRuns"),

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -1371,48 +1371,6 @@ export const archive = authMutation({
   },
 });
 
-export const pin = authMutation({
-  args: {
-    teamSlugOrId: v.string(),
-    id: v.id("taskRuns"),
-  },
-  handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
-
-    const run = await ctx.db.get(args.id);
-    if (!run || run.teamId !== teamId || run.userId !== userId) {
-      throw new Error("Task run not found or unauthorized");
-    }
-
-    await ctx.db.patch(args.id, {
-      pinned: true,
-      updatedAt: Date.now(),
-    });
-  },
-});
-
-export const unpin = authMutation({
-  args: {
-    teamSlugOrId: v.string(),
-    id: v.id("taskRuns"),
-  },
-  handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
-
-    const run = await ctx.db.get(args.id);
-    if (!run || run.teamId !== teamId || run.userId !== userId) {
-      throw new Error("Task run not found or unauthorized");
-    }
-
-    await ctx.db.patch(args.id, {
-      pinned: false,
-      updatedAt: Date.now(),
-    });
-  },
-});
-
 // Get containers that should be stopped based on TTL and settings
 export const getContainersToStop = authQuery({
   args: { teamSlugOrId: v.string() },

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -1371,6 +1371,48 @@ export const archive = authMutation({
   },
 });
 
+export const pin = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    id: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+
+    const run = await ctx.db.get(args.id);
+    if (!run || run.teamId !== teamId || run.userId !== userId) {
+      throw new Error("Task run not found or unauthorized");
+    }
+
+    await ctx.db.patch(args.id, {
+      pinned: true,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const unpin = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    id: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+
+    const run = await ctx.db.get(args.id);
+    if (!run || run.teamId !== teamId || run.userId !== userId) {
+      throw new Error("Task run not found or unauthorized");
+    }
+
+    await ctx.db.patch(args.id, {
+      pinned: false,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 // Get containers that should be stopped based on TTL and settings
 export const getContainersToStop = authQuery({
   args: { teamSlugOrId: v.string() },

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -55,30 +55,7 @@ export const getPinned = authQuery({
       .filter((q) => q.neq(q.field("isArchived"), true))
       .collect();
 
-    // Get pinned task runs
-    const pinnedRuns = await ctx.db
-      .query("taskRuns")
-      .withIndex("by_pinned", (idx) =>
-        idx.eq("pinned", true).eq("teamId", teamId).eq("userId", userId),
-      )
-      .filter((q) => q.neq(q.field("isArchived"), true))
-      .collect();
-
-    // For each pinned run, get its associated task
-    const tasksForRuns = await Promise.all(
-      pinnedRuns.map(async (run) => {
-        const task = await ctx.db.get(run.taskId);
-        return { run, task };
-      }),
-    );
-
-    return {
-      tasks: pinnedTasks.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)),
-      taskRuns: tasksForRuns
-        .filter(({ task }) => task !== null)
-        .map(({ run, task }) => ({ ...run, task }))
-        .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)),
-    };
+    return pinnedTasks.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
   },
 });
 


### PR DESCRIPTION
add pinning tasks/taskruns. needs to be supported in both sidebar and main /dashboard tasklist. pinned stuff should appear even above workspaces. should be pinned via right click. should be its own category on main /dashboard tasklist, but the category shouldn't be visible if there's no pinned tasks/taskruns. remember that user can pin either tasks or taskruns. we will need to add an optional "pinned" column to the tasks/taskRun tables.