### PR TITLE
feat(sandbox): sync user's main .zshrc file

### DIFF
--- a/packages/sandbox/src/sync_files.rs
+++ b/packages/sandbox/src/sync_files.rs
@@ -163,8 +163,14 @@ pub const SYNC_FILES: &[SyncFileDef] = &[
         sandbox_path: "/root/.qwen/settings.json",
         is_dir: false,
     },
-    // Zsh configuration - only sync .zshrc.local for user customizations
-    // (sandbox has its own default .zshrc with git prompt, autosuggestions, etc.)
+    // Zsh configuration - sync user's zshrc if they have one
+    // (sandbox creates a default .zshrc only if user doesn't have their own)
+    SyncFileDef {
+        name: "Zshrc",
+        host_path: ".zshrc",
+        sandbox_path: "/root/.zshrc",
+        is_dir: false,
+    },
     SyncFileDef {
         name: "Zshrc Local",
         host_path: ".zshrc.local",


### PR DESCRIPTION
## Summary
- Sync the user's main `.zshrc` file into the sandbox
- Previously only `.zshrc.local` was synced
- Users now get their full zsh configuration including aliases, functions, and settings

## Test plan
- [ ] User with custom `.zshrc` sees their config in sandbox
- [ ] User without `.zshrc` gets the default sandbox zshrc

Closes sandbox-2s8