### PR TITLE
Fix gemini spawn for --model gemini-3-pro-preview

### DIFF
--- a/packages/shared/src/providers/gemini/configs.ts
+++ b/packages/shared/src/providers/gemini/configs.ts
@@ -11,7 +11,7 @@ export const GEMINI_3_PRO_PREVIEW_CONFIG: AgentConfig = {
   args: [
     "@google/gemini-cli@latest",
     "--model",
-    "gemini-3-pro-preview",
+    "gemini-3.0-pro-preview",
     "--yolo",
     "--telemetry",
     "--telemetry-target=local",


### PR DESCRIPTION
gemini-3-pro-preview command does not work. it shoudl be a command similar to this: gemini --model gemini-3-pro-preview --yolo
why isn't it spawning