### PR TITLE
Add SETUP_MODE env var for local vs cloud

### DIFF
--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -315,6 +315,8 @@ export function WorkspaceSetupPanel({
                     <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
                       Runs after cloning your repository so dependencies and
                       services are ready. Executed from your repository root directory.
+                      The <code className="px-1 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 font-mono">CMUX_SETUP_MODE</code> environment
+                      variable is set to <code className="px-1 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 font-mono">local</code> or <code className="px-1 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 font-mono">cloud</code>.
                     </p>
                   </div>
 

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -990,6 +990,8 @@ export function setupSocketHandlers(
                   env: {
                     ...process.env,
                     ...parsedEnvVars,
+                    // CMUX_SETUP_MODE indicates whether the workspace is running in "local" or "cloud" mode
+                    CMUX_SETUP_MODE: "local",
                   },
                   maxBuffer: 10 * 1024 * 1024,
                 });

--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -83,11 +83,17 @@ export async function runMaintenanceAndDevScripts({
   const devExitCodePath = `${CMUX_RUNTIME_DIR}/dev_${runId}.exit-code`;
   const devErrorLogPath = `${CMUX_RUNTIME_DIR}/dev_${runId}.log`;
 
+  // Determine setup mode based on whether this is a cloud workspace
+  const setupMode = isCloudWorkspace ? "cloud" : "local";
+
   // Create maintenance script if provided
   const maintenanceScriptContent = hasMaintenanceScript
     ? `#!/bin/zsh
 set -eux
 cd ${WORKSPACE_ROOT}
+
+# CMUX_SETUP_MODE indicates whether the workspace is running in "local" or "cloud" mode
+export CMUX_SETUP_MODE="${setupMode}"
 
 echo "=== Maintenance Script Started at \\$(date) ==="
 ${maintenanceScript}


### PR DESCRIPTION
add bash environment variable for setup scripts (per repo one) so that the setup script (in the home page like under configure workspace) can distinguish if we're running in local or cloud mode. think of a good variable name. make sure to document it in the setup script description.