### PR TITLE
Fix preview status not moving to Ready to Review

### DIFF
--- a/packages/convex/convex/preview_jobs_http.ts
+++ b/packages/convex/convex/preview_jobs_http.ts
@@ -37,6 +37,7 @@ async function markPreviewTaskCompleted(
     await ctx.runMutation(internal.tasks.setCompletedInternal, {
       taskId: task._id,
       isCompleted: true,
+      crownEvaluationStatus: "succeeded",
     });
   }
 

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -861,11 +861,22 @@ export const setCompletedInternal = internalMutation({
   args: {
     taskId: v.id("tasks"),
     isCompleted: v.boolean(),
+    crownEvaluationStatus: v.optional(
+      v.union(
+        v.literal("pending"),
+        v.literal("in_progress"),
+        v.literal("succeeded"),
+        v.literal("error"),
+      ),
+    ),
   },
   handler: async (ctx, args) => {
     await ctx.db.patch(args.taskId, {
       isCompleted: args.isCompleted,
       updatedAt: Date.now(),
+      ...(args.crownEvaluationStatus && {
+        crownEvaluationStatus: args.crownEvaluationStatus,
+      }),
     });
   },
 });


### PR DESCRIPTION
for preview jobs, we have it say complete on the left sidebar, but we are still sorting it in the in progress sectino. figure out what thing we are missing that we need to append as complete in order to get it in the ready to review instead.. it seems incomplete in the main dashboard (shows it in in-progress).. there seems to be a mismatch. we actualy want to show it as complete and in ready to review section of the dashboard. why is it not being put there? which condiiton is it not hitting correctly.