### PR TITLE
Implement image-pillbox previews for pasted images

### DIFF
--- a/apps/client/src/components/lexical/ImageComponent.tsx
+++ b/apps/client/src/components/lexical/ImageComponent.tsx
@@ -1,27 +1,25 @@
-// No React import needed with the automatic JSX runtime
+import { ImagePillbox } from "./ImagePillbox";
+
+interface ImageComponentProps {
+  src: string;
+  altText: string;
+  fileName?: string;
+  nodeKey?: string;
+  onRemove?: () => void;
+}
 
 export default function ImageComponent({
   src,
   altText,
   fileName,
-}: {
-  src: string;
-  altText: string;
-  fileName?: string;
-}) {
+  onRemove,
+}: ImageComponentProps) {
   return (
-    <div className="relative inline-block my-2">
-      <img
-        src={src}
-        alt={altText}
-        className="max-w-full h-auto rounded-lg border border-neutral-200 dark:border-neutral-700"
-        style={{ maxHeight: "300px" }}
-      />
-      {fileName && (
-        <div className="absolute bottom-0 left-0 right-0 bg-black/50 text-white text-xs px-2 py-1 rounded-b-lg">
-          {fileName}
-        </div>
-      )}
-    </div>
+    <ImagePillbox
+      src={src}
+      altText={altText}
+      fileName={fileName}
+      onRemove={onRemove}
+    />
   );
 }

--- a/apps/client/src/components/lexical/ImageNode.tsx
+++ b/apps/client/src/components/lexical/ImageNode.tsx
@@ -11,7 +11,7 @@ import type {
 
 import { $applyNodeReplacement, DecoratorNode, type LexicalEditor } from "lexical";
 import * as React from "react";
-import ImageComponent from "./ImageComponent";
+import { ImageNodeComponent } from "./ImageNodeComponent";
 
 export interface ImagePayload {
   altText: string;
@@ -132,8 +132,16 @@ export class ImageNode extends DecoratorNode<React.JSX.Element> {
     return this.__fileName;
   }
 
-  decorate(_editor: LexicalEditor, _config: EditorConfig): React.JSX.Element {
-    return <ImageComponent src={this.__src} altText={this.__altText} fileName={this.__fileName} />;
+  decorate(editor: LexicalEditor, _config: EditorConfig): React.JSX.Element {
+    return (
+      <ImageNodeComponent
+        src={this.__src}
+        altText={this.__altText}
+        fileName={this.__fileName}
+        nodeKey={this.__key}
+        editor={editor}
+      />
+    );
   }
 }
 

--- a/apps/client/src/components/lexical/ImageNodeComponent.tsx
+++ b/apps/client/src/components/lexical/ImageNodeComponent.tsx
@@ -1,0 +1,38 @@
+import { $getNodeByKey, type LexicalEditor } from "lexical";
+import { useCallback } from "react";
+import ImageComponent from "./ImageComponent";
+
+interface ImageNodeComponentProps {
+  src: string;
+  altText: string;
+  fileName?: string;
+  nodeKey: string;
+  editor: LexicalEditor;
+}
+
+export function ImageNodeComponent({
+  src,
+  altText,
+  fileName,
+  nodeKey,
+  editor,
+}: ImageNodeComponentProps) {
+  const handleRemove = useCallback(() => {
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if (node) {
+        node.remove();
+      }
+    });
+  }, [editor, nodeKey]);
+
+  return (
+    <ImageComponent
+      src={src}
+      altText={altText}
+      fileName={fileName}
+      nodeKey={nodeKey}
+      onRemove={handleRemove}
+    />
+  );
+}

