### PR TITLE
refactor: use Stack Auth OAuth token exclusively for GitHub API

### DIFF
--- a/apps/server/src/ghApi.ts
+++ b/apps/server/src/ghApi.ts
@@ -4,88 +4,240 @@ interface GitHubApiError extends Error {
   status?: number;
 }
 
+/**
+ * Create a GitHub API client with an explicit token.
+ * This should be preferred over ghApi when you have the token available.
+ */
+export function createGitHubApiClient(token: string) {
+  return {
+    async fetchGitHub(path: string, options: RequestInit = {}): Promise<Response> {
+      const response = await fetch(`https://api.github.com${path}`, {
+        ...options,
+        headers: {
+          'Accept': 'application/vnd.github.v3+json',
+          'Authorization': `Bearer ${token}`,
+          'User-Agent': 'cmux-app',
+          ...options.headers,
+        },
+      });
+
+      if (!response.ok) {
+        const error = new Error(`GitHub API error: ${response.statusText}`) as GitHubApiError;
+        error.status = response.status;
+        throw error;
+      }
+
+      return response;
+    },
+
+    async fetchAllPages<T>(path: string): Promise<T[]> {
+      const results: T[] = [];
+      let page = 1;
+      const perPage = 100;
+
+      while (true) {
+        const separator = path.includes('?') ? '&' : '?';
+        const response = await this.fetchGitHub(`${path}${separator}per_page=${perPage}&page=${page}`);
+        const data = await response.json() as T[];
+
+        if (data.length === 0) break;
+
+        results.push(...data);
+
+        if (data.length < perPage) break;
+        page++;
+      }
+
+      return results;
+    },
+
+    async getUser(): Promise<string> {
+      const response = await this.fetchGitHub('/user');
+      const data = await response.json();
+      return data.login;
+    },
+
+    async getUserRepos(): Promise<string[]> {
+      const repos = await this.fetchAllPages<{ full_name: string }>('/user/repos');
+      return repos.map(repo => repo.full_name);
+    },
+
+    async getUserOrgs(): Promise<string[]> {
+      const orgs = await this.fetchAllPages<{ login: string }>('/user/orgs');
+      return orgs.map(org => org.login);
+    },
+
+    async getOrgRepos(org: string): Promise<string[]> {
+      const repos = await this.fetchAllPages<{ full_name: string }>(`/orgs/${org}/repos`);
+      return repos.map(repo => repo.full_name);
+    },
+
+    async getRepoBranches(repo: string): Promise<string[]> {
+      const branches = await this.fetchAllPages<{ name: string }>(`/repos/${repo}/branches`);
+      return branches.map(branch => branch.name);
+    },
+
+    async getRepoBranchesWithActivity(repo: string): Promise<{
+      name: string;
+      lastCommitSha?: string;
+      lastActivityAt?: number;
+      isDefault?: boolean;
+    }[]> {
+      type BranchResp = { name: string; commit: { sha: string; url: string } };
+      const branches = await this.fetchAllPages<BranchResp>(`/repos/${repo}/branches`);
+
+      // Also get repo info to determine default branch
+      let defaultBranchName: string | undefined;
+      try {
+        const repoResp = await this.fetchGitHub(`/repos/${repo}`);
+        const repoData = await repoResp.json() as { default_branch?: string };
+        defaultBranchName = repoData.default_branch;
+      } catch {
+        // Ignore - we'll just not have default branch info
+      }
+
+      // Limit concurrent commit detail fetches to avoid rate spikes
+      const concurrency = 6;
+      const results: { name: string; lastCommitSha?: string; lastActivityAt?: number; isDefault?: boolean }[] = [];
+      let index = 0;
+
+      const runNext = async (): Promise<void> => {
+        const i = index++;
+        if (i >= branches.length) return;
+        const br = branches[i]!;
+        try {
+          // commit.url is absolute; extract path for fetchGitHub
+          const { pathname, search } = new URL(br.commit.url);
+          const resp = await this.fetchGitHub(`${pathname}${search ?? ""}`);
+          const data = (await resp.json()) as {
+            commit?: {
+              author?: { date?: string };
+              committer?: { date?: string };
+            };
+          };
+          const dateStr = data.commit?.committer?.date ?? data.commit?.author?.date;
+          const ts = dateStr ? Date.parse(dateStr) : undefined;
+          results[i] = {
+            name: br.name,
+            lastCommitSha: br.commit.sha,
+            lastActivityAt: ts,
+            isDefault: br.name === defaultBranchName,
+          };
+        } catch {
+          results[i] = {
+            name: br.name,
+            lastCommitSha: br.commit.sha,
+            isDefault: br.name === defaultBranchName,
+          };
+        }
+        await runNext();
+      };
+
+      await Promise.all(new Array(Math.min(concurrency, branches.length)).fill(0).map(() => runNext()));
+      return results.filter(Boolean);
+    },
+  };
+}
+
 // Helper functions for common GitHub API operations
