### PR TITLE
cmux proxy: HTTP/2 + host override plumbing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -918,13 +918,36 @@ RUN --mount=type=secret,id=github_token,required=false <<-'EOF'
     set -eux; \
     arch="$(uname -m)"; \
     DOCKER_CHANNEL="${DOCKER_CHANNEL:-stable}"; \
-    DOCKER_VERSION="${DOCKER_VERSION:-$(github-curl -fsSL https://api.github.com/repos/docker/docker/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    FALLBACK_DOCKER_VERSION="27.4.0"; \
+    raw_version="${DOCKER_VERSION:-}"; \
+    if [ -z "$raw_version" ]; then \
+        raw_version="$(github-curl -fsSL https://api.github.com/repos/docker/docker/releases/latest | jq -r '.tag_name' | sed 's/^v//')"; \
+    fi; \
+    sanitize_version() { \
+        local value="$1"; \
+        value="${value#docker-}"; \
+        value="${value#v}"; \
+        printf '%s' "$value"; \
+    }; \
+    DOCKER_VERSION="$(sanitize_version "$raw_version")"; \
     case "$arch" in \
         x86_64) dockerArch='x86_64' ;; \
         aarch64) dockerArch='aarch64' ;; \
         *) echo >&2 "error: unsupported architecture ($arch)"; exit 1 ;; \
     esac; \
-    wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; \
+    download_docker() { \
+        local version="$1"; \
+        wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${version}.tgz"; \
+    }; \
+    if ! download_docker "$DOCKER_VERSION"; then \
+        if [ -z "${raw_version}" ]; then \
+            DOCKER_VERSION="$FALLBACK_DOCKER_VERSION"; \
+            download_docker "$DOCKER_VERSION"; \
+        else \
+            echo "Failed to download docker-${DOCKER_VERSION}.tgz" >&2; \
+            exit 1; \
+        fi; \
+    fi; \
     tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/; \
     rm docker.tgz; \
     dockerd --version || echo "dockerd --version failed (ignored during build)"; \
@@ -941,17 +964,53 @@ RUN --mount=type=secret,id=github_token,required=false <<-'EOF'
         aarch64) composeArch='aarch64'; buildxAsset='linux-arm64'; buildkitAsset='linux-arm64' ;; \
         *) echo >&2 "error: unsupported architecture ($arch)"; exit 1 ;; \
     esac; \
