### PR TITLE
Guard PostHog client init behind env key

### DIFF
--- a/apps/www/instrumentation-client.ts
+++ b/apps/www/instrumentation-client.ts
@@ -36,12 +36,16 @@ Sentry.init({
 
 // Initialize PostHog analytics client
 // https://posthog.com/docs/integrations/js-integration
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-  api_host: "/iiiii",
-  ui_host: "https://us.posthog.com",
-  defaults: '2025-05-24',
-  capture_exceptions: true, // This enables capturing exceptions using Error Tracking, set to false if you don't want this
-  debug: process.env.NODE_ENV === "development",
-});
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+if (posthogKey) {
+  posthog.init(posthogKey, {
+    api_host: "/iiiii",
+    ui_host: "https://us.posthog.com",
+    defaults: '2025-05-24',
+    capture_exceptions: true, // This enables capturing exceptions using Error Tracking, set to false if you don't want this
+    debug: process.env.NODE_ENV === "development",
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## Summary
- guard PostHog client initialization behind an environment variable
- keep analytics client setup unchanged otherwise

## Testing
- bun run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204c158dbc833383778b8b86cdf756)