+// Uses getGitHubTokenFromKeychain which tries Stack Auth OAuth first, then falls back to gh CLI
 export const ghApi = {
   // Fetch with GitHub authentication
   async fetchGitHub(path: string, options: RequestInit = {}): Promise<Response> {
     const token = await getGitHubTokenFromKeychain();
-    
+
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
       error.status = 401;
       throw error;
     }
 
-    const response = await fetch(`https://api.github.com${path}`, {
-      ...options,
-      headers: {
-        'Accept': 'application/vnd.github.v3+json',
-        'Authorization': `Bearer ${token}`,
-        'User-Agent': 'cmux-app',
-        ...options.headers,
-      },
-    });
-
-    if (!response.ok) {
-      const error = new Error(`GitHub API error: ${response.statusText}`) as GitHubApiError;
-      error.status = response.status;
-      throw error;
-    }
-
-    return response;
+    const client = createGitHubApiClient(token);
+    return client.fetchGitHub(path, options);
   },
 
   // Fetch all pages from GitHub API
   async fetchAllPages<T>(path: string): Promise<T[]> {
-    const results: T[] = [];
-    let page = 1;
-    const perPage = 100;
+    const token = await getGitHubTokenFromKeychain();
 
-    while (true) {
-      const separator = path.includes('?') ? '&' : '?';
-      const response = await this.fetchGitHub(`${path}${separator}per_page=${perPage}&page=${page}`);
-      const data = await response.json() as T[];
-      
-      if (data.length === 0) break;
-      
-      results.push(...data);
-      
-      if (data.length < perPage) break;
-      page++;
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
     }
 
-    return results;
+    const client = createGitHubApiClient(token);
+    return client.fetchAllPages<T>(path);
   },
 
   // Get current user
   async getUser(): Promise<string> {
-    const response = await this.fetchGitHub('/user');
-    const data = await response.json();
-    return data.login;
+    const token = await getGitHubTokenFromKeychain();
+
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
+    }
+
+    const client = createGitHubApiClient(token);
+    return client.getUser();
   },
 
   // Get user repos
   async getUserRepos(): Promise<string[]> {
-    const repos = await this.fetchAllPages<{ full_name: string }>('/user/repos');
-    return repos.map(repo => repo.full_name);
+    const token = await getGitHubTokenFromKeychain();
+
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
+    }
+
+    const client = createGitHubApiClient(token);
+    return client.getUserRepos();
   },
 
   // Get user organizations
   async getUserOrgs(): Promise<string[]> {
-    const orgs = await this.fetchAllPages<{ login: string }>('/user/orgs');
-    return orgs.map(org => org.login);
+    const token = await getGitHubTokenFromKeychain();
+
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
+    }
+
+    const client = createGitHubApiClient(token);
+    return client.getUserOrgs();
   },
 
   // Get organization repos
   async getOrgRepos(org: string): Promise<string[]> {
-    const repos = await this.fetchAllPages<{ full_name: string }>(`/orgs/${org}/repos`);
-    return repos.map(repo => repo.full_name);
+    const token = await getGitHubTokenFromKeychain();
+
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
+    }
+
+    const client = createGitHubApiClient(token);
+    return client.getOrgRepos(org);
   },
 
   // Get repo branches
   async getRepoBranches(repo: string): Promise<string[]> {
-    const branches = await this.fetchAllPages<{ name: string }>(`/repos/${repo}/branches`);
-    return branches.map(branch => branch.name);
+    const token = await getGitHubTokenFromKeychain();
+
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
+    }
+
+    const client = createGitHubApiClient(token);
+    return client.getRepoBranches(repo);
   },
 
   // Get repo branches with last activity timestamp
