### PR TITLE
Use mutation for terminal reconnection workflow

### DIFF
--- a/apps/client/src/components/task-run-terminal-session.tsx
+++ b/apps/client/src/components/task-run-terminal-session.tsx
@@ -24,6 +24,8 @@ interface TaskRunTerminalSessionProps {
   terminalId: string;
   isActive: boolean;
   onConnectionStateChange?: (state: TerminalConnectionState) => void;
+  onReconnectAll?: () => void;
+  isReconnecting?: boolean;
 }
 
 function clampDimension(value: number, min: number, max: number, fallback: number) {
@@ -36,6 +38,8 @@ export function TaskRunTerminalSession({
   terminalId,
   isActive,
   onConnectionStateChange,
+  onReconnectAll,
+  isReconnecting,
 }: TaskRunTerminalSessionProps) {
   const callbackRef = useRef<TaskRunTerminalSessionProps["onConnectionStateChange"]>(
     onConnectionStateChange
@@ -311,6 +315,10 @@ export function TaskRunTerminalSession({
     }
   }, [connectionState]);
 
+  const showReconnectButton =
+    (connectionState === "closed" || connectionState === "error") &&
+    Boolean(onReconnectAll);
+
   return (
     <div
       className={clsx("relative w-full h-full", { hidden: !isActive })}
@@ -320,10 +328,22 @@ export function TaskRunTerminalSession({
     >
       <div ref={containerRef} className="absolute inset-0" />
       {statusMessage ? (
-        <div className="absolute inset-0 flex items-center justify-center bg-neutral-950/60 pointer-events-none">
-          <span className="text-sm text-neutral-200 dark:text-neutral-300">
-            {statusMessage}
-          </span>
+        <div className="absolute inset-0 flex items-center justify-center bg-neutral-950/60">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <span className="text-sm text-neutral-200 dark:text-neutral-300">
+              {statusMessage}
+            </span>
+            {showReconnectButton ? (
+              <button
+                type="button"
+                onClick={onReconnectAll}
+                disabled={isReconnecting}
+                className="rounded-md bg-neutral-100 px-3 py-1.5 text-xs font-medium text-neutral-900 transition hover:bg-neutral-200 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
+              >
+                {isReconnecting ? "Reconnecting…" : "Reconnect terminals"}
+              </button>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.terminals.tsx
@@ -12,6 +12,7 @@ import {
   TaskRunTerminalSession,
   type TerminalConnectionState,
 } from "@/components/task-run-terminal-session";
+import { useResumeMorphWorkspace } from "@/hooks/useMorphWorkspace";
 import { toMorphXtermBaseUrl } from "@/lib/toProxyWorkspaceUrl";
 import {
   createTerminalTab,
@@ -191,6 +192,11 @@ function TaskRunTerminals() {
   const [connectionStates, setConnectionStates] = useState<
     Record<string, TerminalConnectionState>
   >({});
+  const [reconnectSeed, setReconnectSeed] = useState(0);
+  const resumeWorkspace = useResumeMorphWorkspace({
+    taskRunId,
+    teamSlugOrId,
+  });
 
   const queryClient = useQueryClient();
 
@@ -328,6 +334,96 @@ function TaskRunTerminals() {
       isDeletingTerminal,
     ]
   );
+
+  const reconnectTerminalsMutation = useMutation({
+    mutationKey: [
+      "terminal-tabs",
+      taskRunId,
+      xtermBaseUrl,
+      "reconnect-all",
+    ],
+    mutationFn: async () => {
+      if (!hasTerminalBackend) {
+        throw new Error("Terminal backend unavailable");
+      }
+
+      if (isMorphProvider) {
+        try {
+          await resumeWorkspace.mutateAsync({
+            path: { taskRunId },
+            body: { teamSlugOrId },
+          });
+        } catch (error) {
+          console.error(
+            "Failed to resume Morph workspace before reconnecting terminals",
+            error
+          );
+        }
+      }
+
+      const refreshed = await tabsQuery.refetch();
+      return refreshed.data ?? terminalIds;
+    },
+    onMutate: async () => {
+      setReconnectSeed((current) => current + 1);
+      setConnectionStates(() => {
+        const next: Record<string, TerminalConnectionState> = {};
+        for (const id of terminalIds) {
+          next[id] = "connecting";
+        }
+        return next;
+      });
+    },
+    onSuccess: (refreshedIds) => {
+      if (!refreshedIds) {
+        return;
+      }
+
+      setConnectionStates((prev) => {
+        const next: Record<string, TerminalConnectionState> = {};
+        for (const id of refreshedIds) {
+          next[id] = prev[id] ?? "connecting";
+        }
+
+        const sameSize =
+          Object.keys(prev).length === Object.keys(next).length &&
+          refreshedIds.length === terminalIds.length;
+
+        if (sameSize) {
+          let unchanged = true;
+          for (const id of refreshedIds) {
+            if (prev[id] !== next[id]) {
+              unchanged = false;
+              break;
+            }
+          }
+          if (unchanged) {
+            return prev;
+          }
+        }
+
+        return next;
+      });
+    },
+    onError: (error) => {
+      console.error("Failed to reconnect terminals", error);
+    },
+  });
+
+  const isReconnectionInFlight =
+    reconnectTerminalsMutation.isPending || resumeWorkspace.isPending;
+
+  const handleReconnectAllTerminals = useCallback(() => {
+    if (!hasTerminalBackend || isReconnectionInFlight) {
+      return;
+    }
+
+    reconnectTerminalsMutation.mutate();
+  }, [
+    hasTerminalBackend,
+    isReconnectionInFlight,
+    reconnectTerminalsMutation,
+  ]);
 
   useEffect(() => {
     if (!hasTerminalBackend || terminalIds.length === 0) {
@@ -481,6 +577,14 @@ function TaskRunTerminals() {
             <div className="flex items-center gap-2">
               <button
                 type="button"
+                onClick={handleReconnectAllTerminals}
+                disabled={!hasTerminalBackend || isReconnectionInFlight}
+                className="flex items-center gap-1 rounded-md border border-neutral-200 px-2 py-1 text-xs font-medium text-neutral-600 transition hover:border-neutral-300 hover:text-neutral-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:text-neutral-100"
+              >
+                {isReconnectionInFlight ? "Reconnecting…" : "Reconnect terminals"}
+              </button>
+              <button
+                type="button"
                 onClick={() => {
                   if (!hasTerminalBackend || isCreatingTerminal) {
                     return;
@@ -530,13 +634,15 @@ function TaskRunTerminals() {
           ) : (
             terminalIds.map((id) => (
               <TaskRunTerminalSession
-                key={id}
+                key={`${id}-${reconnectSeed}`}
                 baseUrl={xtermBaseUrl}
                 terminalId={id}
                 isActive={activeTerminalId === id}
                 onConnectionStateChange={(state) =>
                   handleConnectionStateChange(id, state)
                 }
+                onReconnectAll={handleReconnectAllTerminals}
+                isReconnecting={isReconnectionInFlight}
               />
             ))
           )}


### PR DESCRIPTION
## Summary
- wrap the reconnect-all terminals flow in a TanStack `useMutation` for consistent lifecycle handling
- reset terminal tab states and trigger Morph workspace resume inside the mutation before refetching tabs

## Testing
- bun run check *(hangs during scripts/check.ts; interrupted with Ctrl+C)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922515ac994833399253b7804d630d0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reconnect-all terminals workflow via mutation (resuming Morph workspace, refetching tabs, resetting state) and exposes UI buttons/overlay to trigger it.
> 
> - **Terminals UI/flow**:
>   - Introduce `reconnectTerminalsMutation` using TanStack Query to handle reconnect-all: resumes Morph workspace (via `useResumeMorphWorkspace`) when applicable, refetches terminal tabs, resets `connectionStates`, and bumps `reconnectSeed`.
>   - Add "Reconnect terminals" button in the terminals header; disabled while reconnecting; wires `handleReconnectAllTerminals`.
>   - Re-key terminal sessions as ```${id}-${reconnectSeed}``` to force remount after reconnect.
>   - Manage in-flight state with `isReconnectionInFlight` (mutation or workspace resume pending).
> - **TaskRunTerminalSession component**:
>   - Add optional props `onReconnectAll` and `isReconnecting`; show a reconnect CTA overlay when connection is `closed`/`error`.
>   - Make overlay interactive (remove pointer-events block) and pass through reconnect state/handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5f8d45f370b78e0205b4bc05ee44a27b7249403. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->