### PR TITLE
Hide build agent by default in VSCode

### DIFF
--- a/configs/systemd/bin/configure-openvscode
+++ b/configs/systemd/bin/configure-openvscode
@@ -20,6 +20,7 @@ SETTINGS=$(jq -n \
   --arg theme "$color" \
   '{
     "workbench.startupEditor": "none",
+    "workbench.secondarySideBar.visible": false,
     "terminal.integrated.shellIntegration.enabled": false,
     "terminal.integrated.macOptionClickForcesSelection": true,
     "terminal.integrated.shell.linux": "/usr/bin/zsh",


### PR DESCRIPTION
image.png Can you make the build with agent automatically hidden on default in the vscode instances that get started?