### PR TITLE
Set cloud default upstream to avoid prompts

### DIFF
--- a/apps/www/lib/routes/sandboxes/git.ts
+++ b/apps/www/lib/routes/sandboxes/git.ts
@@ -24,7 +24,7 @@ export const configureGitIdentity = async (
   identity: { name: string; email: string }
 ) => {
   const gitCfgRes = await instance.exec(
-    `bash -lc "git config --global user.name ${singleQuote(identity.name)} && git config --global user.email ${singleQuote(identity.email)} && git config --global init.defaultBranch main && echo NAME:$(git config --global --get user.name) && echo EMAIL:$(git config --global --get user.email) || true"`
+    `bash -lc "git config --global user.name ${singleQuote(identity.name)} && git config --global user.email ${singleQuote(identity.email)} && git config --global init.defaultBranch main && git config --global push.autoSetupRemote true && echo NAME:$(git config --global --get user.name) && echo EMAIL:$(git config --global --get user.email) || true"`
   );
   if (gitCfgRes.exit_code !== 0) {
     console.error(


### PR DESCRIPTION
root ~/workspace git:z-floating-high-overlay # g push
fatal: The current branch z-floating-high-overlay has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin z-floating-high-overlay

To have this happen automatically for branches without a tracking
upstream, see 'push.autoSetupRemote' in 'git help config'.make it so that we never see this message in any cloud vms. make sure to not increase startup times too tho.