### PR TITLE
fix(web-mode): check API keys from Convex for provider status

### DIFF
--- a/apps/client/src/components/dashboard/DashboardInputControls.tsx
+++ b/apps/client/src/components/dashboard/DashboardInputControls.tsx
@@ -123,7 +123,9 @@ export const DashboardInputControls = memo(function DashboardInputControls({
                   Setup required
                 </p>
                 <p className="text-xs text-neutral-300">
-                  Add credentials for this agent in Settings.
+                  {env.NEXT_PUBLIC_WEB_MODE
+                    ? "Add your API key for this agent in Settings."
+                    : "Add credentials for this agent in Settings."}
                 </p>
                 {missingRequirements.length > 0 ? (
                   <ul className="list-disc pl-4 text-xs text-neutral-400">

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -341,8 +341,12 @@ function DashboardComponent() {
         if (uniqueMissing.length > 0) {
           const label = uniqueMissing.length === 1 ? "model" : "models";
           const verb = uniqueMissing.length === 1 ? "is" : "are";
+          const thisThese = uniqueMissing.length === 1 ? "this" : "these";
+          const actionMessage = env.NEXT_PUBLIC_WEB_MODE
+            ? `Add your API keys in Settings to use ${thisThese} ${label}.`
+            : `Update credentials in Settings to use ${thisThese} ${label}.`;
           toast.warning(
-            `${uniqueMissing.join(", ")} ${verb} not configured and was removed from the selection. Update credentials in Settings to use this ${label}.`
+            `${uniqueMissing.join(", ")} ${verb} not configured and was removed from the selection. ${actionMessage}`
           );
         }
       }


### PR DESCRIPTION
In web mode, the provider status check was returning a hardcoded response instead of actually checking API keys from Convex. Now it properly queries for user's API keys and validates each agent's requirements.

Also updates error messages and tooltips to be more specific about API keys when in web mode vs general "credentials" messaging for non-web mode.