### PR TITLE
add back-forward icons and recents panel

### DIFF
--- a/apps/client/src/contexts/navigation-history/index.ts
+++ b/apps/client/src/contexts/navigation-history/index.ts
@@ -1,0 +1,7 @@
+export {
+  NavigationHistoryProvider,
+  useNavigationHistory,
+} from "./navigation-history-context";
+export type {
+  NavigationHistoryEntry,
+} from "./navigation-history-context";

--- a/apps/client/src/contexts/navigation-history/navigation-history-context.tsx
+++ b/apps/client/src/contexts/navigation-history/navigation-history-context.tsx
@@ -1,0 +1,269 @@
+import {
+  useRouter,
+  useRouterState,
+  type AnyRouteMatch,
+  type ParsedLocation,
+} from "@tanstack/react-router";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+const MAX_HISTORY_ENTRIES = 15;
+
+export type NavigationHistoryEntry = {
+  key: string;
+  title: string;
+  href: string;
+  pathname: string;
+  searchStr: string;
+  hash: string;
+  visitedAt: number;
+};
+
+type NavigationHistoryState = {
+  entries: NavigationHistoryEntry[];
+  currentIndex: number;
+};
+
+type NavigationHistoryValue = {
+  entries: NavigationHistoryEntry[];
+  recentEntries: NavigationHistoryEntry[];
+  currentEntry: NavigationHistoryEntry | null;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  goBack: () => void;
+  goForward: () => void;
+  navigateTo: (entry: NavigationHistoryEntry) => void;
+};
+
+const NavigationHistoryContext = createContext<NavigationHistoryValue | null>(
+  null
+);
+
+function createLocationKey(location: ParsedLocation): string {
+  const hash = location.hash ?? "";
+  return `${location.pathname}|${location.searchStr}|${hash}`;
+}
+
+function formatPathname(pathname: string): string {
+  if (!pathname) return "cmux";
+  const segments = pathname
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .filter((segment) => !segment.startsWith("_") && !segment.startsWith("$"));
+  if (segments.length === 0) {
+    return "cmux";
+  }
+  const last = segments[segments.length - 1];
+  return last
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function resolveTitleFromMatch(match: AnyRouteMatch | undefined): string {
+  if (!match) return "cmux";
+  const staticData = match.staticData;
+  if (staticData && typeof staticData === "object" && "title" in staticData) {
+    const candidate = (staticData as { title?: unknown }).title;
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return formatPathname(match.pathname ?? "");
+}
+
+function createHistoryEntry(
+  location: ParsedLocation,
+  title: string
+): NavigationHistoryEntry {
+  return {
+    key: createLocationKey(location),
+    title: title || "cmux",
+    href: location.href,
+    pathname: location.pathname,
+    searchStr: location.searchStr,
+    hash: location.hash,
+    visitedAt: Date.now(),
+  };
+}
+
+function syncHistoryWithLocation(
+  prev: NavigationHistoryState,
+  location: ParsedLocation,
+  title: string
+): NavigationHistoryState {
+  const entry = createHistoryEntry(location, title);
+  if (prev.entries.length === 0) {
+    return {
+      entries: [entry],
+      currentIndex: 0,
+    };
+  }
+
+  const { entries, currentIndex } = prev;
+  const current = entries[currentIndex];
+  if (current && current.key === entry.key) {
+    if (current.title === entry.title) {
+      return prev;
+    }
+    const nextEntries = entries.slice();
+    nextEntries[currentIndex] = { ...current, title: entry.title };
+    return { entries: nextEntries, currentIndex };
+  }
+
+  const backEntry =
+    currentIndex > 0 ? entries[currentIndex - 1] : undefined;
+  if (backEntry && backEntry.key === entry.key) {
+    const nextEntries = entries.slice();
+    nextEntries[currentIndex - 1] = {
+      ...backEntry,
+      title: entry.title,
+      href: entry.href,
+    };
+    return {
+      entries: nextEntries,
+      currentIndex: currentIndex - 1,
+    };
+  }
+
+  const forwardEntry =
+    currentIndex < entries.length - 1
+      ? entries[currentIndex + 1]
+      : undefined;
+  if (forwardEntry && forwardEntry.key === entry.key) {
+    const nextEntries = entries.slice();
+    nextEntries[currentIndex + 1] = {
+      ...forwardEntry,
+      title: entry.title,
+      href: entry.href,
+    };
+    return {
+      entries: nextEntries,
+      currentIndex: currentIndex + 1,
+    };
+  }
+
+  const nextEntries = entries.slice(0, currentIndex + 1).concat(entry);
+  const overflow = nextEntries.length - MAX_HISTORY_ENTRIES;
+  if (overflow > 0) {
+    return {
+      entries: nextEntries.slice(overflow),
+      currentIndex: nextEntries.length - 1 - overflow,
+    };
+  }
+
+  return {
+    entries: nextEntries,
+    currentIndex: nextEntries.length - 1,
+  };
+}
+
+export function NavigationHistoryProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  const location = useRouterState({
+    select: (state) => state.location,
+  });
+  const matches = useRouterState({
+    select: (state) => state.matches,
+  });
+
+  const activeMatch = matches[matches.length - 1];
+  const resolvedTitle = useMemo(
+    () => resolveTitleFromMatch(activeMatch),
+    [activeMatch]
+  );
+
+  const initialEntryRef = useRef<NavigationHistoryEntry | null>(null);
+  if (initialEntryRef.current === null) {
+    initialEntryRef.current = createHistoryEntry(location, resolvedTitle);
+  }
+
+  const [history, setHistory] = useState<NavigationHistoryState>(() => {
+    const entry = initialEntryRef.current;
+    return entry
+      ? { entries: [entry], currentIndex: 0 }
+      : { entries: [], currentIndex: -1 };
+  });
+
+  useEffect(() => {
+    setHistory((prev) => syncHistoryWithLocation(prev, location, resolvedTitle));
+  }, [location.pathname, location.searchStr, location.hash, location.href, resolvedTitle]);
+
+  const { entries, currentIndex } = history;
+  const currentEntry = currentIndex >= 0 ? entries[currentIndex] : null;
+  const canGoBack = currentIndex > 0;
+  const canGoForward =
+    currentIndex >= 0 && currentIndex < entries.length - 1;
+
+  const recentEntries = useMemo(() => {
+    return [...entries].reverse();
+  }, [entries]);
+
+  const goBack = useCallback(() => {
+    if (!canGoBack) return;
+    router.history.back();
+  }, [canGoBack, router]);
+
+  const goForward = useCallback(() => {
+    if (!canGoForward) return;
+    router.history.forward();
+  }, [canGoForward, router]);
+
+  const navigateTo = useCallback(
+    (entry: NavigationHistoryEntry) => {
+      if (!entry) return;
+      router.history.push(entry.href);
+    },
+    [router]
+  );
+
+  const value = useMemo<NavigationHistoryValue>(
+    () => ({
+      entries,
+      recentEntries,
+      currentEntry,
+      canGoBack,
+      canGoForward,
+      goBack,
+      goForward,
+      navigateTo,
+    }),
+    [
+      entries,
+      recentEntries,
+      currentEntry,
+      canGoBack,
+      canGoForward,
+      goBack,
+      goForward,
+      navigateTo,
+    ]
+  );
+
+  return (
+    <NavigationHistoryContext.Provider value={value}>
+      {children}
+    </NavigationHistoryContext.Provider>
+  );
+}
+
+export function useNavigationHistory(): NavigationHistoryValue {
+  const context = useContext(NavigationHistoryContext);
+  if (!context) {
+    throw new Error(
+      "useNavigationHistory must be used within a NavigationHistoryProvider"
+    );
+  }
+  return context;
+}

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -18,6 +18,9 @@ export const Route = createRootRouteWithContext<{
   auth: StackClientApp<true, string>;
 }>()({
   component: RootComponent,
+  staticData: {
+    title: "cmux Client",
+  },
 });
 
 function ToasterWithTheme() {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.connect-complete.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.connect-complete.tsx
@@ -5,6 +5,9 @@ import { useEffect, useRef, useState } from "react";
 export const Route = createFileRoute("/_layout/$teamSlugOrId/connect-complete")(
   {
     component: ConnectComplete,
+    staticData: {
+      title: "GitHub Connect Complete",
+    },
   }
 );
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -44,6 +44,9 @@ import { z } from "zod";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/dashboard")({
   component: DashboardComponent,
+  staticData: {
+    title: "Dashboard",
+  },
   loader: async (opts) => {
     const { teamSlugOrId } = opts.params;
     // Prewarm queries used in the dashboard

--- a/apps/client/src/routes/_layout.$teamSlugOrId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.diff.tsx
@@ -17,6 +17,9 @@ import { toast } from "sonner";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/diff")({
   component: DashboardDiffPage,
+  staticData: {
+    title: "Diff Viewer",
+  },
 });
 
 type DiffSearch = {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx
@@ -76,6 +76,9 @@ export const Route = createFileRoute(
     );
   },
   component: EnvironmentDetailsPage,
+  staticData: {
+    title: "Environment Details",
+  },
   validateSearch: () => ({}),
 });
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.index.tsx
@@ -19,6 +19,9 @@ export const Route = createFileRoute("/_layout/$teamSlugOrId/environments/")({
     });
   },
   component: EnvironmentsListPage,
