### PR TITLE
Increase VNC reconnect rate via URL params

### DIFF
--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -134,6 +134,8 @@ export function toMorphVncUrl(sourceUrl: string): string | null {
   const searchParams = new URLSearchParams();
   searchParams.set("autoconnect", "1");
   searchParams.set("resize", "scale");
+  searchParams.set("reconnect", "1");
+  searchParams.set("reconnect_delay", "1000");
   vncUrl.search = `?${searchParams.toString()}`;
   vncUrl.hash = "";
 

--- a/apps/www/lib/routes/dev-server.route.ts
+++ b/apps/www/lib/routes/dev-server.route.ts
@@ -190,7 +190,15 @@ devServerRouter.openapi(startDevServerRoute, async (c) => {
 
     const vscodeUrl = `${vscodeService.url}/?folder=/root/workspace`;
     console.log(`VSCode URL: ${vscodeUrl}`);
-    const vncUrl = `${vncService.url}/vnc.html`;
+
+    const vncUrl = new URL("/vnc.html", vncService.url);
+    const vncSearchParams = new URLSearchParams();
+    vncSearchParams.set("autoconnect", "1");
+    vncSearchParams.set("resize", "scale");
+    vncSearchParams.set("reconnect", "1");
+    vncSearchParams.set("reconnect_delay", "1000");
+    vncUrl.search = `?${vncSearchParams.toString()}`;
+    const vncUrlString = vncUrl.toString();
 
     // Connect to the worker management namespace
     const clientSocket: Socket<WorkerToServerEvents, ServerToWorkerEvents> =
@@ -274,7 +282,7 @@ devServerRouter.openapi(startDevServerRoute, async (c) => {
         instanceId: instance.id,
         vscodeUrl,
         workerUrl: workerService.url,
-        vncUrl,
+        vncUrl: vncUrlString,
         cdpUrl: `${cdpService.url}/json/version`,
         status: "running",
         taskId: body.taskId,


### PR DESCRIPTION
the vnc viewer iframe is often stuck in connecting... is it possible to increase the reconnection attempt rate? ie by changing the url we load to provide query params? if it's possible, do it.