### PR TITLE
Remove preview proxy TLS MITM

### DIFF
--- a/crates/cmux-proxy/tests/proxy.rs
+++ b/crates/cmux-proxy/tests/proxy.rs
@@ -332,7 +332,14 @@ async fn test_http_proxy_routes_by_header() {
         .await
         .expect("resp custom timeout")
         .unwrap();
-    assert_eq!(resp_custom.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(resp_custom.status(), StatusCode::OK);
+    let custom_body = resp_custom.into_body().collect().await.unwrap().to_bytes();
+    let custom_str = String::from_utf8(custom_body.to_vec()).unwrap();
+    assert!(
+        custom_str.contains("ok:GET:/hello"),
+        "unexpected body: {}",
+        custom_str
+    );
 
     // Missing header -> 400
     let url2 = format!("http://{}:{}/missing", proxy_addr.ip(), proxy_addr.port());

--- a/packages/shared/src/morph-snapshots.ts
+++ b/packages/shared/src/morph-snapshots.ts
@@ -9,7 +9,7 @@ export interface MorphSnapshotPreset {
 
 export const MORPH_SNAPSHOT_PRESETS = [
   {
-    id: "snapshot_cj0nsc2j",
+    id: "snapshot_0f830yar",
     label: "Standard workspace",
     cpu: "4 vCPU",
     memory: "16 GB RAM",
@@ -18,7 +18,7 @@ export const MORPH_SNAPSHOT_PRESETS = [
       "Great default for day-to-day work. Balanced CPU, memory, and storage.",
   },
   {
-    id: "snapshot_qbpom27i",
+    id: "snapshot_wha7mnts",
     label: "Performance workspace",
     cpu: "8 vCPU",
     memory: "32 GB RAM",

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -362,7 +362,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_cj0nsc2j' | 'snapshot_qbpom27i');
+    snapshotId?: string | ('snapshot_0f830yar' | 'snapshot_wha7mnts');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
## Summary
- remove TLS MITM/connect classification from the preview proxy
- keep upstream HTTPS/HTTP2 support while forwarding CONNECT directly
- rely on cmux proxy/redirection without certificate interception