-    DOCKER_COMPOSE_VERSION="${DOCKER_COMPOSE_VERSION:-$(github-curl -fsSL https://api.github.com/repos/docker/compose/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    FALLBACK_VERSION="2.24.7"; \
+    raw_compose="${DOCKER_COMPOSE_VERSION:-$(github-curl -fsSL https://api.github.com/repos/docker/compose/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    sanitize_version() { \
+        local value="$1"; \
+        value="${value#docker-}"; \
+        value="${value#v}"; \
+        printf '%s' "$value"; \
+    }; \
+    DOCKER_COMPOSE_VERSION="$(sanitize_version "$raw_compose")"; \
     github-curl -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${composeArch}" \
-        -o /usr/local/lib/docker/cli-plugins/docker-compose; \
+        -o /usr/local/lib/docker/cli-plugins/docker-compose || { \
+            if [ -z "${raw_compose}" ]; then \
+                DOCKER_COMPOSE_VERSION="$FALLBACK_VERSION"; \
+                github-curl -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${composeArch}" \
+                    -o /usr/local/lib/docker/cli-plugins/docker-compose; \
+            else \
+                exit 1; \
+            fi; \
+        }; \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose; \
-    BUILDX_VERSION="${BUILDX_VERSION:-$(github-curl -fsSL https://api.github.com/repos/docker/buildx/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    BUILDX_FALLBACK="0.15.1"; \
+    raw_buildx="${BUILDX_VERSION:-$(github-curl -fsSL https://api.github.com/repos/docker/buildx/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    BUILDX_VERSION="$(sanitize_version "$raw_buildx")"; \
     github-curl -fsSL "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.${buildxAsset}" \
-        -o /usr/local/lib/docker/cli-plugins/docker-buildx; \
+        -o /usr/local/lib/docker/cli-plugins/docker-buildx || { \
+            if [ -z "${raw_buildx}" ]; then \
+                BUILDX_VERSION="$BUILDX_FALLBACK"; \
+                github-curl -fsSL "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.${buildxAsset}" \
+                    -o /usr/local/lib/docker/cli-plugins/docker-buildx; \
+            else \
+                exit 1; \
+            fi; \
+        }; \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx; \
-    BUILDKIT_VERSION="${BUILDKIT_VERSION:-$(github-curl -fsSL https://api.github.com/repos/moby/buildkit/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    BUILDKIT_FALLBACK="0.15.2"; \
+    raw_buildkit="${BUILDKIT_VERSION:-$(github-curl -fsSL https://api.github.com/repos/moby/buildkit/releases/latest | jq -r '.tag_name' | sed 's/^v//')}"; \
+    BUILDKIT_VERSION="$(sanitize_version "$raw_buildkit")"; \
     github-curl -fsSL "https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/buildkit-v${BUILDKIT_VERSION}.${buildkitAsset}.tar.gz" \
-        -o /tmp/buildkit.tar.gz; \
+        -o /tmp/buildkit.tar.gz || { \
+            if [ -z "${raw_buildkit}" ]; then \
+                BUILDKIT_VERSION="$BUILDKIT_FALLBACK"; \
+                github-curl -fsSL "https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/buildkit-v${BUILDKIT_VERSION}.${buildkitAsset}.tar.gz" \
+                    -o /tmp/buildkit.tar.gz; \
+            else \
+                exit 1; \
+            fi; \
+        }; \
     tar -xzf /tmp/buildkit.tar.gz -C /tmp; \
     install -m 0755 /tmp/bin/buildctl /usr/local/bin/buildctl; \
     install -m 0755 /tmp/bin/buildkitd /usr/local/bin/buildkitd; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -232,6 +232,7 @@ RUN --mount=type=secret,id=github_token,required=false if [ -z "${CODE_RELEASE}"
 
 # Copy package files for monorepo dependency installation
 WORKDIR /cmux
+ENV BUN_INSTALL_CACHE_DIR=/cmux/node_modules/.bun
 COPY package.json bun.lock .npmrc ./
 COPY --parents apps/*/package.json packages/*/package.json scripts/package.json ./
 
@@ -681,6 +682,7 @@ RUN curl -fsSL https://bun.sh/install | bash && \
   bunx --version
 
 ENV PATH="/usr/local/bin:$PATH"
+ENV BUN_INSTALL_CACHE_DIR=/cmux/node_modules/.bun
 
 RUN --mount=type=cache,target=/root/.bun/install/cache \
   bun add -g @openai/codex@0.50.0 @anthropic-ai/claude-code@2.0.27 @google/gemini-cli@0.1.21 opencode-ai@0.6.4 codebuff @devcontainers/cli @sourcegraph/amp

--- a/crates/cmux-proxy/Cargo.lock
+++ b/crates/cmux-proxy/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,8 +183,10 @@ dependencies = [
  "bytes",
  "clap",
  "futures-util",
- "http 0.2.12",
+ "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -341,16 +349,16 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -372,17 +380,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -394,12 +391,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -417,26 +426,46 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
- "want",
 ]
 
 [[package]]
@@ -886,16 +915,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -992,7 +1011,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -1115,7 +1134,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http",
  "httparse",
  "log",
  "rand",

--- a/crates/cmux-proxy/Cargo.toml
+++ b/crates/cmux-proxy/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }
-# HTTP server/client
-hyper = { version = "0.14", features = ["full"] }
-http = "0.2"
+# HTTP/2 server/client
+hyper = { version = "1", features = ["http1", "http2", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "client-legacy"] }
+http = "1"
+http-body-util = "0.1"
 bytes = "1"
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"

--- a/crates/cmux-proxy/tests/ldpreload.rs
+++ b/crates/cmux-proxy/tests/ldpreload.rs
@@ -2,15 +2,22 @@
 mod linux_only {
     use std::env;
     use std::io::{Read, Write};
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::net::TcpListener as StdTcpListener;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::sync::OnceLock;
     use std::time::Duration;
 
+    use bytes::Bytes;
     use cmux_proxy::workspace_ip_from_name;
-    use hyper::service::{make_service_fn, service_fn};
-    use hyper::{Body, Request, Response, Server};
+    use http::{Request, Response};
+    use http_body_util::Full;
+    use hyper::body::Incoming;
+    use hyper::service::service_fn;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use hyper_util::server::conn::auto::Builder as AutoBuilder;
+    use tokio::net::TcpListener as TokioTcpListener;
     use tokio::time::sleep;
     use tokio::time::timeout;
 
@@ -21,20 +28,35 @@ mod linux_only {
     }
 
     async fn start_upstream_http_on_fixed(ip: Ipv4Addr, port: u16, body: &'static str) {
-        let make_svc = make_service_fn(move |_conn| {
-            let body_text = body;
-            async move {
-                Ok::<_, std::convert::Infallible>(service_fn(move |_req: Request<Body>| {
-                    let body_text = body_text;
-                    async move {
-                        Ok::<_, std::convert::Infallible>(Response::new(Body::from(body_text)))
+        let listener = TokioTcpListener::bind(SocketAddr::from((IpAddr::V4(ip), port)))
+            .await
+            .expect("bind upstream");
+        let response_bytes = Bytes::from_static(body.as_bytes());
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let response_bytes = response_bytes.clone();
+                tokio::spawn(async move {
+                    let service = service_fn(move |_req: Request<Incoming>| {
+                        let response_bytes = response_bytes.clone();
+                        async move {
+                            Ok::<_, std::convert::Infallible>(Response::new(Full::new(
+                                response_bytes,
+                            )))
+                        }
+                    });
+                    if let Err(err) = AutoBuilder::new(TokioExecutor::new())
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await
+                    {
+                        eprintln!("ldpreload upstream error: {err}");
                     }
-                }))
+                });
             }
         });
-        let addr: SocketAddr = (IpAddr::V4(ip), port).into();
-        let server = Server::bind(&addr).serve(make_svc);
-        tokio::spawn(server);
         // tiny delay to ensure listener is up
         sleep(Duration::from_millis(50)).await;
     }
@@ -75,7 +97,7 @@ mod linux_only {
         ensure_loopback(ws_ip).await;
 
         // Start a plain TCP echo server bound to the workspace IP
-        let listener = TcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
+        let listener = StdTcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
         let addr = listener.local_addr().unwrap();
         std::thread::spawn(move || {
             if let Ok((mut s, _)) = listener.accept() {
@@ -128,7 +150,7 @@ mod linux_only {
         ensure_loopback(ws_ip).await;
 
         // Start echo server on workspace IP
-        let listener = TcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
+        let listener = StdTcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
         let addr = listener.local_addr().unwrap();
         std::thread::spawn(move || {
             if let Ok((mut s, _)) = listener.accept() {

--- a/crates/cmux-proxy/tests/ldpreload.rs
+++ b/crates/cmux-proxy/tests/ldpreload.rs
@@ -2,8 +2,8 @@
 mod linux_only {
     use std::env;
     use std::io::{Read, Write};
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::net::TcpListener as StdTcpListener;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::sync::OnceLock;
@@ -97,7 +97,8 @@ mod linux_only {
         ensure_loopback(ws_ip).await;
 
         // Start a plain TCP echo server bound to the workspace IP
-        let listener = StdTcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
+        let listener =
+            StdTcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
         let addr = listener.local_addr().unwrap();
         std::thread::spawn(move || {
             if let Ok((mut s, _)) = listener.accept() {
@@ -150,7 +151,8 @@ mod linux_only {
         ensure_loopback(ws_ip).await;
 
         // Start echo server on workspace IP
-        let listener = StdTcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
+        let listener =
+            StdTcpListener::bind(SocketAddr::from((ws_ip, 0))).expect("bind workspace ip");
         let addr = listener.local_addr().unwrap();
         std::thread::spawn(move || {
             if let Ok((mut s, _)) = listener.accept() {

--- a/crates/cmux-proxy/tests/proxy.rs
+++ b/crates/cmux-proxy/tests/proxy.rs
@@ -290,19 +290,11 @@ fn new_test_client() -> Client<HttpConnector, TestRequestBody> {
     Client::builder(TokioExecutor::new()).build(connector)
 }
 
-fn next_port() -> u16 {
-    std::net::TcpListener::bind(("127.0.0.1", 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_http_proxy_routes_by_header() {
     let upstream_addr = start_upstream_http().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         false,
     )
@@ -364,7 +356,7 @@ async fn test_http_proxy_routes_by_header() {
 async fn test_wildcard_bind_accepts_localhost_clients() {
     let upstream_addr = start_upstream_http().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::UNSPECIFIED, next_port())),
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
         "127.0.0.1",
         false,
     )
@@ -394,7 +386,7 @@ async fn test_wildcard_bind_accepts_localhost_clients() {
 async fn test_websocket_proxy_upgrade() {
     let ws_addr = start_upstream_ws_like_upgrade_echo().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         false,
     )
@@ -443,7 +435,7 @@ async fn test_websocket_proxy_upgrade() {
 async fn test_connect_tcp_tunnel() {
     let (echo_addr, _echo_handle) = start_upstream_tcp_echo().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         false,
     )
@@ -500,7 +492,7 @@ async fn test_websocket_end_to_end_frames() {
     // Start real WebSocket upstream and proxy
     let (ws_addr, _ws_handle) = start_upstream_real_ws_echo().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         false,
     )
@@ -558,7 +550,7 @@ async fn test_websocket_ping_pong_forwarding() {
 
     let (ws_addr, _ws_handle) = start_upstream_real_ws_echo().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         false,
     )
@@ -600,7 +592,7 @@ async fn test_concurrent_websocket_connections() {
 
     let (ws_addr, ws_handle) = start_upstream_real_ws_echo_multi().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         false,
     )
@@ -658,7 +650,7 @@ async fn test_concurrent_websocket_connections() {
 async fn test_http2_clients_are_supported() {
     let upstream_addr = start_upstream_http().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         true,
     )
@@ -708,7 +700,7 @@ async fn test_http2_clients_are_supported() {
 async fn test_host_override_header_sets_host() {
     let upstream_addr = start_upstream_host_echo().await;
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
         "127.0.0.1",
         true,
     )

--- a/crates/cmux-proxy/tests/proxy.rs
+++ b/crates/cmux-proxy/tests/proxy.rs
@@ -3,9 +3,11 @@ use std::io::ErrorKind;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
+use bytes::Bytes;
 use cmux_proxy::ProxyConfig;
 use futures_util::{FutureExt, SinkExt, StreamExt};
 use http_body_util::BodyExt;
+use http_body_util::{Empty, Full};
 use hyper::body::Incoming;
 use hyper::client::conn::http2;
 use hyper::server::conn::http1;
@@ -17,8 +19,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio::time::{sleep, timeout};
-use bytes::Bytes;
-use http_body_util::{Empty, Full};
 
 type TestRequestBody = Empty<Bytes>;
 
@@ -337,11 +337,7 @@ async fn test_http_proxy_routes_by_header() {
     assert!(s.contains("ok:GET:/hello"), "unexpected body: {}", s);
 
     // Same request but with a custom host should fail without override
-    let url_custom = format!(
-        "http://{}:{}/hello",
-        proxy_addr.ip(),
-        proxy_addr.port()
-    );
+    let url_custom = format!("http://{}:{}/hello", proxy_addr.ip(), proxy_addr.port());
     let req_custom = Request::builder()
         .method("GET")
         .uri(url_custom)

--- a/crates/cmux-proxy/tests/workspace.rs
+++ b/crates/cmux-proxy/tests/workspace.rs
@@ -4,41 +4,77 @@ use std::convert::Infallible;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
+use bytes::Bytes;
 use cmux_proxy::{workspace_ip_from_name, ProxyConfig};
-use hyper::body::to_bytes;
-use hyper::client::HttpConnector;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Client, Method, Request, Response, Server, StatusCode};
+use futures_util::FutureExt;
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::{BodyExt, Empty, Full};
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper_util::client::legacy::{connect::HttpConnector, Client};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder as AutoBuilder;
+use tokio::net::TcpListener;
 use tokio::sync::oneshot;
-use tokio::time::sleep;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 async fn start_upstream_http_on(ip: Ipv4Addr) -> SocketAddr {
-    let make_svc = make_service_fn(|_conn| async move {
-        Ok::<_, Infallible>(service_fn(|req: Request<Body>| async move {
-            let body = format!("ok:{}:{}", req.method(), req.uri().path());
-            Ok::<_, Infallible>(Response::new(Body::from(body)))
-        }))
+    let listener = TcpListener::bind(SocketAddr::from((IpAddr::V4(ip), 0)))
+        .await
+        .expect("bind upstream");
+    let local = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let service = service_fn(|req: Request<Incoming>| async move {
+                    let body = format!("ok:{}:{}", req.method(), req.uri().path());
+                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(body))))
+                });
+                if let Err(err) = AutoBuilder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await
+                {
+                    eprintln!("HTTP upstream error: {err}");
+                }
+            });
+        }
     });
-    let addr: SocketAddr = (IpAddr::V4(ip), 0).into();
-    let server = Server::bind(&addr).serve(make_svc);
-    let local = server.local_addr();
-    tokio::spawn(server);
     local
 }
 
 #[cfg(target_os = "linux")]
 async fn start_upstream_http_on_fixed(ip: Ipv4Addr, port: u16, body: &'static str) {
-    let make_svc = make_service_fn(move |_conn| async move {
-        let body_text = body;
-        Ok::<_, Infallible>(service_fn(move |_req: Request<Body>| async move {
-            Ok::<_, Infallible>(Response::new(Body::from(body_text)))
-        }))
+    let listener = TcpListener::bind(SocketAddr::from((IpAddr::V4(ip), port)))
+        .await
+        .expect("bind fixed upstream");
+    let response_bytes = Bytes::from_static(body.as_bytes());
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            let response_bytes = response_bytes.clone();
+            tokio::spawn(async move {
+                let service = service_fn(move |_req: Request<Incoming>| {
+                    let response_bytes = response_bytes.clone();
+                    async move {
+                        Ok::<_, Infallible>(Response::new(Full::new(response_bytes)))
+                    }
+                });
+                if let Err(err) = AutoBuilder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await
+                {
+                    eprintln!("HTTP upstream fixed error: {err}");
+                }
+            });
+        }
     });
-    let addr: SocketAddr = (IpAddr::V4(ip), port).into();
-    let server = Server::bind(&addr).serve(make_svc);
-    tokio::spawn(server);
-    // tiny delay to ensure listener is up
     sleep(Duration::from_millis(50)).await;
 }
 
@@ -53,10 +89,28 @@ async fn start_proxy(
         allow_default_upstream,
     };
     let (tx, rx) = oneshot::channel::<()>();
-    let (bound, handle) = cmux_proxy::spawn_proxy(cfg, async move {
-        let _ = rx.await;
-    });
+    let (bound, handle) = cmux_proxy::spawn_proxy(
+        cfg,
+        async move {
+            let _ = rx.await;
+        }
+        .boxed(),
+    );
+    sleep(Duration::from_millis(25)).await;
     (bound, tx, handle)
+}
+
+fn new_test_client() -> Client<HttpConnector, Empty<Bytes>> {
+    let connector = HttpConnector::new();
+    Client::builder(TokioExecutor::new()).build(connector)
+}
+
+fn next_port() -> u16 {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
 }
 
 #[cfg(target_os = "linux")]
@@ -71,21 +125,21 @@ async fn test_http_proxy_routes_by_workspace_header() {
 
     // Start proxy on localhost
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
         "127.0.0.1",
         false,
     )
     .await;
 
     // HTTP client
-    let client: Client<HttpConnector, Body> = Client::new();
+    let client = new_test_client();
     let url = format!("http://{}:{}/hello", proxy_addr.ip(), proxy_addr.port());
     let req = Request::builder()
         .method(Method::GET)
         .uri(url)
         .header("X-Cmux-Workspace-Internal", ws_name)
         .header("X-Cmux-Port-Internal", upstream_addr.port().to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
 
     let resp = timeout(Duration::from_secs(5), client.request(req))
@@ -94,7 +148,7 @@ async fn test_http_proxy_routes_by_workspace_header() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     // fail on purpose
-    let body = to_bytes(resp.into_body()).await.unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
     let s = String::from_utf8(body.to_vec()).unwrap();
     assert!(s.contains("ok:GET:/hello"), "unexpected body: {}", s);
 
@@ -115,20 +169,20 @@ async fn test_http_proxy_routes_by_subdomain_workspace() {
 
     // Start proxy
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
         "127.0.0.1",
         false,
     )
     .await;
 
     // HTTP client. Connect to proxy by address, but send Host: <workspace>-<port>.localhost
-    let client: Client<HttpConnector, Body> = Client::new();
+    let client = new_test_client();
     let url = format!("http://{}:{}/hello", proxy_addr.ip(), proxy_addr.port());
     let req = Request::builder()
         .method(Method::GET)
         .uri(url)
         .header("Host", format!("{}-{}.localhost", ws_name, port))
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
 
     let resp = timeout(Duration::from_secs(5), client.request(req))
@@ -136,7 +190,7 @@ async fn test_http_proxy_routes_by_subdomain_workspace() {
         .expect("resp timeout")
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body()).await.unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
     let s = String::from_utf8(body.to_vec()).unwrap();
     assert!(s.contains("ok-subdomain"), "unexpected body: {}", s);
 
@@ -155,20 +209,20 @@ async fn test_default_upstream_mode_without_workspace_header() {
 
     // Start proxy with allow_default_upstream enabled
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
         "127.0.0.1",
         true,
     )
     .await;
 
     // Send request without workspace header but with workspace-looking host
-    let client: Client<HttpConnector, Body> = Client::new();
+    let client = new_test_client();
     let url = format!("http://{}:{}/default", proxy_addr.ip(), proxy_addr.port());
     let req = Request::builder()
         .method(Method::GET)
         .uri(url)
         .header("X-Cmux-Port-Internal", upstream_addr.port().to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
 
     let resp = timeout(Duration::from_secs(5), client.request(req))
@@ -176,7 +230,7 @@ async fn test_default_upstream_mode_without_workspace_header() {
         .expect("resp timeout")
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body()).await.unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
     let s = String::from_utf8(body.to_vec()).unwrap();
     assert!(
         s.contains("ok:GET:/default"),
@@ -191,7 +245,7 @@ async fn test_default_upstream_mode_without_workspace_header() {
         .uri(ws_url)
         .header("X-Cmux-Workspace-Internal", ws_name)
         .header("X-Cmux-Port-Internal", ws_upstream_addr.port().to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
 
     let ws_resp = timeout(Duration::from_secs(5), client.request(ws_req))
@@ -199,7 +253,7 @@ async fn test_default_upstream_mode_without_workspace_header() {
         .expect("workspace resp timeout")
         .unwrap();
     assert_eq!(ws_resp.status(), StatusCode::OK);
-    let ws_body = to_bytes(ws_resp.into_body()).await.unwrap();
+    let ws_body = ws_resp.into_body().collect().await.unwrap().to_bytes();
     let ws_text = String::from_utf8(ws_body.to_vec()).unwrap();
     assert!(
         ws_text.contains("ok:GET:/workspace"),
@@ -223,21 +277,21 @@ async fn test_http_proxy_routes_by_workspace_non_numeric() {
 
     // Start proxy on localhost
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
         "127.0.0.1",
         false,
     )
     .await;
 
     // HTTP client
-    let client: Client<HttpConnector, Body> = Client::new();
+    let client = new_test_client();
     let url = format!("http://{}:{}/hello", proxy_addr.ip(), proxy_addr.port());
     let req = Request::builder()
         .method(Method::GET)
         .uri(url)
         .header("X-Cmux-Workspace-Internal", ws_name)
         .header("X-Cmux-Port-Internal", upstream_addr.port().to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
 
     let resp = timeout(Duration::from_secs(5), client.request(req))
@@ -245,7 +299,7 @@ async fn test_http_proxy_routes_by_workspace_non_numeric() {
         .expect("resp timeout")
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body()).await.unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
     let s = String::from_utf8(body.to_vec()).unwrap();
     assert!(s.contains("ok:GET:/hello"), "unexpected body: {}", s);
 
@@ -262,12 +316,12 @@ async fn test_workspace_dynamic_server_then_success() {
 
     // Start proxy
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
         "127.0.0.1",
         false,
     )
     .await;
-    let client: Client<HttpConnector, Body> = Client::new();
+    let client = new_test_client();
     let url = format!("http://{}:{}/hello", proxy_addr.ip(), proxy_addr.port());
 
     // First request should fail (no upstream yet)
@@ -276,7 +330,7 @@ async fn test_workspace_dynamic_server_then_success() {
         .uri(&url)
         .header("X-Cmux-Workspace-Internal", ws_name)
         .header("X-Cmux-Port-Internal", port.to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
     let resp1 = timeout(Duration::from_secs(5), client.request(req1))
         .await
@@ -294,14 +348,14 @@ async fn test_workspace_dynamic_server_then_success() {
         .uri(&url)
         .header("X-Cmux-Workspace-Internal", ws_name)
         .header("X-Cmux-Port-Internal", port.to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
     let resp2 = timeout(Duration::from_secs(5), client.request(req2))
         .await
         .expect("resp2 timeout")
         .unwrap();
     assert_eq!(resp2.status(), StatusCode::OK);
-    let body2 = to_bytes(resp2.into_body()).await.unwrap();
+    let body2 = resp2.into_body().collect().await.unwrap().to_bytes();
     assert_eq!(String::from_utf8_lossy(&body2), "ok-from-a");
 
     let _ = shutdown.send(());
@@ -322,12 +376,12 @@ async fn test_same_port_isolation_across_workspaces() {
     start_upstream_http_on_fixed(ip_b, port, "hello-from-B").await;
 
     let (proxy_addr, shutdown, handle) = start_proxy(
-        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        SocketAddr::from((Ipv4Addr::LOCALHOST, next_port())),
         "127.0.0.1",
         false,
     )
     .await;
-    let client: Client<HttpConnector, Body> = Client::new();
+    let client = new_test_client();
     let url = format!("http://{}:{}/check", proxy_addr.ip(), proxy_addr.port());
 
     // Request to A
@@ -336,14 +390,14 @@ async fn test_same_port_isolation_across_workspaces() {
         .uri(&url)
         .header("X-Cmux-Workspace-Internal", ws_a)
         .header("X-Cmux-Port-Internal", port.to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
     let resp_a = timeout(Duration::from_secs(5), client.request(req_a))
         .await
         .expect("resp a timeout")
         .unwrap();
     assert_eq!(resp_a.status(), StatusCode::OK);
-    let body_a = to_bytes(resp_a.into_body()).await.unwrap();
+    let body_a = resp_a.into_body().collect().await.unwrap().to_bytes();
     assert_eq!(String::from_utf8_lossy(&body_a), "hello-from-A");
 
     // Request to B
@@ -352,14 +406,14 @@ async fn test_same_port_isolation_across_workspaces() {
         .uri(&url)
         .header("X-Cmux-Workspace-Internal", ws_b)
         .header("X-Cmux-Port-Internal", port.to_string())
-        .body(Body::empty())
+        .body(Empty::new())
         .unwrap();
     let resp_b = timeout(Duration::from_secs(5), client.request(req_b))
         .await
         .expect("resp b timeout")
         .unwrap();
     assert_eq!(resp_b.status(), StatusCode::OK);
-    let body_b = to_bytes(resp_b.into_body()).await.unwrap();
+    let body_b = resp_b.into_body().collect().await.unwrap().to_bytes();
     assert_eq!(String::from_utf8_lossy(&body_b), "hello-from-B");
 
     let _ = shutdown.send(());

--- a/crates/cmux-proxy/tests/workspace.rs
+++ b/crates/cmux-proxy/tests/workspace.rs
@@ -62,9 +62,7 @@ async fn start_upstream_http_on_fixed(ip: Ipv4Addr, port: u16, body: &'static st
             tokio::spawn(async move {
                 let service = service_fn(move |_req: Request<Incoming>| {
                     let response_bytes = response_bytes.clone();
-                    async move {
-                        Ok::<_, Infallible>(Response::new(Full::new(response_bytes)))
-                    }
+                    async move { Ok::<_, Infallible>(Response::new(Full::new(response_bytes))) }
                 });
                 if let Err(err) = AutoBuilder::new(TokioExecutor::new())
                     .serve_connection(TokioIo::new(stream), service)


### PR DESCRIPTION
## Summary
- add HTTP/2 auto-detection in crates/cmux-proxy so dev servers can be reached over h2 or h1, and plumb the new X-Cmux-Host-Override header through normal + upgrade requests
- extend the proxy integration tests with HTTP/2 coverage and a host-override assertion
- upgrade scripts/docker-local-sanity-check.sh to spin up a Vite app with Bun, curl it locally, and verify the cmux proxy path using HTTP/2 with the internal port + host overrides

## Testing
- cargo test -p cmux-proxy
- bun run check