### PR TITLE
Post PR comment for previews with no-ui-changes

### DIFF
--- a/packages/convex/convex/screenshots_http.ts
+++ b/packages/convex/convex/screenshots_http.ts
@@ -119,7 +119,14 @@ export const uploadScreenshot = httpAction(async (ctx, req) => {
       commitSha: primaryScreenshot.commitSha,
       screenshotSetId: resolvedScreenshotSetId,
     });
-  } else if (payload.status !== "completed") {
+  } else if (resolvedScreenshotSetId) {
+    // No screenshots but we have a screenshot set (e.g., skipped/no-UI-changes).
+    // Still link the screenshot set to the task run so PR comments can be posted.
+    await ctx.runMutation(internal.taskRuns.updateLatestScreenshotSetId, {
+      id: payload.runId,
+      screenshotSetId: resolvedScreenshotSetId,
+    });
+  } else {
     await ctx.runMutation(internal.taskRuns.clearScreenshotMetadata, {
       id: payload.runId,
     });

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -695,6 +695,24 @@ export const clearScreenshotMetadata = internalMutation({
   },
 });
 
+/**
+ * Update only the latestScreenshotSetId without modifying other screenshot fields.
+ * Used when a screenshot set is created (e.g., for skipped/no-UI-changes runs)
+ * but there are no actual image files to store.
+ */
+export const updateLatestScreenshotSetId = internalMutation({
+  args: {
+    id: v.id("taskRuns"),
+    screenshotSetId: v.id("taskRunScreenshotSets"),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, {
+      latestScreenshotSetId: args.screenshotSetId,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 // Update worktree path for a task run
 export const updateWorktreePath = authMutation({
   args: {

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -384,7 +384,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_hszt8v6s' | 'snapshot_smvgcirt' | 'snapshot_pcmfvjra');
+    snapshotId?: string | ('snapshot_6az195xq' | 'snapshot_0kz5x004' | 'snapshot_pcmfvjra');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
it completed the preview job but didn't post a coment even though there were no ui changes: [AMP proxy] Starting local proxy on http://localhost:39400, forwarding to https://ampcode.com[2025-12-04T01:19:06.744Z][worker-1764811146734] [INFO] Worker worker-1764811146734 starting on port 39377[2025-12-04T01:19:06.746Z][worker-1764811146734] [INFO] Namespaces: {  "vscode": "/vscode",  "management": "/management"}[2025-12-04T01:19:06.746Z][worker-1764811146734] [INFO] Worker ready, waiting for terminal creation commands via socket.io[AMP proxy] Listening on port 39400[2025-12-04T01:19:06.744Z][worker-1764811146734] [INFO] Worker worker-1764811146734 starting on port 39377[2025-12-04T01:19:06.746Z][worker-1764811146734] [INFO] Namespaces: {  "vscode": "/vscode",  "management": "/management"}[2025-12-04T01:19:06.746Z][worker-1764811146734] [INFO] Worker ready, waiting for terminal creation commands via socket.ioWorker worker-1764811146734 shutting down...HTTP server closed[AMP proxy] Starting local proxy on http://localhost:39400, forwarding to https://ampcode.com[2025-12-04T01:19:07.815Z][worker-1764811147808] [INFO] Worker worker-1764811147808 starting on port 39377[2025-12-04T01:19:07.815Z][worker-1764811147808] [INFO] Namespaces: {  "vscode": "/vscode",  "management": "/management"}[2025-12-04T01:19:07.816Z][worker-1764811147808] [INFO] Worker ready, waiting for terminal creation commands via socket.io[AMP proxy] Listening on port 39400[2025-12-04T01:19:07.815Z][worker-1764811147808] [INFO] Worker worker-1764811147808 starting on port 39377[2025-12-04T01:19:07.815Z][worker-1764811147808] [INFO] Namespaces: {  "vscode": "/vscode",  "management": "/management"}[2025-12-04T01:19:07.816Z][worker-1764811147808] [INFO] Worker ready, waiting for terminal creation commands via socket.io(node:19966) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.(Use `node --trace-deprecation ...` to show where the warning was created)VSCode connected to worker worker-1764811147808: 73AHT90PYDMlSAC4AAAB from unknownClient disconnected from worker worker-1764811147808: 73AHT90PYDMlSAC4AAABWorker worker-1764811147808 shutting down...HTTP server closed[AMP proxy] Starting local proxy on http://localhost:39400, forwarding to https://ampcode.com[2025-12-04T02:38:16.039Z][worker-1764815896021] [INFO] Worker worker-1764815896021 starting on port 39377[2025-12-04T02:38:16.066Z][worker-1764815896021] [INFO] Namespaces: {  "vscode": "/vscode",  "management": "/management"}[2025-12-04T02:38:16.067Z][worker-1764815896021] [INFO] Worker ready, waiting for terminal creation commands via socket.io[AMP proxy] Listening on port 39400[2025-12-04T02:38:16.039Z][worker-1764815896021] [INFO] Worker worker-1764815896021 starting on port 39377[2025-12-04T02:38:16.066Z][worker-1764815896021] [INFO] Namespaces: {  "vscode": "/vscode",  "management": "/management"}[2025-12-04T02:38:16.067Z][worker-1764815896021] [INFO] Worker ready, waiting for terminal creation commands via socket.io[2025-12-04T02:38:28.360Z] [INFO] [/api/run-task-screenshots] Received request {  "workerId": "worker-1764815896021",  "hasToken": true,  "hasAnthropicKey": false}[2025-12-04T02:38:28.361Z] [INFO] [/api/run-task-screenshots] Resolving task metadata {  "workerId": "worker-1764815896021",  "convexUrl": "https://adorable-wombat-701.convex.site",  "hasConvexUrl": true}[2025-12-04T02:38:28.360Z] [INFO] [/api/run-task-screenshots] Received request {  "workerId": "worker-1764815896021",  "hasToken": true,  "hasAnthropicKey": false}[2025-12-04T02:38:28.361Z] [INFO] [/api/run-task-screenshots] Resolving task metadata {  "workerId": "worker-1764815896021",  "convexUrl": "https://adorable-wombat-701.convex.site",  "hasConvexUrl": true}[2025-12-04T02:38:28.720Z] [INFO] [/api/run-task-screenshots] Crown check response received {  "workerId": "worker-1764815896021",  "hasInfo": true,  "ok": true,  "hasTaskRun": true,  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx",  "isPreviewJob": true}[2025-12-04T02:38:28.721Z] [INFO] [/api/run-task-screenshots] Verified preview job metadata {  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx"}[2025-12-04T02:38:28.722Z] [INFO] Starting automated screenshot workflow {  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx",  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "hasAnthropicKey": true}2025-12-04T02:38:28.728Z start-screenshot-collection triggered[2025-12-04T02:38:28.720Z] [INFO] [/api/run-task-screenshots] Crown check response received {  "workerId": "worker-1764815896021",  "hasInfo": true,  "ok": true,  "hasTaskRun": true,  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx",  "isPreviewJob": true}[2025-12-04T02:38:28.721Z] [INFO] [/api/run-task-screenshots] Verified preview job metadata {  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx"}[2025-12-04T02:38:28.722Z] [INFO] Starting automated screenshot workflow {  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx",  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "hasAnthropicKey": true}[2025-12-04T02:38:28.734Z] [INFO] Screenshot collection trigger recorded {  "path": "/var/log/cmux/screenshot-collector",  "openVSCodeUrl": "http://localhost:39378/?folder=/var/log/cmux"}[2025-12-04T02:38:28.737Z] [INFO] Git repository selected {  "path": "/root/workspace",  "repoHint": null,  "candidates": [    "/root/workspace"  ]}2025-12-04T02:38:28.737Z Evaluating 1 git repo(s) for screenshots[2025-12-04T02:38:28.734Z] [INFO] Screenshot collection trigger recorded {  "path": "/var/log/cmux/screenshot-collector",  "openVSCodeUrl": "http://localhost:39378/?folder=/var/log/cmux"}[2025-12-04T02:38:28.737Z] [INFO] Git repository selected {  "path": "/root/workspace",  "repoHint": null,  "candidates": [    "/root/workspace"  ]}2025-12-04T02:38:28.770Z Git repository selected for screenshots: /root/workspace2025-12-04T02:38:28.770Z Determining merge base from origin HEAD branch...2025-12-04T02:38:28.771Z Using merge base 86b1c817fff7214e0dd232bef69024b28556fef5 from origin/main[2025-12-04T02:38:28.771Z] [INFO] Git repository selected for screenshots {  "workspaceRoot": "/root/workspace",  "selectedRepository": "/root/workspace",  "repositoryCandidates": [    "/root/workspace"  ],  "baseBranch": "origin/main",  "mergeBase": "86b1c817fff7214e0dd232bef69024b28556fef5"}[2025-12-04T02:38:28.771Z] [INFO] Git repository selected for screenshots {  "workspaceRoot": "/root/workspace",  "selectedRepository": "/root/workspace",  "repositoryCandidates": [    "/root/workspace"  ],  "baseBranch": "origin/main",  "mergeBase": "86b1c817fff7214e0dd232bef69024b28556fef5"}2025-12-04T02:38:28.788Z Found 1 text file(s) with diffs out of 1 total2025-12-04T02:38:28.801Z Text files queued for screenshots: apps/worker/src/screenshotCollector/git.ts2025-12-04T02:38:28.813Z Resolved commit ceb0c15542b02533008e1ec5cd4b238205113d1e2025-12-04T02:38:28.819Z No PR description found; proceeding without additional context2025-12-04T02:38:28.820Z Using taskRun JWT for Claude Code screenshot collection2025-12-04T02:38:28.821Z JWT details: present=true, length=303, first 20 chars=eyJhbGciOiJIUzI1NiJ92025-12-04T02:38:28.835Z Using head branch cmux/resolve-merge-base-for-screenshot-previews-9qwic2025-12-04T02:38:28.836Z Claude collector output dir: /root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic2025-12-04T02:38:28.839Z Starting PR screenshot capture in /root/workspace2025-12-04T02:38:28.839Z Found 1 changed files: apps/worker/src/screenshotCollector/git.ts2025-12-04T02:38:28.841Z Capturing 'after' screenshots for head branch: cmux/resolve-merge-base-for-screenshot-previews-9qwic2025-12-04T02:38:28.843Z Starting Claude Agent with browser MCP for branch: cmux/resolve-merge-base-for-screenshot-previews-9qwic2025-12-04T02:38:28.844Z Using taskRun JWT auth. JWT present: true, JWT length: 303, JWT first 20 chars: eyJhbGciOiJIUzI1NiJ92025-12-04T02:38:28.844Z ANTHROPIC_BASE_URL: https://www.cmux.dev/api/anthropic2025-12-04T02:38:28.845Z Arguments to Claude Code: {"prompt":"I need you to take screenshots of the UI changes in this pull request.\n\nPR Title: UI screenshots for cmux/resolve-merge-base-for-screenshot-previews-9qwic\nPR Description: No description provided\n\nCurrent branch: cmux/resolve-merge-base-for-screenshot-previews-9qwic\nFiles changed in this PR:\n- apps/worker/src/screenshotCollector/git.ts\n\nWorking directory: /root/workspace\nScreenshot output directory: /root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic\n\nPlease:\n0. Read CLAUDE.md or AGENTS.md (they may be one level deeper) and install dependencies if needed\n1. Start the development server if needed (check files like README.md, package.json or .devcontainer.json for dev script, explore the repository more if needed. check tmux panes comprehensively to see if the server is running.)\n2. Wait for the server to be ready\n3. Navigate to the pages/components that were modified in the PR\n4. Take full-page screenshots as well as element-specific screenshots of each relevant UI view that was changed\n5. Save every screenshot directly inside /root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic (no subdirectories) with descriptive names like \"homepage-cmux/resolve-merge-base-for-screenshot-previews-9qwic.png\"\n\n<IMPORTANT>\nFocus on capturing visual changes. If no UI changes are present, just let me know.\nWhen providing structured_output, set hasUiChanges to true if you saw UI changes and false otherwise. Include every screenshot you saved with the absolute file path (or a path relative to /root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic) and a short description of what the screenshot shows. The paths must match the files you saved.\nDo not close the browser after you're done, since I will want to click around the final page you navigated to.\nDo not create summary documents.\nIf you can't install dependencies/start the dev server, just let me know. Do not create fake html mocks. We must take screenshots of the actual ground truth UI.\n</IMPORTANT>","cwd":"/root/workspace","pathToClaudeCodeExecutable":"/root/.bun/bin/claude"}2025-12-04T02:38:28.847Z [claude-code-stderr] Spawning Claude Code native binary: /root/.bun/bin/claude --output-format stream-json --verbose --input-format stream-json --system-prompt  --model claude-sonnet-4-5 --json-schema {"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,"required":["hasUiChanges","images"],"properties":{"hasUiChanges":{"type":"boolean"},"images":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["path","description"],"properties":{"path":{"type":"string"},"description":{"type":"string"}}}}}} --mcp-config {"mcpServers":{"chrome":{"command":"bunx","args":["chrome-devtools-mcp","--browserUrl","http://0.0.0.0:39382"]}}} --setting-sources  --permission-mode bypassPermissions --allow-dangerously-skip-permissions2025-12-04T02:38:34.780Z 🔧 System initialized   Model: claude-sonnet-4-5   Tools: 45 available   MCP Servers: chrome(connected)   Permission Mode: bypassPermissions2025-12-04T02:38:37.812Z 💬 I'll help you take screenshots of the UI changes in this pull request. Let me start by examining the repository structure and understanding what was changed.   └─ tokens: in=3 out=82025-12-04T02:38:38.321Z 📖 Read /root/workspace   └─ tokens: in=3 out=82025-12-04T02:38:39.265Z 🔨 Bash find /root/workspace -maxdepth 2 -name "CLAUDE.md"...   └─ tokens: in=3 out=82025-12-04T02:38:39.325Z    ✓ Result: EISDIR: illegal operation on a directory, read2025-12-04T02:38:39.624Z    ✓ Result: /root/workspace/README.md/root/workspace/AGENTS.md/root/workspace/CLAUDE.md2025-12-04T02:38:43.583Z 📖 Read /root/workspace/AGENTS.md   └─ tokens: in=7 out=252025-12-04T02:38:44.036Z 📖 Read /root/workspace/apps/worker/src/screenshotCollector/git.ts   └─ tokens: in=7 out=1162025-12-04T02:38:44.052Z    ✓ Result:      1→This project is called cmux. cmux is a web app that spawns Claude Code, Codex CLI, Gemini CLI, Amp, Opencode, and other coding agent CLIs in parallel across multiple tasks. For each run, cmux s...2025-12-04T02:38:44.059Z    ✓ Result:      1→import { runCommandCapture } from "../crown/utils";     2→     3→export function extractPathFromDiff(rawPath: string): string {     4→  const trimmed = rawPath.trim();     5→  const arrowIn...2025-12-04T02:38:47.890Z 💬 Now let me check the git diff to understand what actually changed:   └─ tokens: in=7 out=12025-12-04T02:38:49.297Z 🔨 Bash git diff origin/main...HEAD -- apps/worker/src/scr...   └─ tokens: in=7 out=12025-12-04T02:38:49.552Z    ✓ Result: diff --git a/apps/worker/src/screenshotCollector/git.ts b/apps/worker/src/screenshotCollector/git.tsindex 9466d99a..e36563d8 100644--- a/apps/worker/src/screenshotCollector/git.ts+++ b/apps/worker/...2025-12-04T02:38:57.138Z 💬 Based on the changes, this PR modifies only a backend TypeScript file (`apps/worker/src/screenshotCollector/git.ts`) that handles Git operations. The changes are:1. Added helper functions `tryFetchBranch` and `tryDeepen` for better Git handling2. Enhanced the `resolveMergeBase` function with better error handling and retry logic for shallow clones**This is purely backend/utility code with no UI changes.** There are no React components, HTML, CSS, or any user-facing interface modifications in this PR.Let me verify there are no other UI-related files or components that might be affected:   └─ tokens: in=5 out=12025-12-04T02:38:58.091Z 🔨 Bash git diff --name-only origin/main...HEAD   └─ tokens: in=5 out=12025-12-04T02:38:58.292Z    ✓ Result: apps/worker/src/screenshotCollector/git.ts2025-12-04T02:39:01.851Z 💬 Perfect. There is only one file changed in this PR, and it's a backend utility file for Git operations with no UI components.   └─ tokens: in=5 out=12025-12-04T02:39:02.427Z 🔧 StructuredOutput {hasUiChanges, images}   └─ tokens: in=5 out=12025-12-04T02:39:02.451Z    ✓ Result: Structured output provided successfully2025-12-04T02:39:08.893Z 💬 ## Summary**No UI changes are present in this pull request.**This PR modifies only a single backend TypeScript file: `apps/worker/src/screenshotCollector/git.ts`The changes are purely functional improvements to Git operations:- Added `tryFetchBranch()` helper function to fetch specific branches with shallow depth- Added `tryDeepen()` helper function to deepen shallow clones- Enhanced `resolveMergeBase()` function with better error handling and retry logic for scenarios involving shallow clones or missing remote branchesSince there are no UI components, pages, or visual elements modified in this PR, there are no screenshots to capture.   └─ tokens: in=4 out=12025-12-04T02:39:08.945Z ✅ Success (8 turns, 34196ms, $0.0958)   Result: ## Summary**No UI changes are present in this pull request.**This PR modifies only a single backend TypeScript file: `apps/worker/src/screenshotCollector/git.ts`The changes are purely functional improvements to Git operations:- Added `tryFetchBranch()` helper function to fetch specific branches with shallow depth- Added `tryDeepen()` helper function to deepen shallow clones- Enhanced `resolveMergeBase()` function with better error handling and retry logic for scenarios involving shallow clones or missing remote branchesSince there are no UI components, pages, or visual elements modified in this PR, there are no screenshots to capture.2025-12-04T02:39:08.946Z Structured output captured (hasUiChanges=false, images=0)2025-12-04T02:39:09.191Z Captured 0 'after' screenshots2025-12-04T02:39:09.192Z Screenshot capture completed. Total: 0 screenshots saved to /root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic[2025-12-04T02:39:09.193Z] [INFO] PR screenshot capture completed {  "screenshotCount": 0,  "outputDir": "/root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic"}2025-12-04T02:39:09.194Z No UI changes detected in this PR[2025-12-04T02:39:09.193Z] [INFO] PR screenshot capture completed {  "screenshotCount": 0,  "outputDir": "/root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic"}[2025-12-04T02:39:09.195Z] [INFO] No UI changes detected in this PR {  "headBranch": "cmux/resolve-merge-base-for-screenshot-previews-9qwic",  "outputDir": "/root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic"}[2025-12-04T02:39:09.195Z] [INFO] Screenshot workflow skipped {  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "reason": "No UI changes detected in this PR"}[2025-12-04T02:39:09.195Z] [INFO] No UI changes detected in this PR {  "headBranch": "cmux/resolve-merge-base-for-screenshot-previews-9qwic",  "outputDir": "/root/screenshots/1764815908835-cmux-resolve-merge-base-for-screenshot-previews-9qwic"}[2025-12-04T02:39:09.195Z] [INFO] Screenshot workflow skipped {  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "reason": "No UI changes detected in this PR"}[2025-12-04T02:39:09.480Z] [INFO] Screenshot metadata uploaded {  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx",  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "storageIds": [],  "screenshotSetId": "nx776y9ty5fy4vq0a1y5qqtmex7wn380",  "status": "skipped"}[2025-12-04T02:39:09.481Z] [INFO] [/api/run-task-screenshots] Screenshots completed, calling /api/preview/complete {  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb"}[2025-12-04T02:39:09.480Z] [INFO] Screenshot metadata uploaded {  "taskId": "kn7d13dt3bgqg30c7yem4t9m917wnabx",  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb",  "storageIds": [],  "screenshotSetId": "nx776y9ty5fy4vq0a1y5qqtmex7wn380",  "status": "skipped"}[2025-12-04T02:39:09.481Z] [INFO] [/api/run-task-screenshots] Screenshots completed, calling /api/preview/complete {  "taskRunId": "kd7e0ct8xs8gncx8aenysyr9qh7wnaxb"}[2025-12-04T02:39:09.922Z] [INFO] [/api/run-task-screenshots] Preview job completed successfully {  "result": {    "success": true,    "skipped": true,    "reason": "No screenshots available",    "runStatusUpdated": true,    "alreadyCompleted": false  }}[2025-12-04T02:39:09.922Z] [INFO] [/api/run-task-screenshots] Preview job completed successfully {  "result": {    "success": true,    "skipped": true,    "reason": "No screenshots available",    "runStatusUpdated": true,    "alreadyCompleted": false  }}(node:39125) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.(Use `node --trace-deprecation ...` to show where the warning was created)VSCode connected to worker worker-1764815896021: H6LCAqUofVuxvaCvAAAB from unknown.. fix this issue. we should always be commmenting on every github pr LOL