### PR TITLE
Prevent bun check from regenerating OpenAPI SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "clean": "bash scripts/clean.sh",
     "clean:node_modules": "bash scripts/clean.sh",
-    "precheck": "bun run generate-openapi-client && bun run generate-morphcloud-openapi-client",
+    "precheck": "bun run generate-openapi-client",
     "check": "bun run scripts/check.ts",
     "lint": "bun run scripts/lint.ts",
     "test": "bun run scripts/test.ts",


### PR DESCRIPTION
The `bun check` command now only regenerates the www openapi client, not the morphcloud client. The morphcloud SDK can still be regenerated manually using `bun run generate-morphcloud-openapi-client`.