### PR TITLE
feat: pass dev and install scripts to screenshot collector prompt

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -124,11 +124,15 @@ async function runPreviewJobScreenshots({
   anthropicApiKey,
   context,
   logPrefix,
+  installCommand,
+  devCommand,
 }: {
   token: string;
   anthropicApiKey?: string;
   context: PreviewJobContext;
   logPrefix: string;
+  installCommand?: string;
+  devCommand?: string;
 }) {
   const { taskId, taskRunId, convexUrl } = context;
 
@@ -144,6 +148,8 @@ async function runPreviewJobScreenshots({
     convexUrl,
     anthropicApiKey,
     taskRunJwt: token,
+    installCommand,
+    devCommand,
   });
 
   log("INFO", `${logPrefix} Screenshots completed, calling /api/preview/complete`, {
@@ -316,6 +322,8 @@ app.post("/api/run-task-screenshots", async (req, res) => {
           anthropicApiKey: data.anthropicApiKey,
           context,
           logPrefix,
+          installCommand: data.installCommand,
+          devCommand: data.devCommand,
         });
       } catch (error) {
         log("ERROR", `${logPrefix} Failed`, error);

--- a/apps/worker/src/screenshotCollector/claudeScreenshotCollector.ts
+++ b/apps/worker/src/screenshotCollector/claudeScreenshotCollector.ts
@@ -90,6 +90,10 @@ type BranchBaseOptions = {
   prDescription: string;
   outputDir: string;
   pathToClaudeCodeExecutable?: string;
+  /** Command to install dependencies (e.g., "bun install", "npm install") */
+  installCommand?: string;
+  /** Command to start the dev server (e.g., "bun run dev", "npm run dev") */
+  devCommand?: string;
 };
 
 type BranchCaptureOptions =
@@ -137,10 +141,18 @@ export async function captureScreenshotsForBranch(
     branch,
     outputDir: requestedOutputDir,
     auth,
+    installCommand,
+    devCommand,
   } = options;
   const outputDir = normalizeScreenshotOutputDir(requestedOutputDir);
   const useTaskRunJwt = isTaskRunJwtAuth(auth);
   const providedApiKey = !useTaskRunJwt ? auth.anthropicApiKey : undefined;
+
+  const devInstructions = installCommand || devCommand
+    ? `
+${installCommand ? `Install command: ${installCommand}` : ""}
+${devCommand ? `Dev server command: ${devCommand}` : ""}`
+    : "";
 
   const prompt = `I need you to take screenshots of the UI changes in this pull request.
 
@@ -153,10 +165,10 @@ ${changedFiles.map((f) => `- ${f}`).join("\n")}
 
 Working directory: ${workspaceDir}
 Screenshot output directory: ${outputDir}
-
+${devInstructions}
 Please:
 0. Read CLAUDE.md or AGENTS.md (they may be one level deeper) and install dependencies if needed
-1. Start the development server if needed (check files like README.md, package.json or .devcontainer.json for dev script, explore the repository more if needed. check tmux panes comprehensively to see if the server is running.)
+1. Start the development server if needed (${devCommand ? `use: ${devCommand}` : "check files like README.md, package.json or .devcontainer.json for dev script, explore the repository more if needed"}. check tmux panes comprehensively to see if the server is running.)
 2. Wait for the server to be ready
 3. Navigate to the pages/components that were modified in the PR
 4. Take full-page screenshots as well as element-specific screenshots of each relevant UI view that was changed
@@ -440,6 +452,8 @@ export async function claudeCodeCapturePRScreenshots(
               outputDir,
               auth: { taskRunJwt: auth.taskRunJwt },
               pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+              installCommand: options.installCommand,
+              devCommand: options.devCommand,
             }
           : {
               workspaceDir,
@@ -450,6 +464,8 @@ export async function claudeCodeCapturePRScreenshots(
               outputDir,
               auth: { anthropicApiKey: auth.anthropicApiKey },
               pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+              installCommand: options.installCommand,
+              devCommand: options.devCommand,
             }
       );
       allScreenshots.push(...beforeScreenshots.screenshots);
@@ -476,6 +492,8 @@ export async function claudeCodeCapturePRScreenshots(
             outputDir,
             auth: { taskRunJwt: auth.taskRunJwt },
             pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+            installCommand: options.installCommand,
+            devCommand: options.devCommand,
           }
         : {
             workspaceDir,
@@ -486,6 +504,8 @@ export async function claudeCodeCapturePRScreenshots(
             outputDir,
             auth: { anthropicApiKey: auth.anthropicApiKey },
             pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+            installCommand: options.installCommand,
+            devCommand: options.devCommand,
           }
     );
     allScreenshots.push(...afterScreenshots.screenshots);

--- a/apps/worker/src/screenshotCollector/runTaskScreenshots.ts
+++ b/apps/worker/src/screenshotCollector/runTaskScreenshots.ts
@@ -14,6 +14,10 @@ export interface RunTaskScreenshotsOptions {
   convexUrl?: string;
   anthropicApiKey?: string | null;
   taskRunJwt?: string | null;
+  /** Command to install dependencies (e.g., "bun install") */
+  installCommand?: string | null;
+  /** Command to start the dev server (e.g., "bun run dev") */
+  devCommand?: string | null;
 }
 
 function resolveContentType(filePath: string): string {
@@ -93,6 +97,8 @@ export async function runTaskScreenshots(
   const result = await startScreenshotCollection({
     anthropicApiKey: anthropicApiKey ?? undefined,
     taskRunJwt,
+    installCommand: options.installCommand,
+    devCommand: options.devCommand,
   });
 
   let images: ScreenshotUploadPayload["images"];

--- a/apps/worker/src/screenshotCollector/startScreenshotCollection.ts
+++ b/apps/worker/src/screenshotCollector/startScreenshotCollection.ts
@@ -27,6 +27,10 @@ export interface StartScreenshotCollectionOptions {
   headBranch?: string | null;
   baseBranch?: string | null;
   changedFiles?: string[] | null;
+  /** Command to install dependencies (e.g., "bun install") */
+  installCommand?: string | null;
+  /** Command to start the dev server (e.g., "bun run dev") */
+  devCommand?: string | null;
 }
 
 interface CapturedScreenshot {
@@ -455,6 +459,8 @@ export async function startScreenshotCollection(
       headBranch,
       outputDir,
       pathToClaudeCodeExecutable: "/root/.bun/bin/claude",
+      installCommand: options.installCommand ?? undefined,
+      devCommand: options.devCommand ?? undefined,
       ...claudeAuth,
     });
 

--- a/packages/convex/convex/preview_jobs_worker.ts
+++ b/packages/convex/convex/preview_jobs_worker.ts
@@ -1323,6 +1323,9 @@ export async function runPreviewJob(
       const screenshotPayload: WorkerRunTaskScreenshots = {
         token: previewJwt,
         convexUrl,
+        // Pass environment scripts so Claude knows how to install deps and run dev server
+        installCommand: environment.maintenanceScript ?? undefined,
+        devCommand: environment.devScript ?? undefined,
       };
 
       try {

--- a/packages/shared/src/worker-schemas.ts
+++ b/packages/shared/src/worker-schemas.ts
@@ -186,12 +186,20 @@ export const WorkerExecResultSchema = z.object({
 export const WorkerStartScreenshotCollectionSchema = z.object({
   anthropicApiKey: z.string().min(1).optional(),
   outputPath: z.string().optional(),
+  /** Command to install dependencies (e.g., "bun install") */
+  installCommand: z.string().optional(),
+  /** Command to start the dev server (e.g., "bun run dev") */
+  devCommand: z.string().optional(),
 });
 
 export const WorkerRunTaskScreenshotsSchema = z.object({
   token: z.string(),
   anthropicApiKey: z.string().optional(),
   convexUrl: z.string().min(1).optional(),
+  /** Command to install dependencies (e.g., "bun install") */
+  installCommand: z.string().optional(),
+  /** Command to start the dev server (e.g., "bun run dev") */
+  devCommand: z.string().optional(),
 });
 
 // Server to Worker Events


### PR DESCRIPTION
## Summary
- Pass `environment.maintenanceScript` and `environment.devScript` from preview job configuration through to the Claude screenshot collector
- Adds `installCommand` and `devCommand` parameters across the entire call chain from Convex to the Claude prompt
- Enables Claude to know how to install dependencies and run the dev server when capturing screenshots

## Test plan
- [ ] Verify screenshot collection works with environments that have maintenance/dev scripts configured
- [ ] Verify screenshot collection still works for environments without these scripts (backwards compatible)