### PR TITLE
feat: allow team members to view each other's tasks/runs

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
@@ -126,8 +126,17 @@ function TaskDetailPage() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [flatRuns, taskId, navigate, teamSlugOrId]);
 
-  if (!task || !taskRuns) {
+  // Distinguish between loading (undefined) and not found (null)
+  if (task === undefined || taskRuns === undefined) {
     return <div className="p-8">Loading...</div>;
+  }
+
+  if (task === null) {
+    return (
+      <div className="p-8 text-neutral-500 dark:text-neutral-400">
+        Task not found or you don't have access to it.
+      </div>
+    );
   }
 
   return (

--- a/packages/convex/_shared/team.ts
+++ b/packages/convex/_shared/team.ts
@@ -11,52 +11,47 @@ type AnyCtx = QueryCtx | MutationCtx;
 
 // Resolve a teamSlugOrId to a canonical team UUID string.
 // Falls back to the input if no team is found (for backwards compatibility).
+// Always enforces team membership when an authenticated user is present.
 export async function getTeamId(
   ctx: AnyCtx,
   teamSlugOrId: string
 ): Promise<string> {
-  if (isUuid(teamSlugOrId)) {
-    return teamSlugOrId;
-  }
+  const identity = await ctx.auth.getUserIdentity();
+  const userId = identity?.subject;
 
-  const [team, identity] = await Promise.all([
-    ctx.db
+  let teamId: string;
+
+  if (isUuid(teamSlugOrId)) {
+    // UUID provided directly - use as-is but still enforce membership below
+    teamId = teamSlugOrId;
+  } else {
+    // Slug provided - resolve to teamId
+    const team = await ctx.db
       .query("teams")
       .withIndex("by_slug", (q) => q.eq("slug", teamSlugOrId))
-      .first(),
-    ctx.auth.getUserIdentity(),
-  ]);
-  const userId = identity?.subject;
-  if (team) {
-    const teamId = team.teamId;
-    if (userId) {
-      const membership = await ctx.db
-        .query("teamMemberships")
-        .withIndex("by_team_user", (q) =>
-          q.eq("teamId", teamId).eq("userId", userId)
-        )
-        .first();
-      if (!membership) {
-        throw new Error("Forbidden: Not a member of this team");
-      }
+      .first();
+    if (team) {
+      teamId = team.teamId;
+    } else {
+      // Back-compat: allow legacy string teamIds (e.g., "default")
+      teamId = teamSlugOrId;
     }
-    return team.teamId;
   }
 
-  // Back-compat: allow legacy string teamIds (e.g., "default").
-  // When identity is available, ensure membership if such a team exists in memberships.
+  // Always enforce membership when user is authenticated
   if (userId) {
     const membership = await ctx.db
       .query("teamMemberships")
       .withIndex("by_team_user", (q) =>
-        q.eq("teamId", teamSlugOrId).eq("userId", userId)
+        q.eq("teamId", teamId).eq("userId", userId)
       )
       .first();
     if (!membership) {
       throw new Error("Forbidden: Not a member of this team");
     }
   }
-  return teamSlugOrId;
+
+  return teamId;
 }
 
 // Resolve a teamSlugOrId to a team UUID without enforcing membership.

--- a/packages/convex/convex/crown.ts
+++ b/packages/convex/convex/crown.ts
@@ -193,13 +193,11 @@ export const getCrownedRun = authQuery({
     taskId: v.id("tasks"),
   },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const crownedRun = await ctx.db
       .query("taskRuns")
       .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
       .filter((q) => q.eq(q.field("teamId"), teamId))
-      .filter((q) => q.eq(q.field("userId"), userId))
       .filter((q) => q.eq(q.field("isCrowned"), true))
       .first();
 
@@ -222,13 +220,11 @@ export const getCrownEvaluation = authQuery({
       return null;
     }
 
-    const userId = ctx.identity.subject;
     const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const evaluation = await ctx.db
       .query("crownEvaluations")
       .withIndex("by_task", (q) => q.eq("taskId", args.taskId as Id<"tasks">))
       .filter((q) => q.eq(q.field("teamId"), teamId))
-      .filter((q) => q.eq(q.field("userId"), userId))
       .first();
 
     return evaluation;

--- a/packages/convex/convex/previewConfigs.ts
+++ b/packages/convex/convex/previewConfigs.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { resolveTeamIdLoose } from "../_shared/team";
+import { getTeamId } from "../_shared/team";
 import { authMutation, authQuery } from "./users/utils";
 import { internalQuery } from "./_generated/server";
 
@@ -16,7 +16,7 @@ export const listByTeam = authQuery({
     teamSlugOrId: v.string(),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const configs = await ctx.db
       .query("previewConfigs")
       .withIndex("by_team", (q) => q.eq("teamId", teamId))
@@ -32,7 +32,7 @@ export const get = authQuery({
     previewConfigId: v.id("previewConfigs"),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const config = await ctx.db.get(args.previewConfigId);
     if (!config || config.teamId !== teamId) {
       return null;
@@ -47,7 +47,7 @@ export const getByRepo = authQuery({
     repoFullName: v.string(),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const repoFullName = normalizeRepoFullName(args.repoFullName);
     const config = await ctx.db
       .query("previewConfigs")
@@ -65,7 +65,7 @@ export const remove = authMutation({
     previewConfigId: v.id("previewConfigs"),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const config = await ctx.db.get(args.previewConfigId);
     if (!config || config.teamId !== teamId) {
       throw new Error("Preview config not found");
@@ -95,7 +95,7 @@ export const upsert = authMutation({
     if (!userId) {
       throw new Error("Authentication required");
     }
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const repoFullName = normalizeRepoFullName(args.repoFullName);
     const now = Date.now();
 

--- a/packages/convex/convex/previewRuns.ts
+++ b/packages/convex/convex/previewRuns.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { resolveTeamIdLoose } from "../_shared/team";
+import { getTeamId } from "../_shared/team";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { authMutation, authQuery } from "./users/utils";
@@ -416,7 +416,7 @@ export const listByConfig = authQuery({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const config = await ctx.db.get(args.previewConfigId);
     if (!config || config.teamId !== teamId) {
       throw new Error("Preview configuration not found");
@@ -440,7 +440,7 @@ export const listByTeam = authQuery({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const take = Math.max(1, Math.min(args.limit ?? 50, 100));
     const runs = await ctx.db
       .query("previewRuns")
@@ -508,7 +508,7 @@ export const createManual = authMutation({
     headRef: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const repoFullName = normalizeRepoFullName(args.repoFullName);
 
     // Find the preview config for this repo

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -164,7 +164,8 @@ const convexSchema = defineSchema({
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
     .index("by_pinned", ["pinned", "teamId", "userId"])
-    .index("by_team_user_preview", ["teamId", "userId", "isPreview"]),
+    .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
+    .index("by_team_preview", ["teamId", "isPreview"]),
 
   taskRuns: defineTable({
     taskId: v.id("tasks"),

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -206,16 +206,13 @@ async function collectRunSubtreeIds(
 async function fetchTaskRunsForTask(
   ctx: QueryCtx,
   teamId: string,
-  userId: string,
   taskId: Id<"tasks">,
   includeArchived = true,
 ): Promise<TaskRunWithChildren[]> {
   const runs = await ctx.db
     .query("taskRuns")
     .withIndex("by_task", (q) => q.eq("taskId", taskId))
-    .filter(
-      (q) => q.eq(q.field("teamId"), teamId) && q.eq(q.field("userId"), userId),
-    )
+    .filter((q) => q.eq(q.field("teamId"), teamId))
     .collect();
 
   const environmentSummaries = new Map<
@@ -372,24 +369,19 @@ export const getByTask = authQuery({
       return [];
     }
 
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     return await fetchTaskRunsForTask(
       ctx,
       teamId,
-      userId,
       args.taskId as Id<"tasks">,
       args.includeArchived ?? true,
     );
   },
 });
 
-const SYSTEM_BRANCH_USER_ID = "__system__";
-
 async function fetchBranchMetadataForRepo(
   ctx: QueryCtx,
   teamId: string,
-  userId: string,
   repo: string,
 ): Promise<Doc<"branches">[]> {
   const rows = await ctx.db
@@ -398,12 +390,9 @@ async function fetchBranchMetadataForRepo(
     .filter((q) => q.eq(q.field("teamId"), teamId))
     .collect();
 
-  const relevant = rows.filter(
-    (row) => row.userId === userId || row.userId === SYSTEM_BRANCH_USER_ID,
-  );
-
+  // Deduplicate by branch name, preferring rows with known SHA info or recent activity
   const byName = new Map<string, Doc<"branches">>();
-  for (const row of relevant) {
+  for (const row of rows) {
     const existing = byName.get(row.name);
     if (!existing) {
       byName.set(row.name, row);
@@ -478,15 +467,14 @@ export const getRunDiffContext = authQuery({
     runId: v.id("taskRuns"),
   },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
     const [taskDoc, taskRuns] = await Promise.all([
       ctx.db.get(args.taskId),
-      fetchTaskRunsForTask(ctx, teamId, userId, args.taskId, true),
+      fetchTaskRunsForTask(ctx, teamId, args.taskId, true),
     ]);
 
-    if (!taskDoc || taskDoc.teamId !== teamId || taskDoc.userId !== userId) {
+    if (!taskDoc || taskDoc.teamId !== teamId) {
       return {
         task: null,
         taskRuns,
@@ -520,7 +508,6 @@ export const getRunDiffContext = authQuery({
         const metadata = await fetchBranchMetadataForRepo(
           ctx,
           teamId,
-          userId,
           trimmedProjectFullName,
         );
         if (metadata.length > 0) {
@@ -604,10 +591,9 @@ export const updateSummary = authMutation({
 export const get = authQuery({
   args: { teamSlugOrId: v.string(), id: v.id("taskRuns") },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     const doc = await ctx.db.get(args.id);
-    if (!doc || doc.teamId !== teamId || doc.userId !== userId) {
+    if (!doc || doc.teamId !== teamId) {
       return null;
     }
     // Rewrite morph URLs in networking field
@@ -898,7 +884,6 @@ export const updateVSCodePorts = authMutation({
 export const getByContainerName = authQuery({
   args: { teamSlugOrId: v.string(), containerName: v.string() },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     const run =
       (await ctx.db
@@ -907,7 +892,6 @@ export const getByContainerName = authQuery({
           q.eq("vscode.containerName", args.containerName),
         )
         .filter((q) => q.eq(q.field("teamId"), teamId))
-        .filter((q) => q.eq(q.field("userId"), userId))
         .first()) ?? null;
 
     if (!run) {

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { SignJWT } from "jose";
 import { env } from "../_shared/convex-env";
-import { resolveTeamIdLoose } from "../_shared/team";
+import { getTeamId, resolveTeamIdLoose } from "../_shared/team";
 import type { Doc, Id } from "./_generated/dataModel";
 import {
   internalMutation,
@@ -369,7 +369,7 @@ export const getByTask = authQuery({
       return [];
     }
 
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     return await fetchTaskRunsForTask(
       ctx,
       teamId,
@@ -467,7 +467,7 @@ export const getRunDiffContext = authQuery({
     runId: v.id("taskRuns"),
   },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
 
     const [taskDoc, taskRuns] = await Promise.all([
       ctx.db.get(args.taskId),
@@ -591,7 +591,7 @@ export const updateSummary = authMutation({
 export const get = authQuery({
   args: { teamSlugOrId: v.string(), id: v.id("taskRuns") },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const doc = await ctx.db.get(args.id);
     if (!doc || doc.teamId !== teamId) {
       return null;
@@ -884,7 +884,7 @@ export const updateVSCodePorts = authMutation({
 export const getByContainerName = authQuery({
   args: { teamSlugOrId: v.string(), containerName: v.string() },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const run =
       (await ctx.db
         .query("taskRuns")

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -47,15 +47,14 @@ export const getPreviewTasks = authQuery({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const take = Math.max(1, Math.min(args.limit ?? 50, 100));
 
-    // Get preview tasks using the dedicated index
+    // Get preview tasks using the dedicated index (team-wide, not user-specific)
     const tasks = await ctx.db
       .query("tasks")
-      .withIndex("by_team_user_preview", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId).eq("isPreview", true),
+      .withIndex("by_team_preview", (idx) =>
+        idx.eq("teamId", teamId).eq("isPreview", true),
       )
       .filter((q) => q.neq(q.field("isArchived"), true))
       .collect();

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -301,10 +301,9 @@ export const getById = authQuery({
       return null;
     }
 
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     const task = await ctx.db.get(args.id as Id<"tasks">);
-    if (!task || task.teamId !== teamId || task.userId !== userId) return null;
+    if (!task || task.teamId !== teamId) return null;
 
     if (task.images && task.images.length > 0) {
       const imagesWithUrls = await Promise.all(
@@ -329,13 +328,11 @@ export const getById = authQuery({
 export const getVersions = authQuery({
   args: { teamSlugOrId: v.string(), taskId: v.id("tasks") },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     return await ctx.db
       .query("taskVersions")
       .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
       .filter((q) => q.eq(q.field("teamId"), teamId))
-      .filter((q) => q.eq(q.field("userId"), userId))
       .collect();
   },
 });

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { resolveTeamIdLoose } from "../_shared/team";
+import { getTeamId, resolveTeamIdLoose } from "../_shared/team";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { internalMutation, internalQuery } from "./_generated/server";
@@ -301,7 +301,7 @@ export const getById = authQuery({
       return null;
     }
 
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     const task = await ctx.db.get(args.id as Id<"tasks">);
     if (!task || task.teamId !== teamId) return null;
 
@@ -328,7 +328,7 @@ export const getById = authQuery({
 export const getVersions = authQuery({
   args: { teamSlugOrId: v.string(), taskId: v.id("tasks") },
   handler: async (ctx, args) => {
-    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
     return await ctx.db
       .query("taskVersions")
       .withIndex("by_task", (q) => q.eq("taskId", args.taskId))


### PR DESCRIPTION
## Summary
- Single-item getters for tasks and taskRuns now filter by teamId only instead of teamId + userId
- This allows team members to view each other's tasks when navigating via GitHub comment links (cmux preview.new)
- List queries (main Tasks view) still filter by userId to show only the user's own tasks by default

## Queries updated
- `tasks.getById`
- `tasks.getVersions`
- `taskRuns.get`
- `taskRuns.getByTask`
- `taskRuns.getRunDiffContext`
- `taskRuns.getByContainerName`
- `crown.getCrownedRun`
- `crown.getCrownEvaluation`

## Test plan
- [ ] Verify main Tasks view still only shows user's own tasks
- [ ] Verify navigating to another team member's task/run via direct URL works
- [ ] Verify sidebar shows task details when viewing another user's task