### PR TITLE
Route anthropic proxy via Cloudflare gateway

### DIFF
--- a/apps/www/app/api/anthropic/v1/messages/route.ts
+++ b/apps/www/app/api/anthropic/v1/messages/route.ts
@@ -2,7 +2,8 @@ import { verifyTaskRunToken, type TaskRunTokenPayload } from "@cmux/shared";
 import { env } from "@/lib/utils/www-env";
 import { NextRequest, NextResponse } from "next/server";
 
-const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_URL =
+  "https://gateway.ai.cloudflare.com/v1/0c1675e0def6de1ab3a50a4e17dc5656/cmux-ai-proxy/anthropic/v1/messages";
 const TEMPORARY_DISABLE_AUTH = true;
 
 const hardCodedApiKey = "sk_placeholder_cmux_anthropic_api_key";


### PR DESCRIPTION
Help me make the apps/www anthropic proxy go through the cloudflare gateway.Here's the anthropic base url: https://gateway.ai.cloudflare.com/v1/0c1675e0def6de1ab3a50a4e17dc5656/cmux-ai-proxy/anthropic