### PR TITLE
Remove unwrap calls and add error handling

### DIFF
--- a/apps/server/native/core/src/lib.rs
+++ b/apps/server/native/core/src/lib.rs
@@ -12,12 +12,14 @@ use napi_derive::napi;
 use types::{BranchInfo, DiffEntry, GitDiffOptions, GitListRemoteBranchesOptions};
 
 #[napi]
-pub async fn get_time() -> String {
+pub async fn get_time() -> Result<String> {
   use std::time::{SystemTime, UNIX_EPOCH};
   #[cfg(debug_assertions)]
   println!("[cmux_native_core] get_time invoked");
-  let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-  now.as_millis().to_string()
+  let now = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map_err(|e| Error::from_reason(format!("System time error: {e}")))?;
+  Ok(now.as_millis().to_string())
 }
 
 #[napi]


### PR DESCRIPTION
…dling

Replaced 10+ .unwrap() calls with proper error handling in git-related Rust code:

- lib.rs: Handle SystemTime::duration_since errors in get_time()
- diff/workspace.rs: Handle strip_prefix and Option::as_ref errors
- diff/refs.rs: Handle pop() and Option::as_ref errors in diff computation
- repo/cache.rs: Handle file_name, to_str, and duration_since errors

All changes ensure graceful error propagation instead of panicking on edge cases.