### PR TITLE
Prevent duplicate preview runs per PR

### DIFF
--- a/packages/convex/convex/previewConfigs.ts
+++ b/packages/convex/convex/previewConfigs.ts
@@ -158,3 +158,12 @@ export const getByTeamAndRepo = internalQuery({
     return config ?? null;
   },
 });
+
+export const getByIdInternal = internalQuery({
+  args: {
+    id: v.id("previewConfigs"),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});


### PR DESCRIPTION
ok there are also two ways of starting preview jobs. one of them is starting them from the crown worker after task completes. the other is via a github webhook. so we need to modify the crown way in that it creates a previewRun... and we need to check before creating a previewRun if there is already a previewRun for this PR... we need to check it in both codepaths... to make sure (both the github webhook and the crown codepaths). if it is already taken as a preview job somewhere, we don't want to duplicate the preview job