### PR TITLE
Collapse duplicate previews, surface latest in PR UI

### DIFF
--- a/apps/client/src/components/dashboard/TaskList.tsx
+++ b/apps/client/src/components/dashboard/TaskList.tsx
@@ -116,6 +116,16 @@ type PreviewRunWithConfig = Doc<"previewRuns"> & {
   taskId?: Id<"tasks">;
 };
 
+// Preview run grouped by PR
+type PreviewRunGroup = {
+  key: string; // "repoFullName#prNumber"
+  repoFullName: string;
+  prNumber: number;
+  prUrl: string;
+  latestRun: PreviewRunWithConfig;
+  olderRuns: PreviewRunWithConfig[];
+};
+
 type PreviewCategoryKey = "in_progress" | "completed";
 
 const PREVIEW_CATEGORY_ORDER: PreviewCategoryKey[] = ["in_progress", "completed"];
@@ -136,7 +146,7 @@ const PREVIEW_CATEGORY_META: Record<
 
 const createEmptyPreviewCategoryBuckets = (): Record<
   PreviewCategoryKey,
-  PreviewRunWithConfig[]
+  PreviewRunGroup[]
 > => ({
   in_progress: [],
   completed: [],
@@ -154,20 +164,61 @@ const getPreviewCategory = (run: PreviewRunWithConfig): PreviewCategoryKey | nul
   return null;
 };
 
+// Group preview runs by PR, with the most recent run as the "latestRun"
+const groupPreviewRunsByPr = (
+  runs: PreviewRunWithConfig[]
+): Map<string, PreviewRunGroup> => {
+  const groups = new Map<string, PreviewRunGroup>();
+
+  // Runs are already sorted by createdAt desc from the API
+  for (const run of runs) {
+    const key = `${run.repoFullName}#${run.prNumber}`;
+    const existing = groups.get(key);
+
+    if (!existing) {
+      groups.set(key, {
+        key,
+        repoFullName: run.repoFullName,
+        prNumber: run.prNumber,
+        prUrl: run.prUrl,
+        latestRun: run,
+        olderRuns: [],
+      });
+    } else {
+      existing.olderRuns.push(run);
+    }
+  }
+
+  return groups;
+};
+
 const categorizePreviewRuns = (
   runs: PreviewRunWithConfig[] | undefined
-): Record<PreviewCategoryKey, PreviewRunWithConfig[]> | null => {
+): Record<PreviewCategoryKey, PreviewRunGroup[]> | null => {
   if (!runs) {
     return null;
   }
+
+  // First group all runs by PR
+  const groups = groupPreviewRunsByPr(runs);
+
+  // Then categorize groups by the status of the latest run
   const buckets = createEmptyPreviewCategoryBuckets();
-  for (const run of runs) {
-    const key = getPreviewCategory(run);
-    // Skip runs that don't belong to any category (e.g., failed runs)
+  for (const group of groups.values()) {
+    const key = getPreviewCategory(group.latestRun);
+    // Skip groups where the latest run doesn't belong to any category (e.g., failed runs)
     if (key !== null) {
-      buckets[key].push(run);
+      buckets[key].push(group);
     }
   }
+
+  // Sort groups by the latest run's createdAt
+  for (const key of PREVIEW_CATEGORY_ORDER) {
+    buckets[key].sort((a, b) =>
+      (b.latestRun.createdAt ?? 0) - (a.latestRun.createdAt ?? 0)
+    );
+  }
+
   return buckets;
 };
 
@@ -263,6 +314,16 @@ export const TaskList = memo(function TaskList({
     }));
   }, [setCollapsedPreviewCategories]);
 
