### PR TITLE
Handle cmux preview edge-case without rerun

### DIFF
--- a/packages/convex/convex/preview_jobs.ts
+++ b/packages/convex/convex/preview_jobs.ts
@@ -120,6 +120,7 @@ export const requestDispatch = internalAction({
       prNumber: payload.run.prNumber,
       headSha: payload.run.headSha?.slice(0, 7),
       status: payload.run.status,
+      taskRunId: payload.run.taskRunId,
     });
 
     // Check if there's already an active preview run for this PR
@@ -146,6 +147,51 @@ export const requestDispatch = internalAction({
         status: payload.run.status,
       });
       return;
+    }
+
+    // Check if the linked task run already has screenshots collected
+    // If so, skip the full preview job and just post the GitHub comment
+    if (payload.run.taskRunId) {
+      const taskRun = await ctx.runQuery(internal.taskRuns.getById, {
+        id: payload.run.taskRunId,
+      });
+
+      if (taskRun?.latestScreenshotSetId) {
+        console.log("[preview-jobs] Task run already has screenshots, using fast path", {
+          previewRunId: args.previewRunId,
+          taskRunId: payload.run.taskRunId,
+          screenshotSetId: taskRun.latestScreenshotSetId,
+        });
+
+        try {
+          await ctx.runMutation(internal.previewRuns.markDispatched, {
+            previewRunId: args.previewRunId,
+          });
+
+          // Post GitHub comment with existing screenshots (skip screenshot collection)
+          await ctx.scheduler.runAfter(
+            0,
+            internal.preview_jobs.postExistingScreenshots,
+            {
+              previewRunId: args.previewRunId,
+              taskRunId: payload.run.taskRunId,
+              screenshotSetId: taskRun.latestScreenshotSetId,
+            },
+          );
+
+          console.log("[preview-jobs] Scheduled fast path for existing screenshots", {
+            previewRunId: args.previewRunId,
+            taskRunId: payload.run.taskRunId,
+          });
+          return;
+        } catch (error) {
+          console.error("[preview-jobs] Failed to schedule fast path", {
+            previewRunId: args.previewRunId,
+            error,
+          });
+          // Fall through to regular dispatch
+        }
+      }
     }
 
     try {
@@ -193,5 +239,168 @@ export const executePreviewJob = internalAction({
   },
   handler: async (ctx, args) => {
     await runPreviewJob(ctx, args.previewRunId);
+  },
+});
+
+/**
+ * Fast path for posting GitHub comment when screenshots already exist.
+ *
+ * This is called when a task is created from cmux (not a preview job) and
+ * screenshots were already collected via the cmux screenshot collector.
+ * In this case, we skip the full preview job (no Morph instance, no screenshot
+ * collection) and directly post the GitHub comment with existing screenshots.
+ */
+export const postExistingScreenshots = internalAction({
+  args: {
+    previewRunId: v.id("previewRuns"),
+    taskRunId: v.id("taskRuns"),
+    screenshotSetId: v.id("taskRunScreenshotSets"),
+  },
+  handler: async (ctx, args) => {
+    const { previewRunId, taskRunId, screenshotSetId } = args;
+
+    console.log("[preview-jobs] postExistingScreenshots: Starting fast path", {
+      previewRunId,
+      taskRunId,
+      screenshotSetId,
+    });
+
+    // Get the preview run and config
+    const payload = await ctx.runQuery(internal.previewRuns.getRunWithConfig, {
+      previewRunId,
+    });
+
+    if (!payload?.run || !payload.config) {
+      console.error("[preview-jobs] postExistingScreenshots: Missing run/config", {
+        previewRunId,
+      });
+      await ctx.runMutation(internal.previewRuns.updateStatus, {
+        previewRunId,
+        status: "failed",
+      });
+      return;
+    }
+
+    const { run } = payload;
+
+    // Verify the screenshot set exists
+    const screenshotSet = await ctx.runQuery(
+      internal.github_pr_queries.getScreenshotSet,
+      { screenshotSetId }
+    );
+
+    if (!screenshotSet) {
+      console.error("[preview-jobs] postExistingScreenshots: Screenshot set not found", {
+        previewRunId,
+        screenshotSetId,
+      });
+      await ctx.runMutation(internal.previewRuns.updateStatus, {
+        previewRunId,
+        status: "failed",
+      });
+      return;
+    }
+
+    console.log("[preview-jobs] postExistingScreenshots: Found screenshot set", {
+      previewRunId,
+      screenshotSetId,
+      imageCount: screenshotSet.images.length,
+      status: screenshotSet.status,
+    });
+
+    // Post GitHub comment if we have installation ID
+    if (run.repoInstallationId) {
+      const taskRun = await ctx.runQuery(internal.taskRuns.getById, {
+        id: taskRunId,
+      });
+
+      if (!taskRun) {
+        console.error("[preview-jobs] postExistingScreenshots: Task run not found", {
+          previewRunId,
+          taskRunId,
+        });
+        await ctx.runMutation(internal.previewRuns.updateStatus, {
+          previewRunId,
+          status: "failed",
+        });
+        return;
+      }
+
+      const team = await ctx.runQuery(internal.teams.getByTeamIdInternal, {
+        teamId: taskRun.teamId,
+      });
+      const teamSlug = team?.slug ?? taskRun.teamId;
+      const workspaceUrl = `https://www.cmux.sh/${teamSlug}/task/${taskRun.taskId}`;
+      const devServerUrl = `https://www.cmux.sh/${teamSlug}/task/${taskRun.taskId}/run/${taskRunId}/browser`;
+
+      const commentResult = await ctx.runAction(
+        internal.github_pr_comments.postPreviewComment,
+        {
+          installationId: run.repoInstallationId,
+          repoFullName: run.repoFullName,
+          prNumber: run.prNumber,
+          screenshotSetId,
+          previewRunId,
+          workspaceUrl,
+          devServerUrl,
+        }
+      );
+
+      if (commentResult.ok) {
+        console.log("[preview-jobs] postExistingScreenshots: Successfully posted GitHub comment", {
+          previewRunId,
+          taskRunId,
+          commentUrl: commentResult.commentUrl,
+        });
+
+        // Mark task as completed since we're done
+        const task = await ctx.runQuery(internal.tasks.getByIdInternal, {
+          id: taskRun.taskId,
+        });
+
+        if (task && !task.isCompleted) {
+          await ctx.runMutation(internal.tasks.setCompletedInternal, {
+            taskId: task._id,
+            isCompleted: true,
+            crownEvaluationStatus: "succeeded",
+          });
+        }
+
+        // Mark task run as completed if not already
+        if (taskRun.status !== "completed" && taskRun.status !== "failed") {
+          await ctx.runMutation(internal.taskRuns.updateStatus, {
+            id: taskRunId,
+            status: "completed",
+          });
+        }
+
+        return;
+      } else {
+        console.error("[preview-jobs] postExistingScreenshots: Failed to post GitHub comment", {
+          previewRunId,
+          taskRunId,
+          error: commentResult.error,
+        });
+        await ctx.runMutation(internal.previewRuns.updateStatus, {
+          previewRunId,
+          status: "failed",
+        });
+        return;
+      }
+    } else {
+      // No GitHub installation ID - just mark as completed
+      console.log("[preview-jobs] postExistingScreenshots: No GitHub installation ID, marking completed", {
+        previewRunId,
+        taskRunId,
+      });
+
+      await ctx.runMutation(internal.previewRuns.updateStatus, {
+        previewRunId,
+        status: "completed",
+        screenshotSetId,
+      });
+
+      return;
+    }
   },
 });


### PR DESCRIPTION
i think there is a bug where if we start a task from cmux and it already does the screenshto collection via cmux, we don't start a preview job.. we will need to start the preview job but not go through the screenshot agent process (just start it and post the preview comment with the screenshot set that already exists)... we dont need to try it again... but we do need to still post a github comment if we do eventually open a github pr for that task... make sure that you handle this edgecase..