--- a/apps/client/src/components/lexical/ImagePillbox.tsx
+++ b/apps/client/src/components/lexical/ImagePillbox.tsx
@@ -1,0 +1,105 @@
+import { X, Image as ImageIcon } from "lucide-react";
+import { useState, useCallback } from "react";
+import { ImagePreviewDialog } from "./ImagePreviewDialog";
+
+interface ImagePillboxProps {
+  src: string;
+  altText: string;
+  fileName?: string;
+  onRemove?: () => void;
+}
+
+export function ImagePillbox({
+  src,
+  altText,
+  fileName,
+  onRemove,
+}: ImagePillboxProps) {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  const displayName = fileName || altText || "Image";
+  // Truncate long filenames
+  const truncatedName =
+    displayName.length > 20
+      ? `${displayName.slice(0, 17)}...`
+      : displayName;
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsPreviewOpen(true);
+    },
+    []
+  );
+
+  const handleRemove = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onRemove?.();
+    },
+    [onRemove]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setIsPreviewOpen(true);
+      }
+    },
+    []
+  );
+
+  return (
+    <>
+      <span
+        className="inline-flex items-center gap-1.5 px-2 py-1 my-0.5 mx-0.5 rounded-lg bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-700 dark:text-neutral-300 text-sm cursor-pointer hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors select-none"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        title={`Click to preview: ${displayName}`}
+      >
+        {/* Thumbnail preview */}
+        <span className="relative flex-shrink-0 w-5 h-5 rounded overflow-hidden bg-neutral-200 dark:bg-neutral-700">
+          <img
+            src={src}
+            alt={altText}
+            className="w-full h-full object-cover"
+            draggable={false}
+          />
+        </span>
+
+        {/* Filename */}
+        <span className="truncate max-w-[120px] text-xs font-medium">
+          {truncatedName}
+        </span>
+
+        {/* Image icon indicator */}
+        <ImageIcon className="w-3 h-3 text-neutral-400 dark:text-neutral-500 flex-shrink-0" />
+
+        {/* Remove button */}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={handleRemove}
+            className="flex-shrink-0 p-0.5 rounded-full hover:bg-neutral-300 dark:hover:bg-neutral-600 transition-colors"
+            title="Remove image"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        )}
+      </span>
+
+      <ImagePreviewDialog
+        isOpen={isPreviewOpen}
+        onClose={() => setIsPreviewOpen(false)}
+        src={src}
+        altText={altText}
+        fileName={fileName}
+      />
+    </>
+  );
+}

--- a/apps/client/src/components/lexical/ImagePreviewDialog.tsx
+++ b/apps/client/src/components/lexical/ImagePreviewDialog.tsx
@@ -1,0 +1,163 @@
+import { X, Download, ZoomIn, ZoomOut } from "lucide-react";
+import { useCallback, useEffect, useState, useRef } from "react";
+
+interface ImagePreviewDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  src: string;
+  altText: string;
+  fileName?: string;
+}
+
+export function ImagePreviewDialog({
+  isOpen,
+  onClose,
+  src,
+  altText,
+  fileName,
+}: ImagePreviewDialogProps) {
+  const [scale, setScale] = useState(1);
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+      if (e.key === "+" || e.key === "=") {
+        setScale((s) => Math.min(s + 0.25, 3));
+      }
+      if (e.key === "-") {
+        setScale((s) => Math.max(s - 0.25, 0.25));
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      // Prevent scrolling on body when dialog is open
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+        document.body.style.overflow = "";
+      };
+    }
+  }, [isOpen, handleKeyDown]);
+
+  // Reset scale when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setScale(1);
+    }
+  }, [isOpen]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === backdropRef.current) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const handleDownload = useCallback(() => {
+    const link = document.createElement("a");
+    link.href = src;
+    link.download = fileName || "image.png";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, [src, fileName]);
+
+  const handleZoomIn = useCallback(() => {
+    setScale((s) => Math.min(s + 0.25, 3));
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    setScale((s) => Math.max(s - 0.25, 0.25));
+  }, []);
+
+  if (!isOpen) return null;
+
+  const displayName = fileName || altText || "Image";
+
+  return (
+    <div
+      ref={backdropRef}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+    >
+      {/* Header with controls */}
+      <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-4 py-3 bg-gradient-to-b from-black/60 to-transparent">
+        <div className="flex items-center gap-3">
+          <span className="text-white text-sm font-medium truncate max-w-[300px]">
+            {displayName}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Zoom controls */}
+          <button
+            type="button"
+            onClick={handleZoomOut}
+            className="p-2 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+            title="Zoom out (-)"
+          >
+            <ZoomOut className="w-4 h-4" />
+          </button>
+          <span className="text-white text-sm min-w-[60px] text-center">
+            {Math.round(scale * 100)}%
+          </span>
+          <button
+            type="button"
+            onClick={handleZoomIn}
+            className="p-2 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+            title="Zoom in (+)"
+          >
+            <ZoomIn className="w-4 h-4" />
+          </button>
+
+          {/* Download button */}
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="p-2 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors ml-2"
+            title="Download image"
+          >
+            <Download className="w-4 h-4" />
+          </button>
+
+          {/* Close button */}
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-2 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors ml-2"
+            title="Close (Esc)"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Image container */}
+      <div className="relative max-w-[90vw] max-h-[85vh] overflow-auto">
+        <img
+          src={src}
+          alt={altText}
+          className="rounded-lg shadow-2xl transition-transform duration-200"
+          style={{
+            transform: `scale(${scale})`,
+            transformOrigin: "center center",
+          }}
+          draggable={false}
+        />
+      </div>
+
+      {/* Hint text */}
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/60 text-xs">
+        Press Esc to close, +/- to zoom
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
when i paste images into the chat, can you make it into some sort of pillbox similar to how cursor does it and when i clik on it it expands into something that i can see (See the image that i pasted into the chat) for this main dashboard chat.