+  // State for expanded preview groups (PRs with older runs)
+  const [expandedPreviewGroups, setExpandedPreviewGroups] = useState<Record<string, boolean>>({});
+
+  const togglePreviewGroup = useCallback((groupKey: string) => {
+    setExpandedPreviewGroups((prev) => ({
+      ...prev,
+      [groupKey]: !prev[groupKey],
+    }));
+  }, []);
+
   return (
     <div className="mt-6 w-full">
       <div className="mb-3 px-4">
@@ -339,10 +400,12 @@ export const TaskList = memo(function TaskList({
                 <PreviewCategorySection
                   key={categoryKey}
                   categoryKey={categoryKey}
-                  previewRuns={previewCategoryBuckets[categoryKey]}
+                  previewGroups={previewCategoryBuckets[categoryKey]}
                   teamSlugOrId={teamSlugOrId}
                   collapsed={Boolean(collapsedPreviewCategories[categoryKey])}
                   onToggle={togglePreviewCategoryCollapse}
+                  expandedGroups={expandedPreviewGroups}
+                  onToggleGroup={togglePreviewGroup}
                 />
               ))}
             </div>
@@ -448,16 +511,20 @@ function TaskCategorySection({
 
 function PreviewCategorySection({
   categoryKey,
-  previewRuns,
+  previewGroups,
   teamSlugOrId,
   collapsed,
   onToggle,
+  expandedGroups,
+  onToggleGroup,
 }: {
   categoryKey: PreviewCategoryKey;
-  previewRuns: PreviewRunWithConfig[];
+  previewGroups: PreviewRunGroup[];
   teamSlugOrId: string;
   collapsed: boolean;
   onToggle: (key: PreviewCategoryKey) => void;
+  expandedGroups: Record<string, boolean>;
+  onToggleGroup: (groupKey: string) => void;
 }) {
   const meta = PREVIEW_CATEGORY_META[categoryKey];
   const handleToggle = useCallback(
@@ -468,6 +535,10 @@ function PreviewCategorySection({
   const toggleLabel = collapsed
     ? `Expand ${meta.title}`
     : `Collapse ${meta.title}`;
+
+  // Count total PRs (groups)
+  const groupCount = previewGroups.length;
+
   return (
     <div className="w-full">
       <div
@@ -494,15 +565,21 @@ function PreviewCategorySection({
           <div className="flex items-center gap-2 text-xs font-medium tracking-tight text-neutral-900 dark:text-neutral-100">
             <span>{meta.title}</span>
             <span className="text-xs text-neutral-500 dark:text-neutral-400">
-              {previewRuns.length}
+              {groupCount}
             </span>
           </div>
         </div>
       </div>
-      {collapsed ? null : previewRuns.length > 0 ? (
+      {collapsed ? null : groupCount > 0 ? (
         <div id={contentId} className="flex flex-col w-full">
-          {previewRuns.map((run) => (
-            <PreviewItem key={run._id} previewRun={run} teamSlugOrId={teamSlugOrId} />
+          {previewGroups.map((group) => (
+            <PreviewGroupItem
+              key={group.key}
+              group={group}
+              teamSlugOrId={teamSlugOrId}
+              isExpanded={expandedGroups[group.key] ?? false}
+              onToggle={() => onToggleGroup(group.key)}
+            />
           ))}
         </div>
       ) : (
@@ -510,6 +587,72 @@ function PreviewCategorySection({
           <p className="pl-5 text-xs text-neutral-500 dark:text-neutral-400 select-none">
             {meta.emptyLabel}
           </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Component for displaying a preview group (PR) with expandable older runs
+function PreviewGroupItem({
+  group,
+  teamSlugOrId,
+  isExpanded,
+  onToggle,
+}: {
+  group: PreviewRunGroup;
+  teamSlugOrId: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const hasOlderRuns = group.olderRuns.length > 0;
+
+  return (
+    <div className="w-full">
+      {/* Latest run - always visible */}
+      <div className="relative">
+        <PreviewItem
+          previewRun={group.latestRun}
+          teamSlugOrId={teamSlugOrId}
+        />
+        {/* Expand/collapse button for older runs */}
+        {hasOlderRuns && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onToggle();
+            }}
+            className="absolute left-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-5 h-5 rounded hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60 transition-colors"
+            aria-label={isExpanded ? "Collapse previous runs" : `Show ${group.olderRuns.length} previous run${group.olderRuns.length === 1 ? "" : "s"}`}
+            aria-expanded={isExpanded}
+          >
+            <ChevronRight
+              className={clsx(
+                "h-3 w-3 text-neutral-400 dark:text-neutral-500 transition-transform duration-200",
+                isExpanded && "rotate-90"
+              )}
+              aria-hidden="true"
+            />
+          </button>
+        )}
+      </div>
+
+      {/* Older runs - collapsible */}
+      {hasOlderRuns && isExpanded && (
+        <div className="relative pl-6 border-l-2 border-neutral-200 dark:border-neutral-700 ml-3">
+          <div className="absolute -left-[7px] top-0 text-[9px] text-neutral-400 dark:text-neutral-500 bg-white dark:bg-neutral-900 px-0.5 select-none">
+            {group.olderRuns.length} older
+          </div>
+          {group.olderRuns.map((run) => (
+            <div key={run._id} className="opacity-60 hover:opacity-100 transition-opacity">
+              <PreviewItem
+                previewRun={run}
+                teamSlugOrId={teamSlugOrId}
+              />
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/apps/client/src/components/sidebar/SidebarPullRequestList.tsx
+++ b/apps/client/src/components/sidebar/SidebarPullRequestList.tsx
@@ -2,16 +2,29 @@ import { GitHubIcon } from "@/components/icons/github";
 import { api } from "@cmux/convex/api";
 import { Link } from "@tanstack/react-router";
 import { useQuery as useConvexQuery } from "convex/react";
+import clsx from "clsx";
 import {
+  Eye,
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
   GitPullRequestDraft,
+  Loader2,
 } from "lucide-react";
 import { useMemo, useState, type MouseEvent } from "react";
 import { SidebarListItem } from "./SidebarListItem";
 import { SIDEBAR_PRS_DEFAULT_LIMIT } from "./const";
-import type { Doc } from "@cmux/convex/dataModel";
+import type { Doc, Id } from "@cmux/convex/dataModel";
+
+type PreviewRunInfo = {
+  _id: string;
+  status: string;
+  createdAt: number;
+  completedAt?: number;
+  headRef?: string;
+  screenshotSetId?: string;
+  taskId?: string;
+};
 
 type Props = {
   teamSlugOrId: string;
@@ -31,6 +44,22 @@ export function SidebarPullRequestList({
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
   const list = useMemo(() => prs ?? [], [prs]);
+
+  // Build the list of PRs to query for preview runs
+  const prsToQuery = useMemo(
+    () =>
+      list.map((pr) => ({
+        repoFullName: pr.repoFullName,
+        prNumber: pr.number,
+      })),
+    [list]
+  );
+
+  // Fetch preview runs for all visible PRs
+  const previewRuns = useConvexQuery(
+    api.previewRuns.getMostRecentForPrs,
+    list.length > 0 ? { teamSlugOrId, prs: prsToQuery } : "skip"
+  );
 
   if (prs === undefined) {
     return (
@@ -54,15 +83,20 @@ export function SidebarPullRequestList({
 
   return (
     <ul className="flex flex-col gap-px">
-      {list.map((pr) => (
-        <PullRequestListItem
-          key={`${pr.repoFullName}#${pr.number}`}
-          pr={pr}
-          teamSlugOrId={teamSlugOrId}
-          expanded={expanded}
-          setExpanded={setExpanded}
-        />
-      ))}
+      {list.map((pr) => {
+        const key = `${pr.repoFullName}#${pr.number}`;
+        const previewRun = previewRuns?.[key];
+        return (
+          <PullRequestListItem
+            key={key}
+            pr={pr}
+            teamSlugOrId={teamSlugOrId}
+            expanded={expanded}
+            setExpanded={setExpanded}
+            previewRun={previewRun}
+          />
+        );
+      })}
     </ul>
   );
 }
@@ -72,9 +106,10 @@ type PullRequestListItemProps = {
   teamSlugOrId: string;
   expanded: Record<string, boolean>;
   setExpanded: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  previewRun?: PreviewRunInfo;
 };
 
-function PullRequestListItem({ pr, teamSlugOrId, expanded, setExpanded }: PullRequestListItemProps) {
+function PullRequestListItem({ pr, teamSlugOrId, expanded, setExpanded, previewRun }: PullRequestListItemProps) {
   const [owner = "", repo = ""] = pr.repoFullName?.split("/", 2) ?? ["", ""];
   const key = `${pr.repoFullName}#${pr.number}`;
   const isExpanded = expanded[key] ?? false;
@@ -105,6 +140,37 @@ function PullRequestListItem({ pr, teamSlugOrId, expanded, setExpanded }: PullRe
       ...prev,
       [key]: !isExpanded,
     }));
+  };
+
+  // Format preview status for display
+  const getPreviewStatusInfo = (run: PreviewRunInfo) => {
+    const isInProgress = run.status === "pending" || run.status === "running";
+    const isCompleted = run.status === "completed" || run.status === "skipped";
+    const isFailed = run.status === "failed";
+
+    const statusLabel = isInProgress
+      ? "Running"
+      : isCompleted
+        ? "Complete"
+        : isFailed
+          ? "Failed"
+          : run.status;
+
+    return { isInProgress, isCompleted, isFailed, statusLabel };
+  };
+
+  // Format time ago for preview run
+  const formatTimeAgo = (timestamp: number) => {
+    const now = Date.now();
+    const diff = now - timestamp;
+    const minutes = Math.floor(diff / 60000);
+    const hours = Math.floor(diff / 3600000);
+    const days = Math.floor(diff / 86400000);
+
+    if (minutes < 1) return "just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    return `${days}d ago`;
   };
 
   return (
@@ -144,29 +210,130 @@ function PullRequestListItem({ pr, teamSlugOrId, expanded, setExpanded }: PullRe
           meta={leadingIcon}
         />
       </Link>
-      {isExpanded && pr.htmlUrl ? (
+      {isExpanded ? (
         <div className="mt-px flex flex-col" role="group">
-          <a
-            href={pr.htmlUrl}
-            target="_blank"
-            rel="noreferrer"
-            onClick={(event) => {
-              event.stopPropagation();
-            }}
-            className="mt-px flex w-full items-center rounded-md pr-2 py-1 text-xs transition-colors hover:bg-neutral-200/45 dark:hover:bg-neutral-800/45"
-            style={{ paddingLeft: "32px" }}
-          >
-            <GitHubIcon
-              className="mr-2 h-3 w-3 text-neutral-400 grayscale opacity-60"
-              aria-hidden
+          {/* Preview run info */}
+          {previewRun && (
+            <PreviewRunLink
+              previewRun={previewRun}
+              teamSlugOrId={teamSlugOrId}
+              getStatusInfo={getPreviewStatusInfo}
+              formatTimeAgo={formatTimeAgo}
             />
-            <span className="text-neutral-600 dark:text-neutral-400">
-              GitHub
-            </span>
-          </a>
+          )}
+          {/* GitHub link */}
+          {pr.htmlUrl && (
+            <a
+              href={pr.htmlUrl}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+              className="mt-px flex w-full items-center rounded-md pr-2 py-1 text-xs transition-colors hover:bg-neutral-200/45 dark:hover:bg-neutral-800/45"
+              style={{ paddingLeft: "32px" }}
+            >
+              <GitHubIcon
+                className="mr-2 h-3 w-3 text-neutral-400 grayscale opacity-60"
+                aria-hidden
+              />
+              <span className="text-neutral-600 dark:text-neutral-400">
+                GitHub
+              </span>
+            </a>
+          )}
         </div>
       ) : null}
     </li>
+  );
+}
+
+// Component to render the preview run link under a PR
+function PreviewRunLink({
+  previewRun,
+  teamSlugOrId,
+  getStatusInfo,
+  formatTimeAgo,
+}: {
+  previewRun: PreviewRunInfo;
+  teamSlugOrId: string;
+  getStatusInfo: (run: PreviewRunInfo) => {
+    isInProgress: boolean;
+    isCompleted: boolean;
+    isFailed: boolean;
+    statusLabel: string;
+  };
+  formatTimeAgo: (timestamp: number) => string;
+}) {
+  const { isInProgress, isCompleted, isFailed, statusLabel } = getStatusInfo(previewRun);
+  const timestamp = previewRun.completedAt || previewRun.createdAt;
+
+  // Status indicator dot/spinner
+  const StatusIndicator = () => {
+    if (isInProgress) {
+      return (
+        <Loader2
+          className="mr-2 h-3 w-3 text-blue-500 animate-spin"
+          aria-hidden
+        />
+      );
+    }
+    return (
+      <div
+        className={clsx(
+          "mr-2 h-2 w-2 rounded-full flex-shrink-0",
+          isCompleted && "bg-green-500",
+          isFailed && "bg-red-500",
+          !isCompleted && !isFailed && "bg-neutral-400"
+        )}
+        aria-hidden
+      />
+    );
+  };
+
+  // If there's a taskId, make it a link to the task
+  if (previewRun.taskId) {
+    return (
+      <Link
+        to="/$teamSlugOrId/task/$taskId"
+        params={{
+          teamSlugOrId,
+          taskId: previewRun.taskId as Id<"tasks">,
+        }}
+        search={{ runId: undefined }}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        className="mt-px flex w-full items-center rounded-md pr-2 py-1 text-xs transition-colors hover:bg-neutral-200/45 dark:hover:bg-neutral-800/45"
+        style={{ paddingLeft: "32px" }}
+      >
+        <StatusIndicator />
+        <Eye className="mr-1.5 h-3 w-3 text-neutral-400 dark:text-neutral-500" aria-hidden />
+        <span className="text-neutral-600 dark:text-neutral-400 flex-1 min-w-0 truncate">
+          Preview
+        </span>
+        <span className="ml-1 text-neutral-400 dark:text-neutral-500 text-[10px]">
+          {statusLabel} {formatTimeAgo(timestamp)}
+        </span>
+      </Link>
+    );
+  }
+
+  // Without taskId, just show status (no link)
+  return (
+    <div
+      className="mt-px flex w-full items-center rounded-md pr-2 py-1 text-xs"
+      style={{ paddingLeft: "32px" }}
+    >
+      <StatusIndicator />
+      <Eye className="mr-1.5 h-3 w-3 text-neutral-400 dark:text-neutral-500" aria-hidden />
+      <span className="text-neutral-500 dark:text-neutral-500 flex-1 min-w-0 truncate">
+        Preview
+      </span>
+      <span className="ml-1 text-neutral-400 dark:text-neutral-500 text-[10px]">
+        {statusLabel} {formatTimeAgo(timestamp)}
+      </span>
+    </div>
   );
 }
 

--- a/packages/convex/convex/previewRuns.ts
+++ b/packages/convex/convex/previewRuns.ts
@@ -613,3 +613,151 @@ export const createManual = authMutation({
     return { previewRunId: runId, reused: false };
   },
 });
+
+/**
+ * Get the most recent preview run for a specific repo and PR number.
+ * Used by the sidebar to show preview status under each PR.
+ */
+export const getMostRecentByRepoPr = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    repoFullName: v.string(),
+    prNumber: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const repoFullName = normalizeRepoFullName(args.repoFullName);
+
+    // First find the preview config for this repo
+    const config = await ctx.db
+      .query("previewConfigs")
+      .withIndex("by_team_repo", (q) =>
+        q.eq("teamId", teamId).eq("repoFullName", repoFullName),
+      )
+      .first();
+
+    if (!config) {
+      return null;
+    }
+
+    // Get the most recent preview run for this config and PR
+    const run = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", config._id).eq("prNumber", args.prNumber),
+      )
+      .order("desc")
+      .first();
+
+    if (!run) {
+      return null;
+    }
+
+    // Get taskId if available
+    let taskId = undefined;
+    if (run.taskRunId) {
+      const taskRun = await ctx.db.get(run.taskRunId);
+      if (taskRun) {
+        taskId = taskRun.taskId;
+      }
+    }
+
+    return {
+      ...run,
+      taskId,
+    };
+  },
+});
+
+/**
+ * Get preview runs for multiple PRs at once (batch query for sidebar efficiency).
+ * Returns a map of "repoFullName#prNumber" -> most recent preview run.
+ */
+export const getMostRecentForPrs = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    prs: v.array(
+      v.object({
+        repoFullName: v.string(),
+        prNumber: v.number(),
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    // Group PRs by repo to minimize config lookups
+    const prsByRepo = new Map<string, number[]>();
+    for (const pr of args.prs) {
+      const repo = normalizeRepoFullName(pr.repoFullName);
+      const existing = prsByRepo.get(repo);
+      if (existing) {
+        existing.push(pr.prNumber);
+      } else {
+        prsByRepo.set(repo, [pr.prNumber]);
+      }
+    }
+
+    // Results map: "repoFullName#prNumber" -> preview run
+    const results: Record<
+      string,
+      {
+        _id: string;
+        status: string;
+        createdAt: number;
+        completedAt?: number;
+        headRef?: string;
+        screenshotSetId?: string;
+        taskId?: string;
+      }
+    > = {};
+
+    for (const [repoFullName, prNumbers] of prsByRepo) {
+      // Find the preview config for this repo
+      const config = await ctx.db
+        .query("previewConfigs")
+        .withIndex("by_team_repo", (q) =>
+          q.eq("teamId", teamId).eq("repoFullName", repoFullName),
+        )
+        .first();
+
+      if (!config) {
+        continue;
+      }
+
+      // Get most recent preview run for each PR
+      for (const prNumber of prNumbers) {
+        const run = await ctx.db
+          .query("previewRuns")
+          .withIndex("by_config_pr", (q) =>
+            q.eq("previewConfigId", config._id).eq("prNumber", prNumber),
+          )
+          .order("desc")
+          .first();
+
+        if (run) {
+          let taskId = undefined;
+          if (run.taskRunId) {
+            const taskRun = await ctx.db.get(run.taskRunId);
+            if (taskRun) {
+              taskId = taskRun.taskId;
+            }
+          }
+
+          const key = `${repoFullName}#${prNumber}`;
+          results[key] = {
+            _id: run._id,
+            status: run.status,
+            createdAt: run.createdAt,
+            completedAt: run.completedAt,
+            headRef: run.headRef,
+            screenshotSetId: run.screenshotSetId,
+            taskId,
+          };
+        }
+      }
+    }
+
+    return results;
+  },
+});


### PR DESCRIPTION
we need a way to handle duplicates in preview tab... ideally we just show the most recent (we need an ui interface to collapse the previous screenshot preview runs or organize them into groups somehow... make this is in high taste)... for the previews tab. also we should show the most recent vscode, preview stuff under the pull request also in the cmux sidebar... make sure todo this carefully (under the chevron should be all of the stuff that was supposed to be for preview task run and make sure that we maintain and update it with the most recent preview run for that pull request)...