### PR TITLE
Default to 8vcpu for preview jobs

### DIFF
--- a/apps/www/components/preview/preview-configure-client.tsx
+++ b/apps/www/components/preview/preview-configure-client.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { formatEnvVarsContent } from "@cmux/shared/utils/format-env-vars-content";
+import { DEFAULT_PREVIEW_CONFIGURE_SNAPSHOT_ID } from "@cmux/shared";
 import clsx from "clsx";
 import {
   FrameworkPresetSelect,
@@ -619,6 +620,7 @@ export function PreviewConfigureClient({
           repoUrl: `https://github.com/${repo}`,
           branch: "main",
           ttlSeconds: 3600,
+          snapshotId: DEFAULT_PREVIEW_CONFIGURE_SNAPSHOT_ID,
         }),
       });
 

--- a/apps/www/lib/utils/morph-defaults.ts
+++ b/apps/www/lib/utils/morph-defaults.ts
@@ -1,5 +1,6 @@
 export {
   DEFAULT_MORPH_SNAPSHOT_ID,
+  DEFAULT_PREVIEW_CONFIGURE_SNAPSHOT_ID,
   MORPH_SNAPSHOT_PRESETS,
 } from "@cmux/shared";
 export type { MorphSnapshotId } from "@cmux/shared";

--- a/packages/shared/src/morph-snapshots.json
+++ b/packages/shared/src/morph-snapshots.json
@@ -3,101 +3,6 @@
   "updatedAt": "2025-12-04T06:13:45Z",
   "presets": [
     {
-      "presetId": "8vcpu_32gb_48gb",
-      "label": "Performance workspace",
-      "cpu": "8 vCPU",
-      "memory": "32 GB RAM",
-      "disk": "48 GB SSD",
-      "versions": [
-        {
-          "version": 1,
-          "snapshotId": "snapshot_zw2z3krp",
-          "capturedAt": "2025-11-18T01:16:45Z"
-        },
-        {
-          "version": 2,
-          "snapshotId": "snapshot_u906mxl0",
-          "capturedAt": "2025-11-18T02:02:19Z"
-        },
-        {
-          "version": 3,
-          "snapshotId": "snapshot_jeo4kgmm",
-          "capturedAt": "2025-11-18T06:43:53Z"
-        },
-        {
-          "version": 4,
-          "snapshotId": "snapshot_i57mwbv2",
-          "capturedAt": "2025-11-23T09:44:10Z"
-        },
-        {
-          "version": 5,
-          "snapshotId": "snapshot_8x6vsofr",
-          "capturedAt": "2025-11-26T20:11:28Z"
-        },
-        {
-          "version": 6,
-          "snapshotId": "snapshot_z9rtr2no",
-          "capturedAt": "2025-11-29T07:56:55Z"
-        },
-        {
-          "version": 7,
-          "snapshotId": "snapshot_vr7uc2h1",
-          "capturedAt": "2025-11-29T21:23:30Z"
-        },
-        {
-          "version": 8,
-          "snapshotId": "snapshot_8b1361wp",
-          "capturedAt": "2025-11-29T22:01:05Z"
-        },
-        {
-          "version": 9,
-          "snapshotId": "snapshot_vyzv7lc5",
-          "capturedAt": "2025-12-01T06:19:18Z"
-        },
-        {
-          "version": 10,
-          "snapshotId": "snapshot_aammgkbb",
-          "capturedAt": "2025-12-02T02:03:50Z"
-        },
-        {
-          "version": 11,
-          "snapshotId": "snapshot_qxy1k0hq",
-          "capturedAt": "2025-12-02T22:39:48Z"
-        },
-        {
-          "version": 12,
-          "snapshotId": "snapshot_tst7w0q1",
-          "capturedAt": "2025-12-02T23:02:45Z"
-        },
-        {
-          "version": 13,
-          "snapshotId": "snapshot_zil2h2rg",
-          "capturedAt": "2025-12-03T08:43:44Z"
-        },
-        {
-          "version": 14,
-          "snapshotId": "snapshot_smvgcirt",
-          "capturedAt": "2025-12-04T01:19:10Z"
-        },
-        {
-          "version": 15,
-          "snapshotId": "snapshot_0kz5x004",
-          "capturedAt": "2025-12-04T01:41:09Z"
-        },
-        {
-          "version": 16,
-          "snapshotId": "snapshot_9ng3y6jd",
-          "capturedAt": "2025-12-04T02:54:46Z"
-        },
-        {
-          "version": 17,
-          "snapshotId": "snapshot_u6orf3jx",
-          "capturedAt": "2025-12-04T06:13:45Z"
-        }
-      ],
-      "description": "Extra headroom for larger codebases or heavier workloads."
-    },
-    {
       "presetId": "4vcpu_16gb_48gb",
       "label": "Standard workspace",
       "cpu": "4 vCPU",
@@ -191,6 +96,101 @@
         }
       ],
       "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
