### PR TITLE
feat(sandbox): auto-scroll to cursor when user types

### DIFF
--- a/packages/sandbox/src/mux/runner.rs
+++ b/packages/sandbox/src/mux/runner.rs
@@ -294,7 +294,7 @@ async fn run_app<B: ratatui::backend::Backend + std::io::Write>(
                         handle_onboard_event(&mut app, onboard_event.clone(), &event_tx_for_handler);
                     }
                     MuxEvent::SendTerminalInput { pane_id, input } => {
-                        if let Ok(manager) = terminal_manager.try_lock() {
+                        if let Ok(mut manager) = terminal_manager.try_lock() {
                             if !manager.send_input(*pane_id, input.clone()) {
                                 tracing::warn!("Failed to send terminal input to pane {:?}", pane_id);
                             }
@@ -795,7 +795,7 @@ fn handle_input(
                         if let Some(pane_id) = app.active_pane_id() {
                             let input = key_to_terminal_input(key.modifiers, key.code);
                             if !input.is_empty() {
-                                if let Ok(guard) = terminal_manager.try_lock() {
+                                if let Ok(mut guard) = terminal_manager.try_lock() {
                                     guard.send_input(pane_id, input);
                                 }
                             }
@@ -940,7 +940,7 @@ fn handle_input(
                                 }
                             }
 
-                            if let Ok(guard) = terminal_manager.try_lock() {
+                            if let Ok(mut guard) = terminal_manager.try_lock() {
                                 let (mouse_mode, sgr_mode) = guard
                                     .get_buffer(pane_id)
                                     .map(|b| (b.mouse_tracking(), b.sgr_mouse_mode()))
@@ -992,7 +992,7 @@ fn handle_input(
         Event::Paste(text) => {
             // Forward paste to active terminal
             if let Some(pane_id) = app.active_pane_id() {
-                if let Ok(guard) = terminal_manager.try_lock() {
+                if let Ok(mut guard) = terminal_manager.try_lock() {
                     guard.send_input(pane_id, text.into_bytes());
                 }
             }

--- a/packages/sandbox/src/mux/terminal.rs
+++ b/packages/sandbox/src/mux/terminal.rs
@@ -3399,8 +3399,16 @@ impl TerminalManager {
         self.sessions.contains_key(&pane_id)
     }
 
-    /// Send input to a terminal session via the multiplexed connection
-    pub fn send_input(&self, pane_id: PaneId, data: Vec<u8>) -> bool {
+    /// Send input to a terminal session via the multiplexed connection.
+    /// Also scrolls to bottom so the user sees where they're typing.
+    pub fn send_input(&mut self, pane_id: PaneId, data: Vec<u8>) -> bool {
+        // Auto-scroll to bottom when user types - they want to see the cursor
+        if let Some(buffer) = self.buffers.get_mut(&pane_id) {
+            if buffer.scroll_offset() > 0 {
+                buffer.scroll_to_bottom();
+            }
+        }
+
         let session = match self.sessions.get(&pane_id) {
             Some(s) => s,
             None => return false,


### PR DESCRIPTION
## Summary
- Auto-scroll terminal to bottom when user sends any input
- Prevents typing blind while viewing scrollback

## Test plan
- [ ] Scroll up in terminal (Alt+PageUp or mouse wheel)
- [ ] Type something
- [ ] Terminal should scroll back to bottom showing cursor

Closes sandbox-oad