### PR TITLE
Add codex-max model variants with reasoning

### DIFF
--- a/packages/shared/src/providers/openai/configs.ts
+++ b/packages/shared/src/providers/openai/configs.ts
@@ -5,44 +5,6 @@ import { checkOpenAIRequirements } from "./check-requirements";
 import { startCodexCompletionDetector } from "./completion-detector";
 import { getOpenAIEnvironment } from "./environment";
 
-export const CODEX_GPT_5_1_CONFIG: AgentConfig = {
-  name: "codex/gpt-5.1",
-  command: "bunx",
-  args: [
-    "@openai/codex@latest",
-    "--model",
-    "gpt-5.1",
-    "--sandbox",
-    "danger-full-access",
-    "--ask-for-approval",
-    "never",
-    "$PROMPT",
-  ],
-  environment: getOpenAIEnvironment,
-  checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
-  completionDetector: startCodexCompletionDetector,
-};
-
-export const CODEX_GPT_5_1_CODEX_CONFIG: AgentConfig = {
-  name: "codex/gpt-5.1-codex",
-  command: "bunx",
-  args: [
-    "@openai/codex@latest",
-    "--model",
-    "gpt-5.1-codex",
-    "--sandbox",
-    "danger-full-access",
-    "--ask-for-approval",
-    "never",
-    "$PROMPT",
-  ],
-  environment: getOpenAIEnvironment,
-  checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
-  completionDetector: startCodexCompletionDetector,
-};
-
 export const CODEX_GPT_5_1_CODEX_MAX_XHIGH_REASONING_CONFIG: AgentConfig = {
   name: "codex/gpt-5.1-codex-max-xhigh",
   command: "bunx",
@@ -119,6 +81,44 @@ export const CODEX_GPT_5_1_CODEX_MAX_LOW_REASONING_CONFIG: AgentConfig = {
     "never",
     "-c",
     'model_reasoning_effort="low"',
+    "$PROMPT",
+  ],
+  environment: getOpenAIEnvironment,
+  checkRequirements: checkOpenAIRequirements,
+  apiKeys: [OPENAI_API_KEY],
+  completionDetector: startCodexCompletionDetector,
+};
+
+export const CODEX_GPT_5_1_CONFIG: AgentConfig = {
+  name: "codex/gpt-5.1",
+  command: "bunx",
+  args: [
+    "@openai/codex@latest",
+    "--model",
+    "gpt-5.1",
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+    "$PROMPT",
+  ],
+  environment: getOpenAIEnvironment,
+  checkRequirements: checkOpenAIRequirements,
+  apiKeys: [OPENAI_API_KEY],
+  completionDetector: startCodexCompletionDetector,
+};
+
+export const CODEX_GPT_5_1_CODEX_CONFIG: AgentConfig = {
+  name: "codex/gpt-5.1-codex",
+  command: "bunx",
+  args: [
+    "@openai/codex@latest",
+    "--model",
+    "gpt-5.1-codex",
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
     "$PROMPT",
   ],
   environment: getOpenAIEnvironment,

--- a/packages/shared/src/providers/openai/configs.ts
+++ b/packages/shared/src/providers/openai/configs.ts
@@ -43,6 +43,90 @@ export const CODEX_GPT_5_1_CODEX_CONFIG: AgentConfig = {
   completionDetector: startCodexCompletionDetector,
 };
 
+export const CODEX_GPT_5_1_CODEX_MAX_XHIGH_REASONING_CONFIG: AgentConfig = {
+  name: "codex/gpt-5.1-codex-max-xhigh",
+  command: "bunx",
+  args: [
+    "@openai/codex@latest",
+    "--model",
+    "gpt-5.1-codex-max",
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+    "-c",
+    'model_reasoning_effort="xhigh"',
+    "$PROMPT",
+  ],
+  environment: getOpenAIEnvironment,
+  checkRequirements: checkOpenAIRequirements,
+  apiKeys: [OPENAI_API_KEY],
+  completionDetector: startCodexCompletionDetector,
+};
+
+export const CODEX_GPT_5_1_CODEX_MAX_HIGH_REASONING_CONFIG: AgentConfig = {
+  name: "codex/gpt-5.1-codex-max-high",
+  command: "bunx",
+  args: [
+    "@openai/codex@latest",
+    "--model",
+    "gpt-5.1-codex-max",
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+    "-c",
+    'model_reasoning_effort="high"',
+    "$PROMPT",
+  ],
+  environment: getOpenAIEnvironment,
+  checkRequirements: checkOpenAIRequirements,
+  apiKeys: [OPENAI_API_KEY],
+  completionDetector: startCodexCompletionDetector,
+};
+
+export const CODEX_GPT_5_1_CODEX_MAX_MEDIUM_REASONING_CONFIG: AgentConfig = {
+  name: "codex/gpt-5.1-codex-max-medium",
+  command: "bunx",
+  args: [
+    "@openai/codex@latest",
+    "--model",
+    "gpt-5.1-codex-max",
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+    "-c",
+    'model_reasoning_effort="medium"',
+    "$PROMPT",
+  ],
+  environment: getOpenAIEnvironment,
+  checkRequirements: checkOpenAIRequirements,
+  apiKeys: [OPENAI_API_KEY],
+  completionDetector: startCodexCompletionDetector,
+};
+
+export const CODEX_GPT_5_1_CODEX_MAX_LOW_REASONING_CONFIG: AgentConfig = {
+  name: "codex/gpt-5.1-codex-max-low",
+  command: "bunx",
+  args: [
+    "@openai/codex@latest",
+    "--model",
+    "gpt-5.1-codex-max",
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+    "-c",
+    'model_reasoning_effort="low"',
+    "$PROMPT",
+  ],
+  environment: getOpenAIEnvironment,
+  checkRequirements: checkOpenAIRequirements,
+  apiKeys: [OPENAI_API_KEY],
+  completionDetector: startCodexCompletionDetector,
+};
+
 export const CODEX_GPT_5_1_CODEX_MINI_CONFIG: AgentConfig = {
   name: "codex/gpt-5.1-codex-mini",
   command: "bunx",


### PR DESCRIPTION
help me add this model:model = "gpt-5.1-codex-max"
model_reasoning_effort = "xhigh"  # or "low"/"medium"/"high"make sure to put it with the other codex modelsmake sure to make 4 new ones with all the different reasoning efforts