### PR TITLE
Prevent duplicate preview runs per PR

### DIFF
--- a/packages/convex/convex/previewRuns.ts
+++ b/packages/convex/convex/previewRuns.ts
@@ -99,6 +99,165 @@ export const linkTaskRun = internalMutation({
   },
 });
 
+/**
+ * Called from crown worker completion to create/link a preview run for a task run.
+ * This is used when a crown task completes with PR information and we want to
+ * capture screenshots and post them to the PR.
+ *
+ * Returns:
+ * - { created: true, previewRunId, isNew: true } if a new preview run was created
+ * - { created: true, previewRunId, isNew: false } if linked to an existing pending/running run
+ * - { created: false, reason: string } if no preview config exists or PR info missing
+ */
+export const enqueueFromTaskRun = internalMutation({
+  args: {
+    taskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const taskRun = await ctx.db.get(args.taskRunId);
+    if (!taskRun) {
+      return { created: false, reason: "Task run not found" };
+    }
+
+    // Check if this taskRun is already linked to a preview run
+    const existingLinkedRun = await ctx.db
+      .query("previewRuns")
+      .filter((q) => q.eq(q.field("taskRunId"), args.taskRunId))
+      .first();
+
+    if (existingLinkedRun) {
+      console.log("[previewRuns] Task run already linked to preview run", {
+        taskRunId: args.taskRunId,
+        previewRunId: existingLinkedRun._id,
+        status: existingLinkedRun.status,
+      });
+      return { created: true, previewRunId: existingLinkedRun._id, isNew: false };
+    }
+
+    // Get PR info from task run
+    const prUrl = taskRun.pullRequestUrl;
+    const prNumber = taskRun.pullRequestNumber;
+
+    if (!prUrl || !prNumber) {
+      console.log("[previewRuns] Task run missing PR info, skipping preview run creation", {
+        taskRunId: args.taskRunId,
+        hasPrUrl: Boolean(prUrl),
+        hasPrNumber: Boolean(prNumber),
+      });
+      return { created: false, reason: "Task run missing PR info" };
+    }
+
+    // Get task to get projectFullName (repoFullName)
+    const task = await ctx.db.get(taskRun.taskId);
+    if (!task?.projectFullName) {
+      console.log("[previewRuns] Task missing projectFullName, skipping preview run creation", {
+        taskRunId: args.taskRunId,
+        taskId: taskRun.taskId,
+      });
+      return { created: false, reason: "Task missing projectFullName" };
+    }
+
+    const repoFullName = normalizeRepoFullName(task.projectFullName);
+
+    // Look up preview config for this team/repo
+    const previewConfig = await ctx.db
+      .query("previewConfigs")
+      .withIndex("by_team_repo", (q) =>
+        q.eq("teamId", taskRun.teamId).eq("repoFullName", repoFullName),
+      )
+      .first();
+
+    if (!previewConfig) {
+      console.log("[previewRuns] No preview config found for repo", {
+        taskRunId: args.taskRunId,
+        teamId: taskRun.teamId,
+        repoFullName,
+      });
+      return { created: false, reason: "No preview config for repo" };
+    }
+
+    if (previewConfig.status === "disabled" || previewConfig.status === "paused") {
+      console.log("[previewRuns] Preview config is disabled/paused", {
+        taskRunId: args.taskRunId,
+        previewConfigId: previewConfig._id,
+        status: previewConfig.status,
+      });
+      return { created: false, reason: `Preview config is ${previewConfig.status}` };
+    }
+
+    // Check for existing pending/running preview run for this PR
+    const existingByPr = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", previewConfig._id).eq("prNumber", prNumber),
+      )
+      .order("desc")
+      .first();
+
+    if (existingByPr && (existingByPr.status === "pending" || existingByPr.status === "running")) {
+      console.log("[previewRuns] Found existing active preview run for PR, linking taskRun", {
+        taskRunId: args.taskRunId,
+        existingRunId: existingByPr._id,
+        prNumber,
+        status: existingByPr.status,
+      });
+
+      // Link this taskRun to the existing preview run if it doesn't have one
+      if (!existingByPr.taskRunId) {
+        await ctx.db.patch(existingByPr._id, {
+          taskRunId: args.taskRunId,
+          updatedAt: Date.now(),
+        });
+      }
+
+      return { created: true, previewRunId: existingByPr._id, isNew: false };
+    }
+
+    // Extract headSha from newBranch or use a placeholder
+    // In crown worker flow, we may not have the exact commit SHA
+    const headSha = taskRun.newBranch ?? `taskrun-${args.taskRunId}`;
+
+    const now = Date.now();
+    const runId = await ctx.db.insert("previewRuns", {
+      previewConfigId: previewConfig._id,
+      teamId: taskRun.teamId,
+      repoFullName,
+      repoInstallationId: previewConfig.repoInstallationId,
+      prNumber,
+      prUrl,
+      headSha,
+      baseSha: undefined,
+      headRef: taskRun.newBranch ?? undefined,
+      headRepoFullName: undefined,
+      headRepoCloneUrl: undefined,
+      taskRunId: args.taskRunId,
+      status: "pending",
+      dispatchedAt: undefined,
+      startedAt: undefined,
+      completedAt: undefined,
+      screenshotSetId: undefined,
+      githubCommentUrl: undefined,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await ctx.db.patch(previewConfig._id, {
+      lastRunAt: now,
+      updatedAt: now,
+    });
+
+    console.log("[previewRuns] Created new preview run from task run", {
+      taskRunId: args.taskRunId,
+      previewRunId: runId,
+      prNumber,
+      prUrl,
+      repoFullName,
+    });
+
+    return { created: true, previewRunId: runId, isNew: true };
+  },
+});
+
 export const markDispatched = internalMutation({
   args: {
     previewRunId: v.id("previewRuns"),


### PR DESCRIPTION
ok there are also two ways of starting preview jobs. one of them is starting them from the crown worker after task completes. the other is via a github webhook. so we need to modify the crown way in that it creates a previewRun... and we need to check before creating a previewRun if there is already a previewRun for this PR... we need to check it in both codepaths... to make sure (both the github webhook and the crown codepaths). if it is already taken as a preview job somewhere, we don't want to duplicate the preview job