### PR TITLE
Fix aria-hidden blocking focused element accessibility

### DIFF
--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -2473,7 +2473,6 @@ export function CommandBar({
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none"
         )}
-        aria-hidden={!open}
         onClick={closeCommand}
       />
       <div
@@ -2481,7 +2480,6 @@ export function CommandBar({
           "fixed inset-x-0 top-[230px] z-[var(--z-commandbar)] flex items-start justify-center pointer-events-none",
           open ? "opacity-100" : "opacity-0"
         )}
-        aria-hidden={!open}
       >
         <div
           className={`w-full max-w-2xl h-auto max-h-[475px] bg-white dark:bg-neutral-900 rounded-xl shadow-2xl border border-neutral-200 dark:border-neutral-700 overflow-hidden flex flex-col ${
@@ -2489,7 +2487,6 @@ export function CommandBar({
               ? "opacity-100 pointer-events-auto"
               : "opacity-0 pointer-events-none"
           }`}
-          aria-hidden={!open}
         >
           <Command
             value={commandValue}


### PR DESCRIPTION
Removed aria-hidden attributes from CommandBar modal container divs to fix accessibility violation where aria-hidden was applied to an ancestor of a focused input element. The divs already use opacity-0 and pointer-events-none for visual hiding, which is sufficient without causing screen reader issues.

Fixes: "Blocked aria-hidden on an element because its descendant retained focus" warning