### PR TITLE
Remove unwrap calls and add error handling

### DIFF
--- a/crates/cmux-proxy/tests/proxy.rs
+++ b/crates/cmux-proxy/tests/proxy.rs
@@ -280,7 +280,8 @@ async fn start_proxy(
             let _ = rx.await;
         }
         .boxed(),
-    );
+    )
+    .expect("failed to spawn proxy");
     sleep(Duration::from_millis(25)).await;
     (bound, tx, handle)
 }

--- a/crates/cmux-proxy/tests/workspace.rs
+++ b/crates/cmux-proxy/tests/workspace.rs
@@ -93,7 +93,8 @@ async fn start_proxy(
             let _ = rx.await;
         }
         .boxed(),
-    );
+    )
+    .expect("failed to spawn proxy");
     sleep(Duration::from_millis(25)).await;
     (bound, tx, handle)
 }


### PR DESCRIPTION
Replaced 8 instances of .unwrap() and .expect() with proper error handling:

1. spawn_proxy function (lib.rs:315-318): Changed return type to Result and replaced 4 expect() calls for bind(), set_nonblocking(), local_addr(), and from_std() with proper error propagation using map_err

2. response_with function (lib.rs:762): Replaced unwrap() with unwrap_or_else() that logs the error and returns a fallback response

3. handle_http function (lib.rs:858): Replaced expect() on headers_mut() with ok_or_else() returning a proper error response

4. handle_upgrade function (lib.rs:951, 968): Replaced unwrap() and expect() on headers_mut() with ok_or_else() returning proper error responses

Updated test files (tests/proxy.rs, tests/workspace.rs) to handle the new spawn_proxy Result return type by adding expect() calls in test harness.

All tests passing.