### PR TITLE
Show only VSCode link for local workspaces

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -839,6 +839,20 @@ function TaskTreeInner({
                   event.preventDefault();
                   return;
                 }
+                // For local workspaces with active VSCode, expand and navigate to VSCode view
+                if (localWorkspaceRunWithVscode) {
+                  event.preventDefault();
+                  setIsExpanded(true);
+                  void navigate({
+                    to: "/$teamSlugOrId/task/$taskId/run/$runId/vscode",
+                    params: {
+                      teamSlugOrId,
+                      taskId: task._id,
+                      runId: localWorkspaceRunWithVscode._id,
+                    },
+                  });
+                  return;
+                }
                 handleToggle(event);
               }}
             >

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -820,7 +820,11 @@ function TaskTreeInner({
               params={{ teamSlugOrId, taskId: task._id }}
               search={{ runId: undefined }}
               activeOptions={{ exact: true }}
-              className="group block"
+              className={clsx(
+                "group block",
+                // For local workspaces, manually add active class since we navigate to VSCode sub-route
+                localWorkspaceRunWithVscode && isTaskSelected && "active"
+              )}
               data-focus-visible={isTaskLinkFocusVisible ? "true" : undefined}
               onMouseEnter={handlePrefetch}
               onFocus={handleTaskLinkFocus}


### PR DESCRIPTION
for local workspaces, we don't need to have the panels view and we shouldn't have git diff viewer eihter. it should just be the vscode link only. like i click it in the workspaces tab of sidebar or dashboard and it should link to the vscode workspace (do this only for local workspaces and not local tasks, cloud tasks, cloud environment tasks)... make sure its the only exception to the rule