### PR TITLE
feat(preview): detect package manager and verify scripts exist

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checks and tests (parallel on one runner)
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           STACK_SECRET_SERVER_KEY: ${{ secrets.STACK_SECRET_SERVER_KEY }}
           STACK_SUPER_SECRET_ADMIN_KEY: ${{ secrets.STACK_SUPER_SECRET_ADMIN_KEY }}
           STACK_DATA_VAULT_SECRET: ${{ secrets.STACK_DATA_VAULT_SECRET }}

--- a/apps/www/app/(preview)/preview/configure/page.tsx
+++ b/apps/www/app/(preview)/preview/configure/page.tsx
@@ -11,7 +11,7 @@ import {
   getTeamSlugOrId,
   type StackTeam,
 } from "@/lib/team-utils";
-import { detectFrameworkPreset } from "@/lib/github/framework-detection";
+import { detectFrameworkAndPackageManager } from "@/lib/github/framework-detection";
 import { env } from "@/lib/utils/www-env";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 
@@ -150,11 +150,12 @@ export default async function PreviewConfigurePage({ searchParams }: PageProps) 
     console.error("Failed to fetch GitHub access token", error);
   }
 
-  const detectedFrameworkPreset = await detectFrameworkPreset(repo, githubAccessToken);
+  const detectionResult = await detectFrameworkAndPackageManager(repo, githubAccessToken);
 
   let initialEnvVarsContent: string | null = null;