@@ -93,43 +245,17 @@ export const ghApi = {
     name: string;
     lastCommitSha?: string;
     lastActivityAt?: number;
+    isDefault?: boolean;
   }[]> {
-    type BranchResp = { name: string; commit: { sha: string; url: string } };
-    const branches = await this.fetchAllPages<BranchResp>(`/repos/${repo}/branches`);
+    const token = await getGitHubTokenFromKeychain();
 
-    // Limit concurrent commit detail fetches to avoid rate spikes
-    const concurrency = 6;
-    const results: { name: string; lastCommitSha?: string; lastActivityAt?: number }[] = [];
-    let index = 0;
+    if (!token) {
+      const error = new Error("No GitHub authentication found") as GitHubApiError;
+      error.status = 401;
+      throw error;
+    }
 
-    const runNext = async (): Promise<void> => {
-      const i = index++;
-      if (i >= branches.length) return;
-      const br = branches[i]!;
-      try {
-        // commit.url is absolute; extract path for fetchGitHub
-        const { pathname, search } = new URL(br.commit.url);
-        const resp = await this.fetchGitHub(`${pathname}${search ?? ""}`);
-        const data = (await resp.json()) as {
-          commit?: {
-            author?: { date?: string };
-            committer?: { date?: string };
-          };
-        };
-        const dateStr = data.commit?.committer?.date ?? data.commit?.author?.date;
-        const ts = dateStr ? Date.parse(dateStr) : undefined;
-        results[i] = {
-          name: br.name,
-          lastCommitSha: br.commit.sha,
-          lastActivityAt: ts,
-        };
-      } catch {
-        results[i] = { name: br.name, lastCommitSha: br.commit.sha };
-      }
-      await runNext();
-    };
-
-    await Promise.all(new Array(Math.min(concurrency, branches.length)).fill(0).map(() => runNext()));
-    return results.filter(Boolean);
+    const client = createGitHubApiClient(token);
+    return client.getRepoBranchesWithActivity(repo);
   },
 };

