### PR TITLE
Improve agent spawn errors with clearer safe details

### DIFF
--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -59,6 +59,7 @@ import {
 } from "./utils/providerStatus";
 import { refreshGitHubData } from "./utils/refreshGitHubData";
 import { runWithAuth, runWithAuthToken } from "./utils/requestContext";
+import { extractSandboxStartError } from "./utils/sandboxErrors";
 import { getWwwClient } from "./utils/wwwClient";
 import { getWwwOpenApiModule } from "./utils/wwwOpenApiModule";
 import { DockerVSCodeInstance } from "./vscode/DockerVSCodeInstance";
@@ -1361,7 +1362,8 @@ export function setupSocketHandlers(
 
           const data = startRes.data;
           if (!data) {
-            throw new Error("Failed to start sandbox");
+            const errorMessage = extractSandboxStartError(startRes);
+            throw new Error(errorMessage);
           }
 
           const sandboxId = data.instanceId;

--- a/apps/server/src/utils/sandboxErrors.ts
+++ b/apps/server/src/utils/sandboxErrors.ts
@@ -1,0 +1,44 @@
+/**
+ * Extract a descriptive error message from a failed sandbox start response.
+ * This avoids leaking sensitive information while providing useful context.
+ */
+export function extractSandboxStartError(startRes: {
+  error?: unknown;
+  response?: Response;
+}): string {
+  const baseMessage = "Failed to start sandbox";
+
+  // Try to get error info from the response
+  const status = startRes.response?.status;
+  const statusText = startRes.response?.statusText;
+
+  // Check for specific HTTP status codes
+  if (status === 401) {
+    return `${baseMessage}: authentication failed`;
+  }
+  if (status === 403) {
+    return `${baseMessage}: access denied`;
+  }
+  if (status === 429) {
+    return `${baseMessage}: rate limited`;
+  }
+  if (status === 503 || status === 502 || status === 504) {
+    return `${baseMessage}: sandbox provider unavailable (${status})`;
+  }
+
+  // Try to extract error message from the error field
+  if (startRes.error) {
+    const error = startRes.error;
+    if (typeof error === "string" && error.length > 0 && error.length < 200) {
+      return `${baseMessage}: ${error}`;
+    }
+  }
+
+  // Include status info if available
+  if (status && status >= 400) {
+    const statusInfo = statusText ? `${status} ${statusText}` : `HTTP ${status}`;
+    return `${baseMessage}: ${statusInfo}`;
+  }
+
+  return baseMessage;
+}

--- a/apps/server/src/vscode/CmuxVSCodeInstance.ts
+++ b/apps/server/src/vscode/CmuxVSCodeInstance.ts
@@ -1,4 +1,5 @@
 import { dockerLogger } from "../utils/fileLogger";
+import { extractSandboxStartError } from "../utils/sandboxErrors";
 import { getWwwClient } from "../utils/wwwClient";
 import { getWwwOpenApiModule } from "../utils/wwwOpenApiModule";
 import {
@@ -70,7 +71,9 @@ export class CmuxVSCodeInstance extends VSCodeInstance {
     });
     const data = startRes.data;
     if (!data) {
-      throw new Error("Failed to start sandbox");
+      // Extract error details from the response for a more descriptive message
+      const errorMessage = extractSandboxStartError(startRes);
+      throw new Error(errorMessage);
     }
 
     this.sandboxId = data.instanceId;


### PR DESCRIPTION
instead of just "Agent spawn failed: Failed to start sandbox"can we have better error message? but make sure to not leak sensitive info, but error should still be as descriptive as possible.