### PR TITLE
Scope cargo home to runner temp on mac release jobs

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -225,6 +225,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Configure Cargo home
+        run: |
+          set -euo pipefail
+          temp_dir="${RUNNER_TEMP:-}"
+          if [[ -z "$temp_dir" ]]; then
+            temp_dir="$(mktemp -d)"
+          fi
+          cargo_home="$temp_dir/cargo-${GITHUB_RUN_ID}-${GITHUB_JOB}"
+          mkdir -p "$cargo_home/bin"
+          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=$cargo_home" >> "$GITHUB_ENV"
+          echo "PATH=$cargo_home/bin:$PATH" >> "$GITHUB_ENV"
       - name: Configure Bun install dir
         run: |
           set -euo pipefail
@@ -320,6 +332,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure Cargo home
+        run: |
+          set -euo pipefail
+          temp_dir="${RUNNER_TEMP:-}"
+          if [[ -z "$temp_dir" ]]; then
+            temp_dir="$(mktemp -d)"
+          fi
+          cargo_home="$temp_dir/cargo-${GITHUB_RUN_ID}-${GITHUB_JOB}"
+          mkdir -p "$cargo_home/bin"
+          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=$cargo_home" >> "$GITHUB_ENV"
+          echo "PATH=$cargo_home/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Configure Bun install dir
         run: |

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -233,8 +233,11 @@ jobs:
             temp_dir="$(mktemp -d)"
           fi
           cargo_home="$temp_dir/cargo-${GITHUB_RUN_ID}-${GITHUB_JOB}"
+          cargo_target_dir="$temp_dir/cargo-target-${GITHUB_RUN_ID}-${GITHUB_JOB}"
           mkdir -p "$cargo_home/bin"
+          mkdir -p "$cargo_target_dir"
           echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_DIR=$cargo_target_dir" >> "$GITHUB_ENV"
           echo "RUSTUP_HOME=$cargo_home" >> "$GITHUB_ENV"
           echo "PATH=$cargo_home/bin:$PATH" >> "$GITHUB_ENV"
       - name: Configure Bun install dir
@@ -341,8 +344,11 @@ jobs:
             temp_dir="$(mktemp -d)"
           fi
           cargo_home="$temp_dir/cargo-${GITHUB_RUN_ID}-${GITHUB_JOB}"
+          cargo_target_dir="$temp_dir/cargo-target-${GITHUB_RUN_ID}-${GITHUB_JOB}"
           mkdir -p "$cargo_home/bin"
+          mkdir -p "$cargo_target_dir"
           echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_DIR=$cargo_target_dir" >> "$GITHUB_ENV"
           echo "RUSTUP_HOME=$cargo_home" >> "$GITHUB_ENV"
           echo "PATH=$cargo_home/bin:$PATH" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
- configure cargo/rustup directories for mac self-hosted release jobs to live under the runner temp directory
- ensure PATH uses the job-scoped cargo bin to avoid cross-job conflicts

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ec4a2f6483339b26bb33fe39609e)