### PR TITLE
Invert saved-notice to display on unsaved changes

### DIFF
--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -481,9 +481,9 @@ export function WorkspaceSetupPanel({
                     Add variable
                   </button>
                   <div className="flex items-center gap-2">
-                    {!hasChanges && !saveMutation.isPending ? (
-                      <span className="text-[11px] text-neutral-500 dark:text-neutral-400">
-                        All changes saved
+                    {hasChanges && !saveMutation.isPending ? (
+                      <span className="text-[11px] text-amber-600 dark:text-amber-400">
+                        Unsaved changes
                       </span>
                     ) : null}
                     <Button


### PR DESCRIPTION
Under "configure workspace..." for home page, reverse "All changes saved" so it only shows up when there's new changes, like "You have unsaved changes" or something like that.