### PR TITLE
Fix slow codex startup by injecting DSR responses

### DIFF
--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -1170,8 +1170,16 @@ impl SandboxService for BubblewrapService {
             let (tx_out, mut rx_out) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
             let tx_err = tx_out.clone();
 
+            // Clone tx_in for DSR response injection
+            let tx_in_for_dsr = tx_in.clone();
+
             tokio::spawn(async move {
                 let mut buf = [0u8; 1024];
+                // DSR cursor position query: ESC [ 6 n
+                const DSR_QUERY: &[u8] = b"\x1b[6n";
+                // DSR status query: ESC [ 5 n
+                const DSR_STATUS_QUERY: &[u8] = b"\x1b[5n";
+
                 loop {
                     match stdout.read(&mut buf).await {
                         Ok(0) => {
@@ -1179,8 +1187,26 @@ impl SandboxService for BubblewrapService {
                             break;
                         }
                         Ok(n) => {
-                            info!("Read from stdout: {:?}", String::from_utf8_lossy(&buf[..n]));
-                            if tx_out.send(buf[..n].to_vec()).await.is_err() {
+                            let data = &buf[..n];
+                            info!("Read from stdout: {:?}", String::from_utf8_lossy(data));
+
+                            // Check for DSR cursor position query and respond immediately
+                            if data.windows(DSR_QUERY.len()).any(|w| w == DSR_QUERY) {
+                                // Respond with cursor at position 1,1 (standard response)
+                                let response = b"\x1b[1;1R".to_vec();
+                                info!("Detected DSR query, injecting cursor position response");
+                                let _ = tx_in_for_dsr.send(response).await;
+                            }
+
+                            // Check for DSR status query and respond
+                            if data.windows(DSR_STATUS_QUERY.len()).any(|w| w == DSR_STATUS_QUERY) {
+                                // Respond with "OK" status
+                                let response = b"\x1b[0n".to_vec();
+                                info!("Detected DSR status query, injecting OK response");
+                                let _ = tx_in_for_dsr.send(response).await;
+                            }
+
+                            if tx_out.send(data.to_vec()).await.is_err() {
                                 break;
                             }
                         }


### PR DESCRIPTION
## Summary
- Fixes ~2 second delay when starting codex in non-PTY attach mode
- Adds DSR response injection to the stdout reader

## Problem
When codex starts with interactive flags, it sends terminal capability queries and waits for responses. In the sandbox non-PTY mode, nothing responds, causing ~2 second timeout.

## Solution
Detect DSR escape sequences in stdout and inject fake responses to stdin.

## Test plan
- [ ] Build sandbox with cargo build --release
- [ ] Test codex startup time in a sandbox via ACP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)