### PR TITLE
chore: bump convex to 1.29.3

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -105,7 +105,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "date-fns": "^4.1.0",
     "debug": "^4.4.1",
     "diff": "^8.0.2",

--- a/apps/preview-proxy/package.json
+++ b/apps/preview-proxy/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bun-plugin-tailwind": "^0.0.15",
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "lucide-react": "^0.540.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -67,7 +67,7 @@
     "ansi-escape-sequences": "^6.2.4",
     "archiver": "^7.0.1",
     "chokidar": "^4.0.3",
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "dockerode": "^4.0.2",
     "dotenv": "^16.6.1",
     "electron": "^38.2.2",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -42,7 +42,7 @@
     "ai": "^5.0.82",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "^1.27.1",
+    "convex": "^1.29.3",
     "hono": "^4.9.1",
     "jose": "^6.1.0",
     "lucide-react": "^0.460.0",

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
     "apps/client": {
       "name": "@cmux/client",
-      "version": "1.0.174",
+      "version": "1.0.177",
       "dependencies": {
         "@base-ui-components/react": "1.0.0-beta.2",
         "@cmux/convex": "workspace:*",
@@ -104,7 +104,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "convex": "1.27.1",
+        "convex": "1.29.3",
         "date-fns": "^4.1.0",
         "debug": "^4.4.1",
         "diff": "^8.0.2",
@@ -200,7 +200,7 @@
       "version": "0.1.0",
       "dependencies": {
         "bun-plugin-tailwind": "^0.0.15",
-        "convex": "1.27.1",
+        "convex": "1.29.3",
         "lucide-react": "^0.540.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -232,7 +232,7 @@
         "ansi-escape-sequences": "^6.2.4",
         "archiver": "^7.0.1",
         "chokidar": "^4.0.3",
-        "convex": "1.27.1",
+        "convex": "1.29.3",
         "dockerode": "^4.0.2",
         "dotenv": "^16.6.1",
         "electron": "^38.2.2",
@@ -325,7 +325,7 @@
         "ai": "^5.0.82",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "convex": "^1.27.1",
+        "convex": "^1.29.3",
         "hono": "^4.9.1",
         "jose": "^6.1.0",
         "lucide-react": "^0.460.0",
@@ -373,7 +373,7 @@
         "@cmux/server": "workspace:*",
         "@cmux/shared": "workspace:*",
         "commander": "^11.1.0",
-        "convex": "1.27.1",
+        "convex": "1.29.3",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "socket.io": "^4.7.2",
@@ -403,7 +403,7 @@
         "@stackframe/stack": "^2.8.48",
         "@t3-oss/env-core": "^0.13.8",
         "ai": "^5.0.51",
-        "convex": "1.27.1",
+        "convex": "1.29.3",
         "convex-helpers": "^0.1.104",
         "jose": "^6.0.7",
         "octokit": "^5.0.5",
@@ -435,7 +435,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@cmux/convex": "workspace:*",
-        "convex": "1.27.1",
+        "convex": "1.29.3",
         "jose": "^6.1.0",
         "socket.io-client": "^4.8.1",
         "zod": "^4.1.5",
@@ -494,7 +494,7 @@
         "@openai/codex-sdk": "^0.46.0",
         "@stackframe/js": "^2.8.48",
         "commander": "^12.1.0",
-        "convex": "^1.27.1",
+        "convex": "^1.29.3",
         "dotenv": "^16.6.1",
         "ignore": "^6.0.2",
         "morphcloud": "^0.0.18",
@@ -512,7 +512,7 @@
     },
   },
   "overrides": {
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "monaco-editor": "^0.53.0",
     "node-abi": "^4.14.0",
     "react": "^19.1.0",
@@ -2969,7 +2969,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.27.1", "", { "dependencies": { "esbuild": "0.25.4", "jwt-decode": "^4.0.0", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-kep7JFn5Bil9/OUZUsL1bgoo0G9DmEf7stkBW67+NqP2FrzBt2TX8yz4V6oKLygzepGy90Ura2FtqXawYKXYIg=="],
+    "convex": ["convex@1.29.3", "", { "dependencies": { "esbuild": "0.25.4", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-tg5TXzMjpNk9m50YRtdp6US+t7ckxE4E+7DNKUCjJ2MupQs2RBSPF/z5SNN4GUmQLSfg0eMILDySzdAvjTrhnw=="],
 
     "convex-helpers": ["convex-helpers@0.1.104", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.24.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.22.4 || ^4.0.15" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-7CYvx7T3K6n+McDTK4ZQaQNNGBzq5aWezpjzsKbOxPXx7oNcTP9wrpef3JxeXWFzkByJv5hRCjseh9B7eNJ7Ig=="],
 
@@ -5523,6 +5523,8 @@
 
     "builder-util/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
+    "bun-react-template/@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+
     "bun-react-template/lucide-react": ["lucide-react@0.540.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ=="],
 
     "bun-types/@types/node": ["@types/node@24.7.2", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA=="],
@@ -5566,6 +5568,8 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
+
+    "cmux/@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
 
     "cmux/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -6275,6 +6279,8 @@
 
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "bun-react-template/@types/bun/bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
 
     "cacache/glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
@@ -6298,6 +6304,8 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cmux-vscode-extension/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "cmux/@types/bun/bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
 
     "color/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "monaco-editor": "^0.53.0",
-    "convex": "1.27.1"
+    "convex": "1.29.3"
   },
   "private": true,
   "scripts": {

--- a/packages/cmux/package.json
+++ b/packages/cmux/package.json
@@ -49,7 +49,7 @@
     "@cmux/server": "workspace:*",
     "@cmux/shared": "workspace:*",
     "commander": "^11.1.0",
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "socket.io": "^4.7.2"

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -35,7 +35,7 @@
     "@stackframe/stack": "^2.8.48",
     "@t3-oss/env-core": "^0.13.8",
     "ai": "^5.0.51",
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "convex-helpers": "^0.1.104",
     "jose": "^6.0.7",
     "octokit": "^5.0.5",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@cmux/convex": "workspace:*",
-    "convex": "1.27.1",
+    "convex": "1.29.3",
     "jose": "^6.1.0",
     "zod": "^4.1.5",
     "socket.io-client": "^4.8.1"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,7 @@
     "@openai/codex-sdk": "^0.46.0",
     "@stackframe/js": "^2.8.48",
     "commander": "^12.1.0",
-    "convex": "^1.27.1",
+    "convex": "^1.29.3",
     "dotenv": "^16.6.1",
     "ignore": "^6.0.2",
     "morphcloud": "^0.0.18",


### PR DESCRIPTION
## Summary
- bump all convex dependencies and root override to version 1.29.3 across the workspace
- refresh bun.lock after the dependency updates

## Testing
- bun run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920f2a30d988333afb23a3f42bb5c2a)