### PR TITLE
Ensure rustup default in VM

### DIFF
--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1823,6 +1823,13 @@ export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH="/usr/local/bin:/usr/local/cargo/bin:$HOME/.local/bin:$PATH"
 EOF
+        # Also add to /etc/environment for non-interactive sessions
+        if ! grep -q 'RUSTUP_HOME=' /etc/environment 2>/dev/null; then
+          echo 'RUSTUP_HOME=/usr/local/rustup' >> /etc/environment
+        fi
+        if ! grep -q 'CARGO_HOME=' /etc/environment 2>/dev/null; then
+          echo 'CARGO_HOME=/usr/local/cargo' >> /etc/environment
+        fi
         if ! grep -q "alias g='git'" /root/.bashrc 2>/dev/null; then
           echo "alias g='git'" >> /root/.bashrc
         fi
@@ -2229,6 +2236,9 @@ PROFILE
         fi
         if ! grep -q 'XDG_RUNTIME_DIR=/run/user/0' /root/.zshrc 2>/dev/null; then
           echo 'export XDG_RUNTIME_DIR=/run/user/0' >> /root/.zshrc
+        fi
+        if ! grep -q 'cmux-paths.sh' /root/.zshrc 2>/dev/null; then
+          echo '[ -f /etc/profile.d/cmux-paths.sh ] && . /etc/profile.d/cmux-paths.sh' >> /root/.zshrc
         fi
         """
     )


### PR DESCRIPTION
im running into a weird issue that doesn't happen when i configure the environment. i configure it correctly and all the sripts seem to work. but then i start another vm instance from the snapshot and i run into this issue: Starting Terminal App Development Environment...
Building native Rust addon...
Internal Error: cargo metadata exited with code 1 and error message:

error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.


error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.

    at parseMetadata (/tmp/bunx-0-@napi-rs/cli@latest/node_modules/@napi-rs/cli/dist/cli.js:433:13)
    at async buildProject (/tmp/bunx-0-@napi-rs/cli@latest/node_modules/@napi-rs/cli/dist/cli.js:1321:25)
    at async execute (/tmp/bunx-0-@napi-rs/cli@latest/node_modules/@napi-rs/cli/dist/cli.js:3718:26)
    at async validateAndExecute (/tmp/bunx-0-@napi-rs/cli@latest/node_modules/clipanion/lib/advanced/Command.mjs:49:37)
    at processTicksAndRejections (native:7:39)

Shutting down... why is this happening. it seems like different behavior even though they should be coming from the same source of truth.