### PR TITLE
fix(sandbox): configure git to always use pager for diffs

### DIFF
--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -475,10 +475,13 @@ fi
         fs::create_dir_all(&root_home).await?;
 
         let gitconfig = root_home.join(".gitconfig");
-        // Only set safe.directory - don't override user's pager preferences
+        // Set safe.directory and configure pager to always show for diffs
         // Users can enable delta via command palette (EnableDeltaPager)
+        // Using 'less -R' without -F ensures pager is used even for small diffs
         let content = r#"[safe]
 	directory = *
+[core]
+	pager = less -R
 "#;
         fs::write(&gitconfig, content).await?;
         Ok(())


### PR DESCRIPTION
## Summary
- Set `core.pager = less -R` in sandbox gitconfig
- Removes `-F` flag so small diffs still show in pager
- Prevents the jarring "flash and disappear" behavior

## Test plan
- [ ] Create sandbox and run `git diff` with small changes
- [ ] Verify pager is used even for one-line diffs

Closes sandbox-dit