--- a/apps/server/src/ghApi.ts
+++ b/apps/server/src/ghApi.ts
@@ -1,4 +1,4 @@
-import { getGitHubTokenFromKeychain } from "./utils/getGitHubToken";
+import { getGitHubOAuthToken } from "./utils/getGitHubToken";
 
 interface GitHubApiError extends Error {
   status?: number;
@@ -140,11 +140,11 @@ export function createGitHubApiClient(token: string) {
 }
 
 // Helper functions for common GitHub API operations
-// Uses getGitHubTokenFromKeychain which tries Stack Auth OAuth first, then falls back to gh CLI
+// Uses getGitHubOAuthToken which gets the OAuth token from Stack Auth
 export const ghApi = {
   // Fetch with GitHub authentication
   async fetchGitHub(path: string, options: RequestInit = {}): Promise<Response> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -158,7 +158,7 @@ export const ghApi = {
 
   // Fetch all pages from GitHub API
   async fetchAllPages<T>(path: string): Promise<T[]> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -172,7 +172,7 @@ export const ghApi = {
 
   // Get current user
   async getUser(): Promise<string> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -186,7 +186,7 @@ export const ghApi = {
 
   // Get user repos
   async getUserRepos(): Promise<string[]> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -200,7 +200,7 @@ export const ghApi = {
 
   // Get user organizations
   async getUserOrgs(): Promise<string[]> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -214,7 +214,7 @@ export const ghApi = {
 
   // Get organization repos
   async getOrgRepos(org: string): Promise<string[]> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -228,7 +228,7 @@ export const ghApi = {
 
   // Get repo branches
   async getRepoBranches(repo: string): Promise<string[]> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;
@@ -247,7 +247,7 @@ export const ghApi = {
     lastActivityAt?: number;
     isDefault?: boolean;
   }[]> {
-    const token = await getGitHubTokenFromKeychain();
+    const token = await getGitHubOAuthToken();
 
     if (!token) {
       const error = new Error("No GitHub authentication found") as GitHubApiError;

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -50,7 +50,7 @@ import { generatePRInfoAndBranchNames } from "./utils/branchNameGenerator";
 import { getConvex } from "./utils/convexClient";
 import { ensureRunWorktreeAndBranch } from "./utils/ensureRunWorktree";
 import { serverLogger } from "./utils/fileLogger";
-import { getGitHubTokenFromKeychain } from "./utils/getGitHubToken";
+import { getGitHubOAuthToken } from "./utils/getGitHubToken";
 import { createGitHubApiClient } from "./ghApi";
 import { createDraftPr, fetchPrDetail } from "./utils/githubPr";
 import { getOctokit } from "./utils/octokit";
@@ -1495,7 +1495,7 @@ export function setupSocketHandlers(
           return;
         }
 
-        const githubToken = await getGitHubTokenFromKeychain();
+        const githubToken = await getGitHubOAuthToken();
         if (!githubToken) {
           callback({
             success: false,
@@ -1608,7 +1608,7 @@ export function setupSocketHandlers(
         const { run, task, branchName, baseBranch } =
           await ensureRunWorktreeAndBranch(taskRunId, safeTeam);
 
-        const githubToken = await getGitHubTokenFromKeychain();
+        const githubToken = await getGitHubOAuthToken();
         if (!githubToken) {
           return callback({
             success: false,
@@ -2247,7 +2247,7 @@ Please address the issue mentioned in the comment above.`;
         const { repo } = GitHubFetchBranchesSchema.parse(data);
 
         // Get OAuth token from Stack Auth for authenticated GitHub API access
-        const githubToken = await getGitHubTokenFromKeychain();
+        const githubToken = await getGitHubOAuthToken();
         if (!githubToken) {
           callback({
             success: false,
@@ -2322,7 +2322,7 @@ Please address the issue mentioned in the comment above.`;
           return;
         }
 
-        const githubToken = await getGitHubTokenFromKeychain();
+        const githubToken = await getGitHubOAuthToken();
         if (!githubToken) {
           callback({
             success: false,

--- a/apps/server/src/utils/dockerGitSetup.ts
+++ b/apps/server/src/utils/dockerGitSetup.ts
@@ -3,14 +3,14 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { serverLogger } from "./fileLogger";
-import { getGitHubTokenFromKeychain } from "./getGitHubToken";
+import { getGitHubOAuthToken } from "./getGitHubToken";
 
 export async function setupGitCredentialsForDocker(
   instanceId: string,
   _convex?: ConvexHttpClient
 ): Promise<string | null> {
   try {
-    const githubToken = await getGitHubTokenFromKeychain();
+    const githubToken = await getGitHubOAuthToken();
     if (!githubToken) {
       return null;
     }

--- a/apps/server/src/utils/getGitHubToken.ts
+++ b/apps/server/src/utils/getGitHubToken.ts
@@ -1,15 +1,11 @@
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import { getAuthHeaderJson } from "./requestContext";
-import { env, getWwwBaseUrl } from "./server-env";
-
-const execAsync = promisify(exec);
+import { getWwwBaseUrl } from "./server-env";
 
 /**
  * Get GitHub OAuth token from Stack Auth via the www API.
  * This uses the current user's connected GitHub account.
  */
-async function getGitHubTokenFromStackAuth(): Promise<string | null> {
+export async function getGitHubOAuthToken(): Promise<string | null> {
   const authHeaderJson = getAuthHeaderJson();
   if (!authHeaderJson) {
     return null;
@@ -25,62 +21,28 @@ async function getGitHubTokenFromStackAuth(): Promise<string | null> {
     });
 
     if (!response.ok) {
-      console.error(`[getGitHubToken] Stack Auth API returned ${response.status}`);
+      console.error(`[getGitHubOAuthToken] Stack Auth API returned ${response.status}`);
       return null;
     }
 
     const data = (await response.json()) as { accessToken: string | null; error: string | null };
     if (data.error) {
-      console.warn(`[getGitHubToken] Stack Auth error: ${data.error}`);
+      console.warn(`[getGitHubOAuthToken] Stack Auth error: ${data.error}`);
       return null;
     }
 
     return data.accessToken;
   } catch (error) {
-    console.error("[getGitHubToken] Failed to get token from Stack Auth:", error);
+    console.error("[getGitHubOAuthToken] Failed to get token from Stack Auth:", error);
     return null;
   }
 }
 
-/**
- * Get GitHub token from local gh CLI.
- * Only used in non-web (Electron) mode.
- */
-async function getGitHubTokenFromGhCli(): Promise<string | null> {
-  try {
-    const { stdout: ghToken } = await execAsync(
-      "bash -lc 'gh auth token 2>/dev/null'"
-    );
-    if (ghToken.trim()) {
-      return ghToken.trim();
-    }
-  } catch {
-    // gh not available or not authenticated
-  }
-  return null;
-}
-
-export async function getGitHubTokenFromKeychain(): Promise<string | null> {
-  // Always try Stack Auth first (works in both web and electron mode)
-  const stackAuthToken = await getGitHubTokenFromStackAuth();
-  if (stackAuthToken) {
-    return stackAuthToken;
-  }
-
-  // In web mode, don't fall back to gh CLI (it won't be available)
-  if (env.NEXT_PUBLIC_WEB_MODE) {
-    return null;
-  }
-
-  // Fall back to gh CLI in non-web mode
-  return getGitHubTokenFromGhCli();
-}
-
-export async function getGitCredentialsFromHost(): Promise<{
+export async function getGitCredentials(): Promise<{
   username?: string;
   password?: string;
 } | null> {
-  const token = await getGitHubTokenFromKeychain();
+  const token = await getGitHubOAuthToken();
 
   if (token) {
     // GitHub tokens use 'oauth' as username

--- a/apps/server/src/utils/markPrReady.test.ts
+++ b/apps/server/src/utils/markPrReady.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getGitHubTokenFromKeychain } from "./getGitHubToken";
+import { getGitHubOAuthToken } from "./getGitHubToken";
 import { markPrReady } from "./markPrReady";
 import { getOctokit } from "./octokit";
 
@@ -15,7 +15,7 @@ describe.skip("markPrReady E2E Tests", () => {
 
   beforeAll(async () => {
     // Get GitHub token
-    githubToken = (await getGitHubTokenFromKeychain()) || "";
+    githubToken = (await getGitHubOAuthToken()) || "";
     if (!githubToken) {
       throw new Error("GitHub token not found. Please configure it first.");
     }

--- a/apps/server/src/utils/refreshGitHubData.ts
+++ b/apps/server/src/utils/refreshGitHubData.ts
@@ -1,8 +1,8 @@
 import { api } from "@cmux/convex/api";
-import { ghApi } from "../ghApi";
-import { listRemoteBranches } from "../native/git";
+import { createGitHubApiClient, ghApi } from "../ghApi";
 import { getConvex } from "./convexClient";
 import { serverLogger } from "./fileLogger";
+import { getGitHubTokenFromKeychain } from "./getGitHubToken";
 
 export async function refreshGitHubData({
   teamSlugOrId,
@@ -91,22 +91,18 @@ export async function refreshBranchesForRepo(
   teamSlugOrId: string
 ) {
   try {
-    // Prefer local git via Rust (gitoxide) for branch listing, sorted by recency
-    let branches: {
-      name: string;
-      lastCommitSha?: string;
-      lastActivityAt?: number;
-    }[];
-    try {
-      branches = await listRemoteBranches({ repoFullName: repo });
-    } catch (e) {
-      // Fallback to GitHub API if native unavailable or errors
-      const nativeMsg = e instanceof Error ? e.message : String(e);
+    // Get OAuth token for authenticated GitHub API access
+    const githubToken = await getGitHubTokenFromKeychain();
+    if (!githubToken) {
       serverLogger.info(
-        `Native branch listing failed for ${repo}; falling back to GitHub API: ${nativeMsg}`
+        "No GitHub authentication found, skipping branch refresh"
       );
-      branches = await ghApi.getRepoBranchesWithActivity(repo);
+      return [];
     }
+
+    // Use GitHub API with OAuth token for branch listing (works for private repos)
+    const ghClient = createGitHubApiClient(githubToken);
+    const branches = await ghClient.getRepoBranchesWithActivity(repo);
 
     if (branches.length > 0) {
       await getConvex().mutation(api.github.bulkUpsertBranchesWithActivity, {

--- a/apps/server/src/utils/refreshGitHubData.ts
+++ b/apps/server/src/utils/refreshGitHubData.ts
@@ -2,7 +2,7 @@ import { api } from "@cmux/convex/api";
 import { createGitHubApiClient, ghApi } from "../ghApi";
 import { getConvex } from "./convexClient";
 import { serverLogger } from "./fileLogger";
-import { getGitHubTokenFromKeychain } from "./getGitHubToken";
+import { getGitHubOAuthToken } from "./getGitHubToken";
 
 export async function refreshGitHubData({
   teamSlugOrId,
@@ -92,7 +92,7 @@ export async function refreshBranchesForRepo(
 ) {
   try {
     // Get OAuth token for authenticated GitHub API access
-    const githubToken = await getGitHubTokenFromKeychain();
+    const githubToken = await getGitHubOAuthToken();
     if (!githubToken) {
       serverLogger.info(
         "No GitHub authentication found, skipping branch refresh"

--- a/apps/server/src/vscode/DockerVSCodeInstance.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.ts
@@ -8,7 +8,7 @@ import { getDockerSocketCandidates } from "@cmux/shared/providers/common/check-d
 import { getConvex } from "../utils/convexClient";
 import { cleanupGitCredentials } from "../utils/dockerGitSetup";
 import { dockerLogger } from "../utils/fileLogger";
-import { getGitHubTokenFromKeychain } from "../utils/getGitHubToken";
+import { getGitHubOAuthToken } from "../utils/getGitHubToken";
 import { getAuthToken, runWithAuthToken } from "../utils/requestContext";
 import {
   VSCodeInstance,
@@ -815,7 +815,7 @@ export class DockerVSCodeInstance extends VSCodeInstance {
       }
 
       // Get GitHub token from host
-      const githubToken = await getGitHubTokenFromKeychain();
+      const githubToken = await getGitHubOAuthToken();
       if (!githubToken) {
         dockerLogger.info(
           "No GitHub token found on host (Convex, gh, or keychain) - skipping gh auth setup"
@@ -1069,7 +1069,7 @@ export class DockerVSCodeInstance extends VSCodeInstance {
 
     try {
       // Get GitHub token from host
-      const githubToken = await getGitHubTokenFromKeychain();
+      const githubToken = await getGitHubOAuthToken();
 
       // Read SSH keys if available
       const homeDir = os.homedir();


### PR DESCRIPTION
## Summary

- Remove `getGitHubTokenFromKeychain` and its fallback to local `gh` CLI credentials
- Rename to `getGitHubOAuthToken` for clarity about the authentication source
- Update `github-fetch-branches` socket handler to use GitHub API instead of native git (which doesn't authenticate)
- Update `refreshBranchesForRepo` to use GitHub API with OAuth token
- All GitHub API calls now consistently use the user's Stack Auth OAuth token

This ensures:
1. Consistent authentication through Stack Auth across all GitHub operations
2. No dependency on local `gh` CLI credentials
3. Private repos can be accessed when the user has granted GitHub OAuth permissions

## Test plan

- [ ] Verify GitHub OAuth connection works in Stack Auth settings
- [ ] Test fetching branches for a private repo
- [ ] Test creating draft PRs
- [ ] Test syncing PR state
- [ ] Test merging branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)