-  let initialMaintenanceScript: string | null = null;
-  let initialDevScript: string | null = null;
+  // Use detected scripts from package.json, can be overridden by environment
+  let initialMaintenanceScript: string | null = detectionResult.maintenanceScript || null;
+  let initialDevScript: string | null = detectionResult.devScript || null;
 
   if (environmentId) {
     try {
@@ -195,7 +196,8 @@ export default async function PreviewConfigurePage({ searchParams }: PageProps) 
       teams={clientTeams}
       repo={repo}
       installationId={installationId}
-      initialFrameworkPreset={detectedFrameworkPreset}
+      initialFrameworkPreset={detectionResult.framework}
+      initialPackageManager={detectionResult.packageManager}
       initialEnvVarsContent={initialEnvVarsContent}
       initialMaintenanceScript={initialMaintenanceScript}
       initialDevScript={initialDevScript}

--- a/apps/www/app/(preview)/preview/configure/page.tsx
+++ b/apps/www/app/(preview)/preview/configure/page.tsx
@@ -154,8 +154,9 @@ export default async function PreviewConfigurePage({ searchParams }: PageProps) 
 
   let initialEnvVarsContent: string | null = null;
   // Use detected scripts from package.json, can be overridden by environment
-  let initialMaintenanceScript: string | null = detectionResult.maintenanceScript || null;
-  let initialDevScript: string | null = detectionResult.devScript || null;
+  // Keep empty string if no dev script found (don't convert to null which would trigger preset fallback)
+  let initialMaintenanceScript: string | null = detectionResult.maintenanceScript;
+  let initialDevScript: string | null = detectionResult.devScript;
 
   if (environmentId) {
     try {

--- a/apps/www/components/preview/framework-preset-select.tsx
+++ b/apps/www/components/preview/framework-preset-select.tsx
@@ -20,6 +20,7 @@ import {
   ViteLogo,
   VueLogo,
 } from "@/components/icons/framework-logos";
+import type { PackageManager } from "@/lib/github/framework-detection";
 
 export type FrameworkPreset =
   | "other"
@@ -50,63 +51,86 @@ type FrameworkPresetConfig = {
   icon: FrameworkIconKey;
 };
 
-export const FRAMEWORK_PRESETS: Record<FrameworkPreset, FrameworkPresetConfig> =
-  {
-    other: {
-      name: "Other",
+// Script templates use "start" for frameworks that traditionally use npm start
+type FrameworkScriptTemplate = {
+  name: string;
+  devScriptName: "dev" | "start";
+  icon: FrameworkIconKey;
+};
+
+const FRAMEWORK_SCRIPT_TEMPLATES: Record<FrameworkPreset, FrameworkScriptTemplate> = {
+  other: { name: "Other", devScriptName: "dev", icon: "other" },
+  next: { name: "Next.js", devScriptName: "dev", icon: "next" },
+  vite: { name: "Vite", devScriptName: "dev", icon: "vite" },
+  remix: { name: "Remix", devScriptName: "dev", icon: "remix" },
+  nuxt: { name: "Nuxt", devScriptName: "dev", icon: "nuxt" },
+  sveltekit: { name: "SvelteKit", devScriptName: "dev", icon: "svelte" },
+  angular: { name: "Angular", devScriptName: "start", icon: "angular" },
+  cra: { name: "Create React App", devScriptName: "start", icon: "react" },
+  vue: { name: "Vue", devScriptName: "dev", icon: "vue" },
+};
+
+function getInstallCommand(pm: PackageManager): string {
+  switch (pm) {
+    case "bun":
+      return "bun install";
+    case "pnpm":
+      return "pnpm install";
+    case "yarn":
+      return "yarn install";
+    case "npm":
+    default:
+      return "npm install";
+  }
+}
+
+function getRunCommand(pm: PackageManager, scriptName: string): string {
+  switch (pm) {
+    case "bun":
+      return `bun run ${scriptName}`;
+    case "pnpm":
+      return `pnpm run ${scriptName}`;
+    case "yarn":
+      return `yarn ${scriptName}`;
+    case "npm":
+    default:
+      return `npm run ${scriptName}`;
+  }
+}
+
+export function getFrameworkPresetConfig(
+  preset: FrameworkPreset,
+  packageManager: PackageManager = "npm"
+): FrameworkPresetConfig {
+  const template = FRAMEWORK_SCRIPT_TEMPLATES[preset];
+  if (preset === "other") {
+    return {
+      name: template.name,
       maintenanceScript: "",
       devScript: "",
-      icon: "other",
-    },
-    next: {
-      name: "Next.js",
-      maintenanceScript: "npm install",
-      devScript: "npm run dev",
-      icon: "next",
-    },
-    vite: {
-      name: "Vite",
-      maintenanceScript: "npm install",
-      devScript: "npm run dev",
-      icon: "vite",
-    },
-    remix: {
-      name: "Remix",
-      maintenanceScript: "npm install",
-      devScript: "npm run dev",
-      icon: "remix",
-    },
-    nuxt: {
-      name: "Nuxt",
-      maintenanceScript: "npm install",
-      devScript: "npm run dev",
-      icon: "nuxt",
-    },
-    sveltekit: {
-      name: "SvelteKit",
-      maintenanceScript: "npm install",
-      devScript: "npm run dev",
-      icon: "svelte",
-    },
-    angular: {
-      name: "Angular",
-      maintenanceScript: "npm install",
-      devScript: "npm start",
-      icon: "angular",
-    },
-    cra: {
-      name: "Create React App",
-      maintenanceScript: "npm install",
-      devScript: "npm start",
-      icon: "react",
-    },
-    vue: {
-      name: "Vue",
-      maintenanceScript: "npm install",
-      devScript: "npm run dev",
-      icon: "vue",
-    },
+      icon: template.icon,
+    };
+  }
+  return {
+    name: template.name,
+    maintenanceScript: getInstallCommand(packageManager),
+    devScript: getRunCommand(packageManager, template.devScriptName),
+    icon: template.icon,
   };
+}
+
+// Default presets using npm for backward compatibility
+export const FRAMEWORK_PRESETS: Record<FrameworkPreset, FrameworkPresetConfig> = {
+  other: getFrameworkPresetConfig("other", "npm"),
+  next: getFrameworkPresetConfig("next", "npm"),
+  vite: getFrameworkPresetConfig("vite", "npm"),
+  remix: getFrameworkPresetConfig("remix", "npm"),
+  nuxt: getFrameworkPresetConfig("nuxt", "npm"),
+  sveltekit: getFrameworkPresetConfig("sveltekit", "npm"),
+  angular: getFrameworkPresetConfig("angular", "npm"),
+  cra: getFrameworkPresetConfig("cra", "npm"),
+  vue: getFrameworkPresetConfig("vue", "npm"),
+};
 
 const FRAMEWORK_ICON_META: Record<
   FrameworkIconKey,

--- a/apps/www/components/preview/framework-preset-select.tsx
+++ b/apps/www/components/preview/framework-preset-select.tsx
@@ -287,9 +287,6 @@ const SelectItem = forwardRef<
         <div className="font-medium text-neutral-900 dark:text-neutral-100">
           {config.name}
         </div>
-        <div className="text-xs text-neutral-500 dark:text-neutral-400">
-          Default: {config.devScript || "Custom"}
-        </div>
       </div>
       <SelectPrimitive.ItemIndicator className="absolute right-3">
         <Check className="h-4 w-4 text-neutral-900 dark:text-neutral-100" />

--- a/apps/www/components/preview/preview-configure-client.tsx
+++ b/apps/www/components/preview/preview-configure-client.tsx
@@ -25,9 +25,10 @@ import { formatEnvVarsContent } from "@cmux/shared/utils/format-env-vars-content
 import clsx from "clsx";
 import {
   FrameworkPresetSelect,
-  FRAMEWORK_PRESETS,
+  getFrameworkPresetConfig,
   type FrameworkPreset,
 } from "./framework-preset-select";
+import type { PackageManager } from "@/lib/github/framework-detection";
 
 const MASKED_ENV_VALUE = "••••••••••••••••";
 
@@ -59,6 +60,7 @@ type PreviewConfigureClientProps = {
   repo: string;
   installationId: string | null;
   initialFrameworkPreset?: FrameworkPreset;
+  initialPackageManager?: PackageManager;
   initialEnvVarsContent?: string | null;
   initialMaintenanceScript?: string | null;
   initialDevScript?: string | null;
@@ -364,6 +366,7 @@ export function PreviewConfigureClient({
   repo,
   installationId: _installationId,
   initialFrameworkPreset = "other",
+  initialPackageManager = "npm",
   initialEnvVarsContent,
   initialMaintenanceScript,
   initialDevScript,
@@ -389,8 +392,10 @@ export function PreviewConfigureClient({
       initialEnvVars.some((r) => r.name.trim().length > 0 || r.value.trim().length > 0),
     [initialEnvPrefilled, initialEnvVars]
   );
-  const initialFrameworkConfig =
-    FRAMEWORK_PRESETS[initialFrameworkPreset] ?? FRAMEWORK_PRESETS.other;
+  const initialFrameworkConfig = getFrameworkPresetConfig(
+    initialFrameworkPreset,
+    initialPackageManager
+  );
   const initialMaintenanceScriptValue =
     initialMaintenanceScript ?? initialFrameworkConfig.maintenanceScript;
   const initialDevScriptValue =
@@ -734,7 +739,7 @@ export function PreviewConfigureClient({
       setFrameworkPreset(preset);
       // Only auto-fill if user hasn't manually edited the scripts
       if (!hasUserEditedScripts) {
-        const presetConfig = FRAMEWORK_PRESETS[preset];
+        const presetConfig = getFrameworkPresetConfig(preset, initialPackageManager);
         setMaintenanceScript(presetConfig.maintenanceScript);
         setDevScript(presetConfig.devScript);
         // Update none states based on whether the preset has scripts
@@ -742,7 +747,7 @@ export function PreviewConfigureClient({
         setDevNone(presetConfig.devScript.trim().length === 0);
       }
     },
-    [hasUserEditedScripts]
+    [hasUserEditedScripts, initialPackageManager]
   );
 
   const handleMaintenanceScriptChange = useCallback((value: string) => {

--- a/apps/www/lib/github/framework-detection.test.ts
+++ b/apps/www/lib/github/framework-detection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { detectFrameworkAndPackageManager } from "./framework-detection";
+
+// These tests make real GitHub API calls.
+// Without authentication, we're limited to 60 requests/hour.
+// Set GITHUB_TOKEN env var for higher rate limits.
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+describe("detectFrameworkAndPackageManager", () => {
+  it("detects stack-auth/stack-auth as pnpm with dev script", async () => {
+    const result = await detectFrameworkAndPackageManager("stack-auth/stack-auth", GITHUB_TOKEN);
+
+    expect(result.packageManager).toBe("pnpm");
+    expect(result.maintenanceScript).toBe("pnpm install");
+    expect(result.devScript).toBe("pnpm run dev");
+  }, 30000);
+
+  it("detects manaflow-ai/cmux as bun (no dev script in package.json)", async () => {
+    const result = await detectFrameworkAndPackageManager("manaflow-ai/cmux", GITHUB_TOKEN);
+
+    expect(result.packageManager).toBe("bun");
+    expect(result.maintenanceScript).toBe("bun install");
+    // cmux uses ./scripts/dev.sh, not a package.json script
+    expect(result.devScript).toBe("");
+  }, 30000);
+
+  it("detects calcom/cal.com as yarn with dev script", async () => {
+    const result = await detectFrameworkAndPackageManager("calcom/cal.com", GITHUB_TOKEN);
+
+    expect(result.packageManager).toBe("yarn");
+    expect(result.maintenanceScript).toBe("yarn install");
+    expect(result.devScript).toBe("yarn dev");
+  }, 30000);
+});

--- a/apps/www/lib/github/framework-detection.test.ts
+++ b/apps/www/lib/github/framework-detection.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { detectFrameworkAndPackageManager } from "./framework-detection";
 
-// These tests make real GitHub API calls.
-// Without authentication, we're limited to 60 requests/hour.
-// Set GITHUB_TOKEN env var for higher rate limits.
+// These tests make real GitHub API calls and require authentication.
+// They are skipped in CI unless GITHUB_TOKEN is provided.
+// Run locally with: GITHUB_TOKEN=$(gh auth token) bun test framework-detection
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const shouldSkip = !GITHUB_TOKEN;
 
-describe("detectFrameworkAndPackageManager", () => {
+describe.skipIf(shouldSkip)("detectFrameworkAndPackageManager", () => {
   it("detects stack-auth/stack-auth as pnpm with dev script", async () => {
     const result = await detectFrameworkAndPackageManager("stack-auth/stack-auth", GITHUB_TOKEN);
 


### PR DESCRIPTION
## Summary
- Detect package manager from lock files (bun.lockb, pnpm-lock.yaml, yarn.lock, package-lock.json)
- Verify dev scripts actually exist in package.json before suggesting them (checks for `dev`, `start`, `serve`, `develop`)
- Return detected `maintenanceScript` and `devScript` directly from detection API
- Parallelize package.json fetches for better performance

## API Request Optimization
**Before:** Sequential fetches, worst case ~41 requests
**After:** Parallel fetches, typically 2-5 requests

- Package.json fetches now run in parallel via `Promise.all`
- Lock file detection uses tree snapshot (0 extra API requests)
- File existence checks use tree snapshot

## Test plan
Added tests for real repos:
- `stack-auth/stack-auth` → pnpm, `pnpm run dev` ✓
- `manaflow-ai/cmux` → bun, `bun install`, no dev script ✓
- `calcom/cal.com` → yarn, `yarn dev` ✓

Run with: `GITHUB_TOKEN=$(gh auth token) bun test apps/www/lib/github/framework-detection.test.ts`