### PR TITLE
Fix token expiry syncing with convex

### DIFF
--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -46,7 +46,7 @@ import type { RealtimeServer } from "./realtime";
 import { RepositoryManager } from "./repositoryManager";
 import type { GitRepoInfo } from "./server";
 import { getPRTitleFromTaskDescription } from "./utils/branchNameGenerator";
-import { getConvex } from "./utils/convexClient";
+import { getConvex, getConvexWithTokenGetter } from "./utils/convexClient";
 import { ensureRunWorktreeAndBranch } from "./utils/ensureRunWorktree";
 import { serverLogger } from "./utils/fileLogger";
 import { getGitHubTokenFromKeychain } from "./utils/getGitHubToken";
@@ -558,6 +558,11 @@ export function setupSocketHandlers(
           taskId,
         });
 
+        // Create a token getter that returns the latest auth token from the socket's closure.
+        // This allows long-running async operations to get refreshed tokens even after
+        // the original AsyncLocalStorage context token has expired.
+        const getAuthTokenFromSocket = () => currentAuthToken;
+
         (async () => {
           try {
             // Generate PR title early from the task description
@@ -567,12 +572,15 @@ export function setupSocketHandlers(
                 taskData.taskDescription,
                 safeTeam
               );
-              // Persist to Convex immediately
-              await getConvex().mutation(api.tasks.setPullRequestTitle, {
-                teamSlugOrId: safeTeam,
-                id: taskId,
-                pullRequestTitle: generatedTitle,
-              });
+              // Persist to Convex immediately, using the token getter to ensure fresh token
+              await getConvexWithTokenGetter(getAuthTokenFromSocket).mutation(
+                api.tasks.setPullRequestTitle,
+                {
+                  teamSlugOrId: safeTeam,
+                  id: taskId,
+                  pullRequestTitle: generatedTitle,
+                }
+              );
               serverLogger.info(
                 `[Server] Saved early PR title: ${generatedTitle}`
               );
@@ -584,6 +592,7 @@ export function setupSocketHandlers(
             }
 
             // Spawn all agents in parallel (each will create its own taskRun)
+            // Pass the token getter so agents can use fresh tokens during long-running operations
             const agentResults = await spawnAllAgents(
               taskId,
               {
@@ -596,6 +605,7 @@ export function setupSocketHandlers(
                 images: taskData.images,
                 theme: taskData.theme,
                 environmentId: taskData.environmentId,
+                authTokenGetter: getAuthTokenFromSocket,
               },
               safeTeam
             );

--- a/apps/server/src/utils/convexClient.ts
+++ b/apps/server/src/utils/convexClient.ts
@@ -3,9 +3,41 @@ import { ConvexHttpClient } from "convex/browser";
 import { getAuthToken } from "./requestContext";
 import { env } from "./server-env";
 
+/**
+ * A function that returns the current auth token.
+ * Used for long-running operations that need to get the latest token.
+ */
+export type AuthTokenGetter = () => string | undefined;
+
 // Return a Convex client bound to the current auth context
 export function getConvex() {
   const auth = getAuthToken();
+  if (!auth) {
+    throw new Error("No auth token found");
+  }
+
+  // Try to get from cache first
+  const cachedClient = convexClientCache.get(auth, env.NEXT_PUBLIC_CONVEX_URL);
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  // Create new client and cache it
+  const client = new ConvexHttpClient(env.NEXT_PUBLIC_CONVEX_URL);
+  client.setAuth(auth);
+  convexClientCache.set(auth, env.NEXT_PUBLIC_CONVEX_URL, client);
+  return client;
+}
+
+/**
+ * Return a Convex client using a token getter function.
+ * This allows long-running operations to get the latest token
+ * even after the original AsyncLocalStorage context token has expired.
+ *
+ * The getter is called on each invocation to ensure the latest token is used.
+ */
+export function getConvexWithTokenGetter(getToken: AuthTokenGetter) {
+  const auth = getToken();
   if (!auth) {
     throw new Error("No auth token found");
   }


### PR DESCRIPTION
figure out how to fix this issue: 
Task failed to start: gemini/3-pro-preview: {"code":"InvalidAuthHeader","message":"Could not validate token: Token expired 8 seconds ago"} this is a problem with convex stackauth some sort of expiry and we're not resetting the accessToken... its when we refresh token but we reset it on our end but not in convex end or something