### PR TITLE
Lock start after submission to prevent duplicates

### DIFF
--- a/apps/client/src/components/dashboard/DashboardStartTaskButton.tsx
+++ b/apps/client/src/components/dashboard/DashboardStartTaskButton.tsx
@@ -6,15 +6,17 @@ interface DashboardStartTaskButtonProps {
   canSubmit: boolean;
   onStartTask: () => void;
   disabledReason?: string;
+  isStarting: boolean;
 }
 
 export function DashboardStartTaskButton({
   canSubmit,
   onStartTask,
   disabledReason,
+  isStarting,
 }: DashboardStartTaskButtonProps) {
   const isMac = navigator.userAgent.toUpperCase().indexOf("MAC") >= 0;
-  const isDisabled = !canSubmit || !!disabledReason;
+  const isDisabled = isStarting || !canSubmit || !!disabledReason;
 
   return (
     <Tooltip delayDuration={0}>
@@ -31,8 +33,9 @@ export function DashboardStartTaskButton({
             className="!h-7 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:focus-visible:ring-offset-neutral-900"
             onClick={onStartTask}
             disabled={isDisabled}
+            aria-busy={isStarting}
           >
-            Start task
+            {isStarting ? "Starting..." : "Start task"}
           </Button>
         </span>
       </TooltipTrigger>

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -144,6 +144,8 @@ function DashboardComponent() {
   const [, setDockerReady] = useState<boolean | null>(null);
   const [providerStatus, setProviderStatus] =
     useState<ProviderStatusResponse | null>(null);
+  const [isStartingTask, setIsStartingTask] = useState(false);
+  const isStartingTaskRef = useRef(false);
 
   // const [hasDismissedCloudRepoOnboarding, setHasDismissedCloudRepoOnboarding] =
   //   useState<boolean>(false);
@@ -409,53 +411,60 @@ function DashboardComponent() {
   }, [selectedBranch, branchNames, remoteDefaultBranch]);
 
   const handleStartTask = useCallback(async () => {
-    // For local mode, perform a fresh docker check right before starting
-    if (!isEnvSelected && !isCloudMode) {
-      // Always check Docker status when in local mode, regardless of current state
-      if (socket) {
-        const ready = await new Promise<boolean>((resolve) => {
-          socket.emit("check-provider-status", (response) => {
-            const isRunning = !!response?.dockerStatus?.isRunning;
-            if (typeof isRunning === "boolean") {
-              setDockerReady(isRunning);
-            }
-            resolve(isRunning);
-          });
-        });
-
-        // Only show the alert if Docker is actually not running after checking
-        if (!ready) {
-          toast.error("Docker is not running. Start Docker Desktop.");
-          return;
-        }
-      } else {
-        // If socket is not connected, we can't verify Docker status
-        console.error("Cannot verify Docker status: socket not connected");
-        toast.error(
-          "Cannot verify Docker status. Please ensure the server is running."
-        );
-        return;
-      }
-    }
-
-    if (!selectedProject[0] || !taskDescription.trim()) {
-      console.error("Please select a project and enter a task description");
-      return;
-    }
-    if (!socket) {
-      console.error("Socket not connected");
+    if (isStartingTaskRef.current) {
       return;
     }
 
-    // Use the effective selected branch (respects available branches and sensible defaults)
-    const branch = effectiveSelectedBranch[0];
-    const projectFullName = selectedProject[0];
-    const envSelected = projectFullName.startsWith("env:");
-    const environmentId = envSelected
-      ? (projectFullName.replace(/^env:/, "") as Id<"environments">)
-      : undefined;
+    isStartingTaskRef.current = true;
+    setIsStartingTask(true);
 
     try {
+      // For local mode, perform a fresh docker check right before starting
+      if (!isEnvSelected && !isCloudMode) {
+        // Always check Docker status when in local mode, regardless of current state
+        if (socket) {
+          const ready = await new Promise<boolean>((resolve) => {
+            socket.emit("check-provider-status", (response) => {
+              const isRunning = !!response?.dockerStatus?.isRunning;
+              if (typeof isRunning === "boolean") {
+                setDockerReady(isRunning);
+              }
+              resolve(isRunning);
+            });
+          });
+
+          // Only show the alert if Docker is actually not running after checking
+          if (!ready) {
+            toast.error("Docker is not running. Start Docker Desktop.");
+            return;
+          }
+        } else {
+          // If socket is not connected, we can't verify Docker status
+          console.error("Cannot verify Docker status: socket not connected");
+          toast.error(
+            "Cannot verify Docker status. Please ensure the server is running."
+          );
+          return;
+        }
+      }
+
+      if (!selectedProject[0] || !taskDescription.trim()) {
+        console.error("Please select a project and enter a task description");
+        return;
+      }
+      if (!socket) {
+        console.error("Socket not connected");
+        return;
+      }
+
+      // Use the effective selected branch (respects available branches and sensible defaults)
+      const branch = effectiveSelectedBranch[0];
+      const projectFullName = selectedProject[0];
+      const envSelected = projectFullName.startsWith("env:");
+      const environmentId = envSelected
+        ? (projectFullName.replace(/^env:/, "") as Id<"environments">)
+        : undefined;
+
       // Extract content including images from the editor
       const content = editorApiRef.current?.getContent();
       const images = content?.images || [];
@@ -562,6 +571,9 @@ function DashboardComponent() {
       console.log("Task created:", taskId);
     } catch (error) {
       console.error("Error starting task:", error);
+    } finally {
+      isStartingTaskRef.current = false;
+      setIsStartingTask(false);
     }
   }, [
     selectedProject,
@@ -961,6 +973,7 @@ function DashboardComponent() {
               providerStatus={providerStatus}
               canSubmit={canSubmit}
               onStartTask={handleStartTask}
+              isStartingTask={isStartingTask}
             />
             {shouldShowWorkspaceSetup ? (
               <WorkspaceSetupPanel
@@ -1038,6 +1051,7 @@ type DashboardMainCardProps = {
   providerStatus: ProviderStatusResponse | null;
   canSubmit: boolean;
   onStartTask: () => void;
+  isStartingTask: boolean;
 };
 
 function DashboardMainCard({
@@ -1066,6 +1080,7 @@ function DashboardMainCard({
   providerStatus,
   canSubmit,
   onStartTask,
+  isStartingTask,
 }: DashboardMainCardProps) {
   return (
     <div className="relative bg-white dark:bg-neutral-700/50 border border-neutral-500/15 dark:border-neutral-500/15 rounded-2xl transition-all">
@@ -1103,6 +1118,8 @@ function DashboardMainCard({
         <DashboardStartTaskButton
           canSubmit={canSubmit}
           onStartTask={onStartTask}
+          isStarting={isStartingTask}
+          disabledReason={isStartingTask ? "Starting task..." : undefined}
         />
       </DashboardInputFooter>
     </div>


### PR DESCRIPTION
we need to fix an issue where i can accidentally press start task twice and it sends two tasks of the same prompt out. we need to lock start task after submitting it once so this doesn't happen, you can only start it once.