### PR TITLE
Prevent daily release without changes

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -1,0 +1,79 @@
+name: Daily Release
+
+on:
+  schedule:
+    - cron: "30 12 * * *" # 4:30 AM PST
+  workflow_dispatch:
+
+concurrency:
+  group: daily-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: "24"
+  BUN_VERSION: "1.2.21"
+
+jobs:
+  run-release:
+    name: Run release script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check for changes since last release
+        id: release_changes
+        run: |
+          last_tag=$(git describe --tags --match "v[0-9]*" --abbrev=0 2>/dev/null || echo "")
+
+          if [ -z "$last_tag" ]; then
+            echo "No release tags found. Proceeding with release." >> "$GITHUB_STEP_SUMMARY"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$last_tag"..HEAD; then
+            echo "No changes since last release ($last_tag)." >> "$GITHUB_STEP_SUMMARY"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected since last release ($last_tag)." >> "$GITHUB_STEP_SUMMARY"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.release_changes.outputs.proceed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        if: steps.release_changes.outputs.proceed == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies (bun)
+        if: steps.release_changes.outputs.proceed == 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Configure git user
+        if: steps.release_changes.outputs.proceed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run release script
+        if: steps.release_changes.outputs.proceed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun ./scripts/release.ts
+
+      - name: Skip release (no changes)
+        if: steps.release_changes.outputs.proceed == 'false'
+        run: echo "Skipping release because no changes were detected since the last tag."


### PR DESCRIPTION
## Summary
- add a change-detection step that finds the latest release tag and skips releases when no changes are present
- gate setup/install/release steps on the change-detection output and log when the workflow is skipped

## Testing
- bun run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920fd7ac898833380312dda814ed54a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a scheduled GitHub Actions daily release that detects changes since last tag and only runs the Bun-based release when updates exist.
> 
> - **CI/CD**:
>   - Add `/.github/workflows/daily-release.yml` with schedule and manual dispatch.
>   - Implement change detection (`git describe` + `git diff`) to set `proceed` and write to `$GITHUB_STEP_SUMMARY`.
>   - Gate Node/Bun setup, dependency install (`bun install --frozen-lockfile`), git config, and release run (`bun ./scripts/release.ts`) on `proceed`.
>   - Configure concurrency group `daily-release`, `contents: write` permission, and env versions (`NODE_VERSION`, `BUN_VERSION`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0d12de1d5d9ff4a14385aa1d8e3b2c7490c9a2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->