### PR TITLE
Fix account switch loading to show correct repos

### DIFF
--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -327,7 +327,7 @@ export function PreviewDashboard({
   };
 
   const fetchRepos = useCallback(
-    async (searchTerm: string) => {
+    async (searchTerm: string, signal?: AbortSignal) => {
       if (!canSearchRepos || selectedInstallationId === null) {
         setRepos([]);
         return;
@@ -343,13 +343,19 @@ export function PreviewDashboard({
         if (trimmed) {
           params.set("search", trimmed);
         }
-        const response = await fetch(`/api/integrations/github/repos?${params.toString()}`);
+        const response = await fetch(`/api/integrations/github/repos?${params.toString()}`, {
+          signal,
+        });
         if (!response.ok) {
           throw new Error(await response.text());
         }
         const payload = (await response.json()) as { repos: RepoSearchResult[] };
         setRepos(trimmed ? payload.repos : payload.repos.slice(0, 5));
       } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          // Request was cancelled, don't update state
+          return;
+        }
         const message = err instanceof Error ? err.message : "Failed to load repositories";
         console.error("[PreviewDashboard] Failed to load repositories", err);
         setErrorMessage(message);
@@ -361,15 +367,23 @@ export function PreviewDashboard({
   );
 
 
-  // Debounced search effect
+  // Debounced search effect with abort controller
   useEffect(() => {
-    if (!canSearchRepos || selectedInstallationId === null) return;
+    if (!canSearchRepos || selectedInstallationId === null) {
+      setRepos([]);
+      setIsLoadingRepos(false);
+      return;
+    }
 
+    const abortController = new AbortController();
     const timeoutId = setTimeout(() => {
-      void fetchRepos(repoSearch);
+      void fetchRepos(repoSearch, abortController.signal);
     }, 300);
 
-    return () => clearTimeout(timeoutId);
+    return () => {
+      clearTimeout(timeoutId);
+      abortController.abort();
+    };
   }, [repoSearch, canSearchRepos, selectedInstallationId, fetchRepos]);
 
   const handleContinue = useCallback((repoName: string) => {
@@ -385,9 +399,14 @@ export function PreviewDashboard({
 
   useEffect(() => {
     if (selectedInstallationId !== null) {
-      void fetchRepos("");
+      const abortController = new AbortController();
+      void fetchRepos("", abortController.signal);
+      return () => {
+        abortController.abort();
+      };
     } else {
       setRepos([]);
+      setIsLoadingRepos(false);
     }
   }, [selectedInstallationId, fetchRepos]);
 
@@ -447,6 +466,9 @@ export function PreviewDashboard({
                 void handleInstallGithubApp();
                 return;
               }
+              // Clear repos and show loading state immediately when switching accounts
+              setRepos([]);
+              setIsLoadingRepos(true);
               setSelectedInstallationId(Number(value));
             }}
             className="h-10 appearance-none bg-transparent py-2 pl-11 pr-8 text-sm text-white focus:outline-none"

--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -351,15 +351,15 @@ export function PreviewDashboard({
         }
         const payload = (await response.json()) as { repos: RepoSearchResult[] };
         setRepos(trimmed ? payload.repos : payload.repos.slice(0, 5));
+        setIsLoadingRepos(false);
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") {
-          // Request was cancelled, don't update state
+          // Request was cancelled, don't update any state
           return;
         }
         const message = err instanceof Error ? err.message : "Failed to load repositories";
         console.error("[PreviewDashboard] Failed to load repositories", err);
         setErrorMessage(message);
-      } finally {
         setIsLoadingRepos(false);
       }
     },
@@ -371,7 +371,6 @@ export function PreviewDashboard({
   useEffect(() => {
     if (!canSearchRepos || selectedInstallationId === null) {
       setRepos([]);
-      setIsLoadingRepos(false);
       return;
     }
 
@@ -406,7 +405,6 @@ export function PreviewDashboard({
       };
     } else {
       setRepos([]);
-      setIsLoadingRepos(false);
     }
   }, [selectedInstallationId, fetchRepos]);
 


### PR DESCRIPTION
choose a repository seems to be buggy sometimes, when we switch accounts, sometimes it doesnt go into the loading state so it shows repos that are of a different account. we dont want this to happen. someitme we siwtch accounts in the loading state and it loads the previous account's repos too... too confusing. this is in /preview page.