### PR TITLE
Add delta pager toggle to command palette

### DIFF
--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -475,22 +475,10 @@ fi
         fs::create_dir_all(&root_home).await?;
 
         let gitconfig = root_home.join(".gitconfig");
+        // Only set safe.directory - don't override user's pager preferences
+        // Users can enable delta via command palette (EnableDeltaPager)
         let content = r#"[safe]
 	directory = *
-
-[core]
-	pager = delta
-
-[interactive]
-	diffFilter = delta --color-only
-
-[delta]
-	navigate = true
-	line-numbers = true
-	side-by-side = false
-
-[merge]
-	conflictStyle = zdiff3
 "#;
         fs::write(&gitconfig, content).await?;
         Ok(())

--- a/packages/sandbox/src/mux/commands.rs
+++ b/packages/sandbox/src/mux/commands.rs
@@ -75,6 +75,10 @@ pub enum MuxCommand {
     ScrollPageDown,
     ScrollToTop,
     ScrollToBottom,
+
+    // Terminal utilities
+    EnableDeltaPager,
+    DisableDeltaPager,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -151,6 +155,9 @@ impl MuxCommand {
             MuxCommand::ScrollPageDown,
             MuxCommand::ScrollToTop,
             MuxCommand::ScrollToBottom,
+            // Terminal utilities
+            MuxCommand::EnableDeltaPager,
+            MuxCommand::DisableDeltaPager,
         ]
     }
 
@@ -213,6 +220,8 @@ impl MuxCommand {
             MuxCommand::ScrollPageDown => "Scroll Page Down",
             MuxCommand::ScrollToTop => "Scroll to Top",
             MuxCommand::ScrollToBottom => "Scroll to Bottom",
+            MuxCommand::EnableDeltaPager => "Enable Delta Pager",
+            MuxCommand::DisableDeltaPager => "Disable Delta Pager",
         }
     }
 
@@ -244,6 +253,8 @@ impl MuxCommand {
             MuxCommand::ScrollPageDown => &["page down", "scroll down fast"],
             MuxCommand::ScrollToTop => &["beginning", "start", "top"],
             MuxCommand::ScrollToBottom => &["end", "bottom"],
+            MuxCommand::EnableDeltaPager => &["git diff", "syntax highlighting", "pretty diff"],
+            MuxCommand::DisableDeltaPager => &["git diff", "plain diff", "default pager"],
             _ => &[],
         }
     }
@@ -307,6 +318,8 @@ impl MuxCommand {
             MuxCommand::ScrollPageDown => "Scroll down one page",
             MuxCommand::ScrollToTop => "Scroll to the top",
             MuxCommand::ScrollToBottom => "Scroll to the bottom",
+            MuxCommand::EnableDeltaPager => "Use delta for syntax-highlighted git diffs",
+            MuxCommand::DisableDeltaPager => "Use default pager for git diffs",
         }
     }
 
@@ -375,6 +388,8 @@ impl MuxCommand {
             | MuxCommand::ScrollPageDown
             | MuxCommand::ScrollToTop
             | MuxCommand::ScrollToBottom => "General",
+
+            MuxCommand::EnableDeltaPager | MuxCommand::DisableDeltaPager => "Terminal",
         }
     }
 
@@ -496,6 +511,10 @@ impl MuxCommand {
             MuxCommand::ScrollPageDown => Some((KeyModifiers::ALT, KeyCode::PageDown)),
             MuxCommand::ScrollToTop => Some((KeyModifiers::ALT, KeyCode::Home)),
             MuxCommand::ScrollToBottom => Some((KeyModifiers::ALT, KeyCode::End)),
+
+            // Terminal utilities - access via command palette only
+            MuxCommand::EnableDeltaPager => None,
+            MuxCommand::DisableDeltaPager => None,
         }
     }
 

--- a/packages/sandbox/src/mux/events.rs
+++ b/packages/sandbox/src/mux/events.rs
@@ -49,4 +49,11 @@ pub enum MuxEvent {
     ThemeChanged { colors: TerminalColors },
     /// Onboarding event (image check, download progress, etc.)
     Onboard(OnboardEvent),
+    /// Send input to a terminal pane
+    SendTerminalInput { pane_id: PaneId, input: Vec<u8> },
+    /// Execute a command in a sandbox silently via exec API
+    ExecInSandbox {
+        sandbox_id: String,
+        command: Vec<String>,
+    },
 }

--- a/packages/sandbox/src/mux/runner.rs
+++ b/packages/sandbox/src/mux/runner.rs
@@ -293,6 +293,35 @@ async fn run_app<B: ratatui::backend::Backend + std::io::Write>(
                         let event_tx_for_handler = app.event_tx.clone();
                         handle_onboard_event(&mut app, onboard_event.clone(), &event_tx_for_handler);
                     }
+                    MuxEvent::SendTerminalInput { pane_id, input } => {
+                        if let Ok(manager) = terminal_manager.try_lock() {
+                            if !manager.send_input(*pane_id, input.clone()) {
+                                tracing::warn!("Failed to send terminal input to pane {:?}", pane_id);
+                            }
+                        }
+                    }
+                    MuxEvent::ExecInSandbox { sandbox_id, command } => {
+                        // Execute command in sandbox silently via exec API
+                        let base_url = app.base_url.clone();
+                        let sandbox_id = sandbox_id.clone();
+                        let command = command.clone();
+                        tokio::spawn(async move {
+                            let client = reqwest::Client::new();
+                            let url = format!(
+                                "{}/sandboxes/{}/exec",
+                                base_url.trim_end_matches('/'),
+                                sandbox_id
+                            );
+                            let body = crate::models::ExecRequest {
+                                command,
+                                workdir: None,
+                                env: Vec::new(),
+                            };
+                            if let Err(e) = client.post(&url).json(&body).send().await {
+                                tracing::warn!("Failed to exec in sandbox: {}", e);
+                            }
+                        });
+                    }
                     _ => {}
                 }
                 app.handle_event(event);