+    },
+    {
+      "presetId": "8vcpu_32gb_48gb",
+      "label": "Performance workspace",
+      "cpu": "8 vCPU",
+      "memory": "32 GB RAM",
+      "disk": "48 GB SSD",
+      "versions": [
+        {
+          "version": 1,
+          "snapshotId": "snapshot_zw2z3krp",
+          "capturedAt": "2025-11-18T01:16:45Z"
+        },
+        {
+          "version": 2,
+          "snapshotId": "snapshot_u906mxl0",
+          "capturedAt": "2025-11-18T02:02:19Z"
+        },
+        {
+          "version": 3,
+          "snapshotId": "snapshot_jeo4kgmm",
+          "capturedAt": "2025-11-18T06:43:53Z"
+        },
+        {
+          "version": 4,
+          "snapshotId": "snapshot_i57mwbv2",
+          "capturedAt": "2025-11-23T09:44:10Z"
+        },
+        {
+          "version": 5,
+          "snapshotId": "snapshot_8x6vsofr",
+          "capturedAt": "2025-11-26T20:11:28Z"
+        },
+        {
+          "version": 6,
+          "snapshotId": "snapshot_z9rtr2no",
+          "capturedAt": "2025-11-29T07:56:55Z"
+        },
+        {
+          "version": 7,
+          "snapshotId": "snapshot_vr7uc2h1",
+          "capturedAt": "2025-11-29T21:23:30Z"
+        },
+        {
+          "version": 8,
+          "snapshotId": "snapshot_8b1361wp",
+          "capturedAt": "2025-11-29T22:01:05Z"
+        },
+        {
+          "version": 9,
+          "snapshotId": "snapshot_vyzv7lc5",
+          "capturedAt": "2025-12-01T06:19:18Z"
+        },
+        {
+          "version": 10,
+          "snapshotId": "snapshot_aammgkbb",
+          "capturedAt": "2025-12-02T02:03:50Z"
+        },
+        {
+          "version": 11,
+          "snapshotId": "snapshot_qxy1k0hq",
+          "capturedAt": "2025-12-02T22:39:48Z"
+        },
+        {
+          "version": 12,
+          "snapshotId": "snapshot_tst7w0q1",
+          "capturedAt": "2025-12-02T23:02:45Z"
+        },
+        {
+          "version": 13,
+          "snapshotId": "snapshot_zil2h2rg",
+          "capturedAt": "2025-12-03T08:43:44Z"
+        },
+        {
+          "version": 14,
+          "snapshotId": "snapshot_smvgcirt",
+          "capturedAt": "2025-12-04T01:19:10Z"
+        },
+        {
+          "version": 15,
+          "snapshotId": "snapshot_0kz5x004",
+          "capturedAt": "2025-12-04T01:41:09Z"
+        },
+        {
+          "version": 16,
+          "snapshotId": "snapshot_9ng3y6jd",
+          "capturedAt": "2025-12-04T02:54:46Z"
+        },
+        {
+          "version": 17,
+          "snapshotId": "snapshot_u6orf3jx",
+          "capturedAt": "2025-12-04T06:13:45Z"
+        }
+      ],
+      "description": "Extra headroom for larger codebases or heavier workloads."
     },
     {
       "presetId": "6vcpu_24gb_48gb",

--- a/packages/shared/src/morph-snapshots.json
+++ b/packages/shared/src/morph-snapshots.json
@@ -3,101 +3,6 @@
   "updatedAt": "2025-12-04T06:13:45Z",
   "presets": [
     {
-      "presetId": "4vcpu_16gb_48gb",
-      "label": "Standard workspace",
-      "cpu": "4 vCPU",
-      "memory": "16 GB RAM",
-      "disk": "48 GB SSD",
-      "versions": [
-        {
-          "version": 1,
-          "snapshotId": "snapshot_ytlhlcfm",
-          "capturedAt": "2025-11-18T01:16:45Z"
-        },
-        {
-          "version": 2,
-          "snapshotId": "snapshot_yvodwo7a",
-          "capturedAt": "2025-11-18T02:03:35Z"
-        },
-        {
-          "version": 3,
-          "snapshotId": "snapshot_i2v6nwzf",
-          "capturedAt": "2025-11-18T06:44:29Z"
-        },
-        {
-          "version": 4,
-          "snapshotId": "snapshot_svdf7qmg",
-          "capturedAt": "2025-11-23T09:45:47Z"
-        },
-        {
-          "version": 5,
-          "snapshotId": "snapshot_4l1fzyvr",
-          "capturedAt": "2025-11-26T20:11:45Z"
-        },
-        {
-          "version": 6,
-          "snapshotId": "snapshot_of44b6xs",
-          "capturedAt": "2025-11-29T07:57:23Z"
-        },
-        {
-          "version": 7,
-          "snapshotId": "snapshot_wpcxzz6p",
-          "capturedAt": "2025-11-29T21:23:40Z"
-        },
-        {
-          "version": 8,
-          "snapshotId": "snapshot_u00k1p82",
-          "capturedAt": "2025-11-29T22:00:34Z"
-        },
-        {
-          "version": 9,
-          "snapshotId": "snapshot_bxgzvjun",
-          "capturedAt": "2025-12-01T06:19:30Z"
-        },
-        {
-          "version": 10,
-          "snapshotId": "snapshot_75gexwe9",
-          "capturedAt": "2025-12-02T02:01:34Z"
-        },
-        {
-          "version": 11,
-          "snapshotId": "snapshot_r8vql9h8",
-          "capturedAt": "2025-12-02T22:40:18Z"
-        },
-        {
-          "version": 12,
-          "snapshotId": "snapshot_xrlir8y6",
-          "capturedAt": "2025-12-02T23:03:02Z"
-        },
-        {
-          "version": 13,
-          "snapshotId": "snapshot_6b7swr45",
-          "capturedAt": "2025-12-03T08:44:36Z"
-        },
-        {
-          "version": 14,
-          "snapshotId": "snapshot_hszt8v6s",
-          "capturedAt": "2025-12-04T01:19:39Z"
-        },
-        {
-          "version": 15,
-          "snapshotId": "snapshot_6az195xq",
-          "capturedAt": "2025-12-04T01:41:29Z"
-        },
-        {
-          "version": 16,
-          "snapshotId": "snapshot_g6va110f",
-          "capturedAt": "2025-12-04T02:56:35Z"
-        },
-        {
-          "version": 17,
-          "snapshotId": "snapshot_mpzw0j37",
-          "capturedAt": "2025-12-04T06:13:17Z"
-        }
-      ],
-      "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
-    },
-    {
       "presetId": "8vcpu_32gb_48gb",
       "label": "Performance workspace",
       "cpu": "8 vCPU",
@@ -191,6 +96,101 @@
         }
       ],
       "description": "Extra headroom for larger codebases or heavier workloads."
+    },
+    {
+      "presetId": "4vcpu_16gb_48gb",
+      "label": "Standard workspace",
+      "cpu": "4 vCPU",
+      "memory": "16 GB RAM",
+      "disk": "48 GB SSD",
+      "versions": [
+        {
+          "version": 1,
+          "snapshotId": "snapshot_ytlhlcfm",
+          "capturedAt": "2025-11-18T01:16:45Z"
+        },
+        {
+          "version": 2,
+          "snapshotId": "snapshot_yvodwo7a",
+          "capturedAt": "2025-11-18T02:03:35Z"
+        },
+        {
+          "version": 3,
+          "snapshotId": "snapshot_i2v6nwzf",
+          "capturedAt": "2025-11-18T06:44:29Z"
+        },
+        {
+          "version": 4,
+          "snapshotId": "snapshot_svdf7qmg",
+          "capturedAt": "2025-11-23T09:45:47Z"
+        },
+        {
+          "version": 5,
+          "snapshotId": "snapshot_4l1fzyvr",
+          "capturedAt": "2025-11-26T20:11:45Z"
+        },
+        {
+          "version": 6,
+          "snapshotId": "snapshot_of44b6xs",
+          "capturedAt": "2025-11-29T07:57:23Z"
+        },
+        {
+          "version": 7,
+          "snapshotId": "snapshot_wpcxzz6p",
+          "capturedAt": "2025-11-29T21:23:40Z"
+        },
+        {
+          "version": 8,
+          "snapshotId": "snapshot_u00k1p82",
+          "capturedAt": "2025-11-29T22:00:34Z"
+        },
+        {
+          "version": 9,
+          "snapshotId": "snapshot_bxgzvjun",
+          "capturedAt": "2025-12-01T06:19:30Z"
+        },
+        {
+          "version": 10,
+          "snapshotId": "snapshot_75gexwe9",
+          "capturedAt": "2025-12-02T02:01:34Z"
+        },
+        {
+          "version": 11,
+          "snapshotId": "snapshot_r8vql9h8",
+          "capturedAt": "2025-12-02T22:40:18Z"
+        },
+        {
+          "version": 12,
+          "snapshotId": "snapshot_xrlir8y6",
+          "capturedAt": "2025-12-02T23:03:02Z"
+        },
+        {
+          "version": 13,
+          "snapshotId": "snapshot_6b7swr45",
+          "capturedAt": "2025-12-03T08:44:36Z"
+        },
+        {
+          "version": 14,
+          "snapshotId": "snapshot_hszt8v6s",
+          "capturedAt": "2025-12-04T01:19:39Z"
+        },
+        {
+          "version": 15,
+          "snapshotId": "snapshot_6az195xq",
+          "capturedAt": "2025-12-04T01:41:29Z"
+        },
+        {
+          "version": 16,
+          "snapshotId": "snapshot_g6va110f",
+          "capturedAt": "2025-12-04T02:56:35Z"
+        },
+        {
+          "version": 17,
+          "snapshotId": "snapshot_mpzw0j37",
+          "capturedAt": "2025-12-04T06:13:17Z"
+        }
+      ],
+      "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
     },
     {
       "presetId": "6vcpu_24gb_48gb",

--- a/packages/shared/src/morph-snapshots.ts
+++ b/packages/shared/src/morph-snapshots.ts
@@ -116,3 +116,20 @@ if (!firstPreset) {
 }
 
 export const DEFAULT_MORPH_SNAPSHOT_ID: MorphSnapshotId = firstPreset.id;
+
+/**
+ * Get the latest snapshot ID for a given preset ID.
+ */
+export const getSnapshotIdByPresetId = (
+  presetId: string,
+): MorphSnapshotId | undefined => {
+  const preset = MORPH_SNAPSHOT_PRESETS.find((p) => p.presetId === presetId);
+  return preset?.id;
+};
+
+/**
+ * The default snapshot ID for preview configure environments.
+ * Uses the 8vcpu preset for better performance during environment setup.
+ */
+export const DEFAULT_PREVIEW_CONFIGURE_SNAPSHOT_ID: MorphSnapshotId =
+  getSnapshotIdByPresetId("8vcpu_32gb_48gb") ?? DEFAULT_MORPH_SNAPSHOT_ID;


### PR DESCRIPTION
can you default to the bigger cpu macine (we have 4vcpu and 8vcpu snapshots) can you default to the bigger cpu machine for the preview jobs...