### PR TITLE
feat(sandbox): preinstall neovim and emacs in Docker container

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -136,6 +136,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   zsh-autosuggestions \
   zsh-syntax-highlighting \
   vim \
+  neovim \
+  emacs-nox \
   tini \
   python3 \
   python3-venv \


### PR DESCRIPTION
## Summary
- Add neovim and emacs-nox to the Docker base image
- Users can now use nvim/emacs without manual installation

## Test plan
- [ ] Build Docker image successfully
- [ ] Verify `nvim --version` works in sandbox
- [ ] Verify `emacs --version` works in sandbox

Closes sandbox-ssw