### PR TITLE
fix: use unique id as React key for provider connections

### DIFF
--- a/apps/www/app/(preview)/preview/page.tsx
+++ b/apps/www/app/(preview)/preview/page.tsx
@@ -33,6 +33,7 @@ type TeamOption = {
 
 function serializeProviderConnections(
   connections: Array<{
+    id: string;
     installationId: number;
     accountLogin: string | null | undefined;
     accountType: string | null | undefined;
@@ -40,6 +41,7 @@ function serializeProviderConnections(
   }>
 ) {
   return connections.map((conn) => ({
+    id: conn.id,
     installationId: conn.installationId,
     accountLogin: conn.accountLogin ?? null,
     accountType: conn.accountType ?? null,

--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -30,6 +30,7 @@ import { LucideIcon } from "lucide-react";
 import { useOAuthPopup } from "@/hooks/use-oauth-popup";
 
 type ProviderConnection = {
+  id: string;
   installationId: number;
   accountLogin: string | null;
   accountType: string | null;
@@ -800,7 +801,7 @@ function PreviewDashboardInner({
             className="h-10 appearance-none bg-transparent py-2 pl-11 pr-8 text-sm text-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           >
             {activeConnections.map((conn) => (
-              <option key={conn.installationId} value={conn.installationId}>
+              <option key={conn.id} value={conn.installationId}>
                 {conn.accountLogin || `ID: ${conn.installationId}`}
               </option>
             ))}

--- a/packages/convex/convex/github.ts
+++ b/packages/convex/convex/github.ts
@@ -179,6 +179,7 @@ export const listProviderConnections = authQuery({
       .withIndex("by_team", (q) => q.eq("teamId", teamId))
       .collect();
     return rows.map((r) => ({
+      id: r._id,
       installationId: r.installationId,
       accountLogin: r.accountLogin,
       accountType: r.accountType,


### PR DESCRIPTION
## Summary
- Fixes React duplicate key warning in preview dashboard when multiple provider connections share the same `installationId`
- Adds Convex document `_id` as `id` field to provider connections query
- Uses `id` instead of `installationId` as the React key for the connection options dropdown

## Test plan
- [ ] Verify no duplicate key warnings in console when viewing preview dashboard with provider connections