### PR TITLE
Pass refreshed access token to server on refresh

### DIFF
--- a/apps/client/src/contexts/socket/electron-socket-provider.tsx
+++ b/apps/client/src/contexts/socket/electron-socket-provider.tsx
@@ -101,6 +101,24 @@ export const ElectronSocketProvider: React.FC<React.PropsWithChildren> = ({
     };
   }, [authToken, teamSlugOrId]);
 
+  // Send updated auth token to server whenever authJson changes (e.g., token refresh every 9 minutes)
+  useEffect(() => {
+    if (!socket || !isConnected || !authJsonQuery.data) {
+      return;
+    }
+
+    const authJson = authJsonQuery.data;
+    if (!authJson?.accessToken) {
+      return;
+    }
+
+    console.log("[ElectronSocket] Sending updated auth token to server");
+    socket.emit("update-auth", {
+      authToken: authJson.accessToken,
+      authJson: JSON.stringify(authJson),
+    });
+  }, [socket, isConnected, authJsonQuery.data]);
+
   const contextValue = useMemo<SocketContextType>(
     () => ({
       socket,

--- a/apps/client/src/contexts/socket/socket-provider.tsx
+++ b/apps/client/src/contexts/socket/socket-provider.tsx
@@ -115,6 +115,24 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({
     };
   }, [url, authToken, teamSlugOrId]);
 
+  // Send updated auth token to server whenever authJson changes (e.g., token refresh every 9 minutes)
+  useEffect(() => {
+    if (!socket || !isConnected || !authJsonQuery.data) {
+      return;
+    }
+
+    const authJson = authJsonQuery.data;
+    if (!authJson?.accessToken) {
+      return;
+    }
+
+    console.log("[Socket] Sending updated auth token to server");
+    socket.emit("update-auth", {
+      authToken: authJson.accessToken,
+      authJson: JSON.stringify(authJson),
+    });
+  }, [socket, isConnected, authJsonQuery.data]);
+
   const contextValue: SocketContextType = useMemo(
     () => ({
       socket,

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -17,6 +17,7 @@ import {
   type CreateLocalWorkspaceResponse,
   CreateCloudWorkspaceSchema,
   type CreateCloudWorkspaceResponse,
+  UpdateAuthSchema,
   type AvailableEditors,
   type FileInfo,
   isLoopbackHostname,
@@ -198,13 +199,13 @@ export function setupSocketHandlers(
   rt.onConnection((socket) => {
     // Ensure every packet runs within the auth context associated with this socket
     const q = socket.handshake.query?.auth;
-    const token = Array.isArray(q)
+    let token = Array.isArray(q)
       ? q[0]
       : typeof q === "string"
         ? q
         : undefined;
     const qJson = socket.handshake.query?.auth_json;
-    const tokenJson = Array.isArray(qJson)
+    let tokenJson = Array.isArray(qJson)
       ? qJson[0]
       : typeof qJson === "string"
         ? qJson
@@ -221,6 +222,18 @@ export function setupSocketHandlers(
       runWithAuth(token, tokenJson, () => next());
     });
     serverLogger.info("Client connected:", socket.id);
+
+    // Handle auth token updates (e.g., when token refreshes every 9 minutes)
+    socket.on("update-auth", (data) => {
+      try {
+        const { authToken, authJson } = UpdateAuthSchema.parse(data);
+        token = authToken;
+        tokenJson = authJson;
+        serverLogger.info("Auth token updated for socket:", socket.id);
+      } catch (error) {
+        serverLogger.error("Error updating auth token:", error);
+      }
+    });
 
     // Rust N-API test endpoint
     socket.on("rust-get-time", async (callback) => {

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -374,6 +374,12 @@ export const SpawnFromCommentSchema = z.object({
   devicePixelRatio: z.number().optional(),
 });
 
+// Auth token update schema
+export const UpdateAuthSchema = z.object({
+  authToken: z.string(),
+  authJson: z.string().optional(),
+});
+
 // Provider status schemas
 export const ProviderStatusSchema = z.object({
   name: z.string(),
@@ -476,6 +482,7 @@ export type GitHubSyncPrState = z.infer<typeof GitHubSyncPrStateSchema>;
 export type GitHubMergeBranch = z.infer<typeof GitHubMergeBranchSchema>;
 export type ArchiveTask = z.infer<typeof ArchiveTaskSchema>;
 export type SpawnFromComment = z.infer<typeof SpawnFromCommentSchema>;
+export type UpdateAuth = z.infer<typeof UpdateAuthSchema>;
 export type ProviderStatus = z.infer<typeof ProviderStatusSchema>;
 export type DockerStatus = z.infer<typeof DockerStatusSchema>;
 export type GitStatus = z.infer<typeof GitStatusSchema>;
@@ -590,6 +597,7 @@ export interface ClientToServerEvents {
       error?: string;
     }) => void
   ) => void;
+  "update-auth": (data: UpdateAuth) => void;
 }
 
 export interface ServerToClientEvents {


### PR DESCRIPTION
so the problem with {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 250 seconds ago"} can be solved if we pass the refreshedAccessToken (Which we do every 9 minutes or something like that in our code) into server.. via socket-handler.ts... i think... server is just having the outdated token which makes this error happen, we need to pass it everytime we get a refreshed token since it expires.