### PR TITLE
Parallelize Stack seed upserts

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -36,6 +36,7 @@ import type * as http from "../http.js";
 import type * as localWorkspaces from "../localWorkspaces.js";
 import type * as migrations from "../migrations.js";
 import type * as screenshots_http from "../screenshots_http.js";
+import type * as seed from "../seed.js";
 import type * as stack from "../stack.js";
 import type * as stack_webhook from "../stack_webhook.js";
 import type * as stack_webhook_actions from "../stack_webhook_actions.js";
@@ -95,6 +96,7 @@ declare const fullApi: ApiFromModules<{
   localWorkspaces: typeof localWorkspaces;
   migrations: typeof migrations;
   screenshots_http: typeof screenshots_http;
+  seed: typeof seed;
   stack: typeof stack;
   stack_webhook: typeof stack_webhook;
   stack_webhook_actions: typeof stack_webhook_actions;

--- a/packages/convex/convex/seed.ts
+++ b/packages/convex/convex/seed.ts
@@ -1,0 +1,107 @@
+import {
+  StackAdminApp,
+  type ServerTeam,
+  type ServerTeamUser,
+  type ServerUser,
+} from "@stackframe/js";
+import { internalMutation } from "./_generated/server";
+import { env } from "../_shared/convex-env";
+import { ensureMembershipCore, upsertTeamCore, upsertUserCore } from "./stack";
+
+function requireEnv(name: keyof typeof env): string {
+  const value = env[name];
+  if (!value) throw new Error(`Missing required env: ${String(name)}`);
+  return String(value);
+}
+
+export const init = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const projectId = requireEnv("NEXT_PUBLIC_STACK_PROJECT_ID");
+    const publishableClientKey = requireEnv("NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY");
+    const secretServerKey = requireEnv("STACK_SECRET_SERVER_KEY");
+    const superSecretAdminKey = requireEnv("STACK_SUPER_SECRET_ADMIN_KEY");
+
+    const admin = new StackAdminApp({
+      tokenStore: "memory",
+      projectId,
+      publishableClientKey,
+      secretServerKey,
+      superSecretAdminKey,
+    });
+
+    const summary = {
+      usersProcessed: 0,
+      teamsProcessed: 0,
+      membershipsProcessed: 0,
+    };
+
+    let cursor: string | undefined = undefined;
+    for (;;) {
+      const page = (await admin.listUsers({
+        cursor,
+        limit: 200,
+        includeAnonymous: false,
+      })) as ServerUser[] & { nextCursor: string | null };
+
+      await Promise.all(
+        page.map((user) =>
+          upsertUserCore(ctx, {
+            id: user.id,
+            primaryEmail: user.primaryEmail ?? undefined,
+            primaryEmailVerified: user.primaryEmailVerified,
+            primaryEmailAuthEnabled:
+              (user as unknown as { emailAuthEnabled?: boolean }).emailAuthEnabled ?? false,
+            displayName: user.displayName ?? undefined,
+            selectedTeamId: user.selectedTeam?.id ?? undefined,
+            selectedTeamDisplayName: user.selectedTeam?.displayName ?? undefined,
+            selectedTeamProfileImageUrl: user.selectedTeam?.profileImageUrl ?? undefined,
+            profileImageUrl: user.profileImageUrl ?? undefined,
+            signedUpAtMillis: user.signedUpAt.getTime(),
+            lastActiveAtMillis: user.lastActiveAt.getTime(),
+            hasPassword: user.hasPassword,
+            otpAuthEnabled: user.otpAuthEnabled,
+            passkeyAuthEnabled: user.passkeyAuthEnabled,
+            clientMetadata: user.clientMetadata,
+            clientReadOnlyMetadata: user.clientReadOnlyMetadata,
+            serverMetadata: (user as unknown as { serverMetadata?: unknown }).serverMetadata,
+            isAnonymous: user.isAnonymous,
+            oauthProviders: undefined,
+          })
+        )
+      );
+      summary.usersProcessed += page.length;
+
+      if (!page.nextCursor) break;
+      cursor = page.nextCursor;
+    }
+
+    const teams = (await admin.listTeams()) as ServerTeam[];
+    await Promise.all(
+      teams.map((team) =>
+        upsertTeamCore(ctx, {
+          id: team.id,
+          displayName: team.displayName ?? undefined,
+          profileImageUrl: team.profileImageUrl ?? undefined,
+          clientMetadata: team.clientMetadata,
+          clientReadOnlyMetadata: team.clientReadOnlyMetadata,
+          serverMetadata: (team as unknown as { serverMetadata?: unknown }).serverMetadata,
+          createdAtMillis: team.createdAt.getTime(),
+        })
+      )
+    );
+    summary.teamsProcessed += teams.length;
+
+    for (const team of teams) {
+      const members = (await team.listUsers()) as ServerTeamUser[];
+      await Promise.all(
+        members.map((member) => ensureMembershipCore(ctx, team.id, member.id))
+      );
+      summary.membershipsProcessed += members.length;
+    }
+
+    return summary;
+  },
+});
+
+export default init;

--- a/packages/convex/convex/stack.ts
+++ b/packages/convex/convex/stack.ts
@@ -30,7 +30,7 @@ type UpsertUserArgs = {
   oauthProviders?: Array<{ id: string; accountId: string; email?: string }>;
 };
 
-async function upsertUserCore(ctx: MutationCtx, args: UpsertUserArgs) {
+export async function upsertUserCore(ctx: MutationCtx, args: UpsertUserArgs) {
   const now = Date.now();
   const existing = await ctx.db
     .query("users")
@@ -246,7 +246,7 @@ async function resolveTeamSlug(
   return generateSlugFromName(ctx, args.id, args.displayName);
 }
 
-async function upsertTeamCore(ctx: MutationCtx, args: UpsertTeamArgs) {
+export async function upsertTeamCore(ctx: MutationCtx, args: UpsertTeamArgs) {
   const now = Date.now();
   const existing = await ctx.db
     .query("teams")
@@ -342,7 +342,7 @@ export const deleteTeamPublic = authMutation({
   handler: async (ctx, { id }) => deleteTeamCore(ctx as unknown as MutationCtx, id),
 });
 
-async function ensureMembershipCore(ctx: MutationCtx, teamId: string, userId: string) {
+export async function ensureMembershipCore(ctx: MutationCtx, teamId: string, userId: string) {
     const now = Date.now();
     const existing = await ctx.db
       .query("teamMemberships")


### PR DESCRIPTION
## Summary
- run Stack user imports in parallel per page to speed up Convex seeding
- upsert teams and memberships concurrently while maintaining import summaries

## Testing
- bun run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692039206ef48333958c2407e9217654)