### PR TITLE
feat(sandbox): add Alt+Shift+X shortcut to delete sandbox

### DIFF
--- a/packages/sandbox/src/mux/commands.rs
+++ b/packages/sandbox/src/mux/commands.rs
@@ -489,7 +489,9 @@ impl MuxCommand {
 
             // Sandbox management - use Alt
             MuxCommand::NewSandbox => Some((KeyModifiers::ALT, KeyCode::Char('n'))),
-            MuxCommand::DeleteSandbox => None, // No default keybinding, access via command palette
+            MuxCommand::DeleteSandbox => {
+                Some((KeyModifiers::ALT | KeyModifiers::SHIFT, KeyCode::Char('X')))
+            }
             MuxCommand::RefreshSandboxes => Some((KeyModifiers::ALT, KeyCode::Char('R'))), // Alt+Shift+R
 
             // Session - use Alt


### PR DESCRIPTION
## Summary
- Add `Alt+Shift+X` keyboard shortcut for deleting sandboxes
- Previously only accessible via command palette
- Uses X since Alt+Shift+W is taken by CloseTab

## Test plan
- [ ] Press Alt+Shift+X with sandbox selected → prompts for deletion
- [ ] Verify keybinding shows in command palette

Closes sandbox-xrq