--- a/packages/sandbox/src/mux/state.rs
+++ b/packages/sandbox/src/mux/state.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
@@ -208,6 +208,9 @@ pub struct MuxApp<'a> {
 
     /// Onboarding state for Docker image setup
     pub onboard: Option<OnboardState>,
+
+    /// Sandboxes that have delta pager enabled
+    pub delta_enabled_sandboxes: HashSet<SandboxId>,
 }
 
 impl<'a> MuxApp<'a> {
@@ -239,6 +242,7 @@ impl<'a> MuxApp<'a> {
             cursor_blink: true,
             cursor_color: None,
             onboard: None,
+            delta_enabled_sandboxes: HashSet::new(),
         }
     }
 
@@ -306,6 +310,12 @@ impl<'a> MuxApp<'a> {
     /// Set a status message that will be displayed temporarily.
     pub fn set_status(&mut self, message: impl Into<String>) {
         self.status_message = Some((message.into(), std::time::Instant::now()));
+    }
+
+    /// Check if delta pager is enabled for the current sandbox.
+    pub fn is_delta_enabled(&self) -> bool {
+        self.selected_sandbox_id()
+            .is_some_and(|id| self.delta_enabled_sandboxes.contains(&id))
     }
 
     /// Clear expired status messages.
@@ -658,6 +668,50 @@ impl<'a> MuxApp<'a> {
             | MuxCommand::ScrollToBottom => {
                 // TODO: Forward to active pane
             }
+
+            // Terminal utilities - execute git config silently via exec API
+            MuxCommand::EnableDeltaPager => {
+                if let Some(sandbox_id) = self.selected_sandbox_id() {
+                    // Enable delta with line numbers, navigation, and always-pager mode
+                    let cmd = vec![
+                        "/bin/sh".to_string(),
+                        "-c".to_string(),
+                        "git config --global core.pager 'delta --paging=always' && \
+                         git config --global interactive.diffFilter 'delta --color-only' && \
+                         git config --global delta.navigate true && \
+                         git config --global delta.line-numbers true && \
+                         git config --global delta.paging always"
+                            .to_string(),
+                    ];
+                    let _ = self.event_tx.send(MuxEvent::ExecInSandbox {
+                        sandbox_id: sandbox_id.to_string(),
+                        command: cmd,
+                    });
+                    self.delta_enabled_sandboxes.insert(sandbox_id);
+                    self.set_status("Delta pager enabled");
+                }
+            }
+            MuxCommand::DisableDeltaPager => {
+                if let Some(sandbox_id) = self.selected_sandbox_id() {
+                    let cmd = vec![
+                        "/bin/sh".to_string(),
+                        "-c".to_string(),
+                        "git config --global --unset core.pager; \
+                         git config --global --unset interactive.diffFilter; \
+                         git config --global --unset delta.navigate; \
+                         git config --global --unset delta.line-numbers; \
+                         git config --global --unset delta.paging; \
+                         true"
+                            .to_string(),
+                    ];
+                    let _ = self.event_tx.send(MuxEvent::ExecInSandbox {
+                        sandbox_id: sandbox_id.to_string(),
+                        command: cmd,
+                    });
+                    self.delta_enabled_sandboxes.remove(&sandbox_id);
+                    self.set_status("Delta pager disabled");
+                }
+            }
         }
     }
 
@@ -825,6 +879,12 @@ impl<'a> MuxApp<'a> {
             }
             MuxEvent::Onboard(_) => {
                 // Onboard events are handled in the runner
+            }
+            MuxEvent::SendTerminalInput { .. } => {
+                // Terminal input is handled in the runner
+            }
+            MuxEvent::ExecInSandbox { .. } => {
+                // Exec requests are handled in the runner
             }
         }
     }

--- a/packages/sandbox/src/mux/ui.rs
+++ b/packages/sandbox/src/mux/ui.rs
@@ -643,6 +643,24 @@ fn render_command_palette(f: &mut Frame, app: &mut MuxApp) {
 
     let (items, selected_line_index) = app.command_palette.get_items();
 
+    // Filter out the inappropriate delta command based on current state
+    let delta_enabled = app.is_delta_enabled();
+    let items: Vec<_> = items
+        .into_iter()
+        .filter(|item| {
+            if let PaletteItem::Command { command, .. } = item {
+                // If delta is enabled, hide EnableDeltaPager; if disabled, hide DisableDeltaPager
+                if delta_enabled && *command == MuxCommand::EnableDeltaPager {
+                    return false;
+                }
+                if !delta_enabled && *command == MuxCommand::DisableDeltaPager {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+
     for item in items {
         match item {
             PaletteItem::Header(text) => {


### PR DESCRIPTION
## Summary
- Add EnableDeltaPager and DisableDeltaPager commands to command palette
- Only shows relevant command based on current state (Enable when disabled, Disable when enabled)
- Executes git config silently via sandbox exec API instead of typing into terminal
- Delta configured with line numbers, navigation, and always-pager mode

## Test plan
- [ ] Open dmux and connect to a sandbox
- [ ] Open command palette (Alt+P), search "delta"
- [ ] Should see "Enable Delta Pager" (since delta is disabled by default)
- [ ] Select it, run `git diff` in terminal - should show syntax-highlighted output
- [ ] Open palette again, search "delta" - should now show "Disable Delta Pager"
- [ ] Select it, run `git diff` again - should show plain output