### PR TITLE
feat(sandbox): implement remaining easy escape sequences

### DIFF
--- a/packages/sandbox/docs/escape-sequence-todos.md
+++ b/packages/sandbox/docs/escape-sequence-todos.md
@@ -45,18 +45,18 @@ See `src/mux/terminal.rs` for the current implementation. Key supported sequence
   - `OSC 112 ST`
   - Also implemented OSC 12 (set/query cursor color)
 
-- [ ] **CSI ? 1004 h/l** - Focus Reporting
+- [x] **CSI ? 1004 h/l** - Focus Reporting
   - `CSI ? 1004 h` = enable focus events
   - `CSI ? 1004 l` = disable focus events
   - When enabled, send `CSI I` on focus in, `CSI O` on focus out
   - Used by vim/neovim to detect when terminal gains/loses focus
 
-- [ ] **OSC 7** - Current Working Directory
+- [x] **OSC 7** - Current Working Directory
   - Format: `OSC 7 ; file://hostname/path ST`
   - Shells emit this after each command
   - Store in terminal state for UI display / tab titles
 
-- [ ] **CSI ? 1034 h/l** - Meta Sends Escape
+- [x] **CSI ? 1034 h/l** - Meta Sends Escape
   - Controls whether Alt+key sends ESC+key or sets high bit
   - Most terminals default to ESC prefix mode
 


### PR DESCRIPTION
## Summary
- Add CSI ? 1004 h/l (focus reporting mode) - vim/neovim use this
- Add CSI ? 1034 h/l (meta sends escape mode)
- Add OSC 7 (current working directory) - shells emit after each command

These complete all the "Easy" items from docs/escape-sequence-todos.md.

## Test plan
- [ ] Programs that use focus events (vim) receive CSI I on focus in
- [ ] Shell's OSC 7 is parsed and stored in terminal state
- [ ] Meta sends escape mode can be toggled

Closes sandbox-hre