### PR TITLE
Fix xterm dimensions undefined error on navigation

### DIFF
--- a/apps/client/src/components/RestoredTerminalView.tsx
+++ b/apps/client/src/components/RestoredTerminalView.tsx
@@ -46,14 +46,28 @@ export function RestoredTerminalView({
     xterm.loadAddon(webLinksAddon);
 
     xterm.open(terminalRef.current);
-    fitAddon.fit();
+
+    // Guard against calling fit() when terminal is not fully initialized
+    if (xterm.element?.isConnected) {
+      try {
+        fitAddon.fit();
+      } catch (error) {
+        console.debug("[RestoredTerminalView] fitAddon.fit() failed during mount", error);
+      }
+    }
 
     xtermRef.current = xterm;
     fitAddonRef.current = fitAddon;
 
     // Handle resize
     const handleResize = () => {
-      fitAddon.fit();
+      if (xterm.element?.isConnected) {
+        try {
+          fitAddon.fit();
+        } catch (error) {
+          console.debug("[RestoredTerminalView] fitAddon.fit() failed during resize", error);
+        }
+      }
     };
 
     const resizeObserver = new ResizeObserver(handleResize);

--- a/apps/client/src/components/Terminal.tsx
+++ b/apps/client/src/components/Terminal.tsx
@@ -26,11 +26,23 @@ export function Terminal({ isActive, initialScrollback }: TerminalProps) {
     if (!terminal) return;
 
     const handleResize = () => {
-      if (fitAddon) {
-        fitAddon.fit();
+      if (fitAddon && terminal.element?.isConnected) {
+        try {
+          fitAddon.fit();
+        } catch (error) {
+          console.debug("[Terminal] fitAddon.fit() failed during resize", error);
+        }
       }
     };
-    fitAddon.fit();
+
+    // Guard against calling fit() when terminal is not fully initialized
+    if (terminal.element?.isConnected) {
+      try {
+        fitAddon.fit();
+      } catch (error) {
+        console.debug("[Terminal] fitAddon.fit() failed during mount", error);
+      }
+    }
 
     window.addEventListener("resize", handleResize);
 
@@ -54,8 +66,12 @@ export function Terminal({ isActive, initialScrollback }: TerminalProps) {
   }, [initialScrollback, terminal, hasWrittenInitialScrollback]);
 
   useEffect(() => {
-    if (isActive && terminal) {
-      fitAddon.fit();
+    if (isActive && terminal && terminal.element?.isConnected) {
+      try {
+        fitAddon.fit();
+      } catch (error) {
+        console.debug("[Terminal] fitAddon.fit() failed when becoming active", error);
+      }
       terminal.focus();
     }
   }, [isActive, fitAddon, terminal]);

--- a/apps/client/src/components/task-run-terminal-session.tsx
+++ b/apps/client/src/components/task-run-terminal-session.tsx
@@ -147,8 +147,22 @@ export function TaskRunTerminalSession({
     if (!terminal || !fitAddon) {
       return;
     }
-    fitAddon.fit();
-    queueResize();
+
+    // Guard against calling fit() when terminal is not fully initialized or is being disposed
+    // This prevents "Cannot read properties of undefined (reading 'dimensions')" errors
+    const element = terminal.element;
+    if (!element || !element.isConnected) {
+      return;
+    }
+
+    try {
+      fitAddon.fit();
+      queueResize();
+    } catch (error) {
+      // Silently ignore fit errors during mount/unmount transitions
+      // This can happen when the viewport is not yet initialized or already disposed
+      console.debug("[TaskRunTerminalSession] fitAddon.fit() failed, likely during mount/unmount", error);
+    }
   }, [queueResize, terminal]);
 
   const flushPendingResize = useCallback(() => {


### PR DESCRIPTION
…mensions')

Add defensive checks before calling FitAddon.fit() to prevent errors when the terminal viewport is not fully initialized or has been disposed. This fixes the error that occurs during navigation to preview routes.

Changes:
- Add element.isConnected checks before calling fit()
- Wrap fit() calls in try-catch blocks to handle race conditions
- Add debug logging to help diagnose future issues

This prevents the error: "Cannot read properties of undefined (reading 'dimensions')" that was occurring in the Viewport.syncScrollArea method during route transitions.

Fixes issue #7049911351