+  staticData: {
+    title: "Environment List",
+  },
 });
 
 function EnvironmentsListPage() {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.new-version.tsx
@@ -32,6 +32,9 @@ export const Route = createFileRoute(
 )({
   component: NewSnapshotVersionPage,
   validateSearch: searchSchema,
+  staticData: {
+    title: "New Environment Version",
+  },
 });
 
 function NewSnapshotVersionPage() {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.new.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.new.tsx
@@ -69,6 +69,9 @@ export const Route = createFileRoute("/_layout/$teamSlugOrId/environments/new")(
   {
     component: EnvironmentsPage,
     validateSearch: searchSchema,
+    staticData: {
+      title: "New Environment",
+    },
   }
 );
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.environments.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.environments.tsx
@@ -3,6 +3,9 @@ import z from "zod";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/environments")({
   component: EnvironmentsLayout,
+  staticData: {
+    title: "Environments",
+  },
   validateSearch: (search: Record<string, unknown>) => {
     const step = z.enum(["select", "configure"]).optional().parse(search.step);
     const selectedRepos = z

--- a/apps/client/src/routes/_layout.$teamSlugOrId.logs.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.logs.tsx
@@ -4,6 +4,9 @@ import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/logs")({
   component: LogsRoute,
+  staticData: {
+    title: "Team Logs",
+  },
 });
 
 function LogsRoute() {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.prs-only.$owner.$repo.$number.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.prs-only.$owner.$repo.$number.tsx
@@ -7,6 +7,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/prs-only/$owner/$repo/$number"
 )({
   component: PROnlyRoute,
+  staticData: {
+    title: "Pull Request Review",
+  },
   loader: async (opts) => {
     const { teamSlugOrId, owner, repo, number } = opts.params;
     void preloadPullRequestDetail({

--- a/apps/client/src/routes/_layout.$teamSlugOrId.prs.$owner.$repo.$number.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.prs.$owner.$repo.$number.tsx
@@ -6,6 +6,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/prs/$owner/$repo/$number"
 )({
   component: PRDetailsRoute,
+  staticData: {
+    title: "Pull Request Detail",
+  },
   loader: async (opts) => {
     const { teamSlugOrId, owner, repo, number } = opts.params;
     void preloadPullRequestDetail({

--- a/apps/client/src/routes/_layout.$teamSlugOrId.prs.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.prs.tsx
@@ -10,6 +10,9 @@ import { useMemo, useState } from "react";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/prs")({
   component: PRsPage,
+  staticData: {
+    title: "Pull Requests",
+  },
   loader: async (opts) => {
     const { teamSlugOrId } = opts.params;
     convexQueryClient.convexClient.prewarmQuery({

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -17,6 +17,9 @@ import { toast } from "sonner";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/settings")({
   component: SettingsComponent,
+  staticData: {
+    title: "Team Settings",
+  },
 });
 
 function SettingsComponent() {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -70,6 +70,9 @@ const paramsSchema = z.object({
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/task/$taskId/")({
   component: TaskDetailPage,
+  staticData: {
+    title: "Task Overview",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => ({

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
@@ -25,6 +25,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/browser"
 )({
   component: BrowserComponent,
+  staticData: {
+    title: "Run Browser",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => ({

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -497,6 +497,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/diff",
 )({
   component: RunDiffPage,
+  staticData: {
+    title: "Run Diff",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.index.tsx
@@ -26,6 +26,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/"
 )({
   component: TaskRunComponent,
+  staticData: {
+    title: "Run Overview",
+  },
   parseParams: (params) => ({
     ...params,
     taskRunId: typedZid("taskRuns").parse(params.runId),

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.pr.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.pr.tsx
@@ -19,6 +19,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/pr"
 )({
   component: RunPullRequestPage,
+  staticData: {
+    title: "Run Pull Request",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$previewId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.preview.$previewId.tsx
@@ -51,6 +51,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/preview/$previewId"
 )({
   component: PreviewPage,
+  staticData: {
+    title: "Run Preview",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
@@ -33,6 +33,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/terminals"
 )({
   component: TaskRunTerminals,
+  staticData: {
+    title: "Run Terminals",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => ({

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -31,6 +31,9 @@ export const Route = createFileRoute(
   "/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode"
 )({
   component: VSCodeComponent,
+  staticData: {
+    title: "Run VS Code",
+  },
   params: {
     parse: paramsSchema.parse,
     stringify: (params) => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
@@ -15,6 +15,9 @@ import { useQuery } from "convex/react";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/task/$taskId")({
   component: TaskDetailPage,
+  staticData: {
+    title: "Task Detail",
+  },
   parseParams: (params) => ({
     ...params,
     taskId: typedZid("tasks").parse(params.taskId),

--- a/apps/client/src/routes/_layout.$teamSlugOrId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/components/Sidebar";
 import { SIDEBAR_PRS_DEFAULT_LIMIT } from "@/components/sidebar/const";
 import { convexQueryClient } from "@/contexts/convex/convex-query-client";
 import { ExpandTasksProvider } from "@/contexts/expand-tasks/ExpandTasksProvider";
+import { NavigationHistoryProvider } from "@/contexts/navigation-history";
 import { cachedGetUser } from "@/lib/cachedGetUser";
 import { setLastTeamSlugOrId } from "@/lib/lastTeam";
 import { stackClientApp } from "@/lib/stack";
@@ -14,6 +15,9 @@ import { Suspense, useEffect, useMemo } from "react";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId")({
   component: LayoutComponentWrapper,
+  staticData: {
+    title: "Team Workspace",
+  },
   beforeLoad: async ({ params, location }) => {
     const user = await cachedGetUser(stackClientApp);
     if (!user) {
@@ -125,9 +129,9 @@ function LayoutComponentWrapper() {
     setLastTeamSlugOrId(teamSlugOrId);
   }, [teamSlugOrId]);
   return (
-    <>
+    <NavigationHistoryProvider>
       <LayoutComponent />
       <CmuxComments teamSlugOrId={teamSlugOrId} />
-    </>
+    </NavigationHistoryProvider>
   );
 }

--- a/apps/client/src/routes/_layout.$teamSlugOrId.workspaces.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.workspaces.tsx
@@ -13,6 +13,9 @@ import { useMemo } from "react";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/workspaces")({
   component: WorkspacesRoute,
+  staticData: {
+    title: "Workspaces",
+  },
   loader: async ({ params }) => {
     const { teamSlugOrId } = params;
     void convexQueryClient.queryClient.ensureQueryData(

--- a/apps/client/src/routes/_layout.debug.tsx
+++ b/apps/client/src/routes/_layout.debug.tsx
@@ -5,6 +5,9 @@ import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_layout/debug")({
   component: DebugComponent,
+  staticData: {
+    title: "Debug",
+  },
 });
 
 function DebugComponent() {

--- a/apps/client/src/routes/_layout.profile.tsx
+++ b/apps/client/src/routes/_layout.profile.tsx
@@ -2,6 +2,9 @@ import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_layout/profile")({
   component: ProfileComponent,
+  staticData: {
+    title: "Profile",
+  },
 });
 
 function ProfileComponent() {

--- a/apps/client/src/routes/_layout.team-picker.tsx
+++ b/apps/client/src/routes/_layout.team-picker.tsx
@@ -21,6 +21,9 @@ import type React from "react";
 
 export const Route = createFileRoute("/_layout/team-picker")({
   component: TeamPicker,
+  staticData: {
+    title: "Team Picker",
+  },
 });
 
 function TeamPicker() {

--- a/apps/client/src/routes/_layout.tsx
+++ b/apps/client/src/routes/_layout.tsx
@@ -11,6 +11,9 @@ import {
 
 export const Route = createFileRoute("/_layout")({
   component: Layout,
+  staticData: {
+    title: "App Shell",
+  },
   beforeLoad: async ({ context }) => {
     const user = await cachedGetUser(stackClientApp);
     if (!user) {

--- a/apps/client/src/routes/debug-icon.tsx
+++ b/apps/client/src/routes/debug-icon.tsx
@@ -6,6 +6,9 @@ import { useMemo, useState } from "react";
 
 export const Route = createFileRoute("/debug-icon")({
   component: DebugIconPage,
+  staticData: {
+    title: "Debug Icons",
+  },
 });
 
 function NumberInput({

--- a/apps/client/src/routes/debug-monaco.tsx
+++ b/apps/client/src/routes/debug-monaco.tsx
@@ -89,6 +89,9 @@ function computeDiffStats(original: string, modified: string) {
 
 export const Route = createFileRoute("/debug-monaco")({
   component: DebugMonacoPage,
+  staticData: {
+    title: "Debug Monaco",
+  },
 });
 
 function DebugMonacoPage() {
@@ -126,4 +129,3 @@ function DebugMonacoPage() {
     </div>
   );
 }
-

--- a/apps/client/src/routes/debug-webcontents.tsx
+++ b/apps/client/src/routes/debug-webcontents.tsx
@@ -3,6 +3,9 @@ import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/debug-webcontents")({
   component: DebugWebContentsRoute,
+  staticData: {
+    title: "Debug WebContents",
+  },
 });
 
 function DebugWebContentsRoute() {

--- a/apps/client/src/routes/electron-error.tsx
+++ b/apps/client/src/routes/electron-error.tsx
@@ -16,6 +16,9 @@ const errorSearchSchema = z.object({
 export const Route = createFileRoute("/electron-error" as any)({
   validateSearch: errorSearchSchema,
   component: ElectronErrorPage,
+  staticData: {
+    title: "Electron Error",
+  },
 });
 
 interface ErrorDisplay {

--- a/apps/client/src/routes/electron-web-contents.tsx
+++ b/apps/client/src/routes/electron-web-contents.tsx
@@ -8,6 +8,9 @@ import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/electron-web-contents")({
   component: ElectronWebContentsPage,
+  staticData: {
+    title: "Electron WebContents",
+  },
 });
 
 interface ElectronWebContentsPageProps {

--- a/apps/client/src/routes/handler.$.tsx
+++ b/apps/client/src/routes/handler.$.tsx
@@ -4,6 +4,9 @@ import { createFileRoute, useLocation } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/handler/$")({
   component: HandlerComponent,
+  staticData: {
+    title: "Handler",
+  },
 });
 
 function HandlerComponent() {

--- a/apps/client/src/routes/index.tsx
+++ b/apps/client/src/routes/index.tsx
@@ -15,4 +15,7 @@ export const Route = createFileRoute("/")({
     throw redirect({ to: "/team-picker" });
   },
   component: () => null,
+  staticData: {
+    title: "Start",
+  },
 });

--- a/apps/client/src/routes/monaco-single-buffer.tsx
+++ b/apps/client/src/routes/monaco-single-buffer.tsx
@@ -589,6 +589,9 @@ const FILE_LABEL_ZONE_HEIGHT = 32;
 
 export const Route = createFileRoute("/monaco-single-buffer")({
   component: MonacoSingleBufferRoute,
+  staticData: {
+    title: "Monaco Single Buffer",
+  },
 });
 
 function MonacoSingleBufferRoute() {

--- a/apps/client/src/routes/sign-in.tsx
+++ b/apps/client/src/routes/sign-in.tsx
@@ -15,4 +15,7 @@ export const Route = createFileRoute("/sign-in")({
     }
   },
   component: SignInComponent,
+  staticData: {
+    title: "Sign In",
+  },
 });


### PR DESCRIPTION
for electron, add back and forward navigation to the right of the cmux.dev logo (left of plus button). should be iconbuttons with no border (but yes bg with transition on hover). should have third button with time icon that will show recently viewed pages. just show 15 entries, no scroll necessary. ideally i want to see the page titles for each of the recent ones. so we need a data structure to store titles of the pages we navigated to/from. and for each of the tanstack routes, we need to add good titles as well.