### PR TITLE
Investigate and fix workspace flicker in VSCode

### DIFF
--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -231,35 +231,9 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
     };
   }, []);
 
-  // Control iframe wrapper visibility based on this panel's expansion state
-  useEffect(() => {
-    if (typeof document === "undefined" || !type) return;
-
-    // Find the container div for this panel's content
-    const container = document.querySelector(`[data-panel-position="${position}"]`);
-    if (!container) return;
-
-    // Find any iframe target within this panel
-    const iframeTarget = container.querySelector('[data-iframe-target]') as HTMLElement;
-    if (!iframeTarget) return;
-
-    const iframeKey = iframeTarget.getAttribute('data-iframe-target');
-    if (!iframeKey) return;
-
-    // Find the corresponding iframe wrapper
-    const wrapper = document.querySelector(`[data-iframe-key="${iframeKey}"]`) as HTMLElement;
-    if (!wrapper) return;
-
-    if (isAnyPanelExpanded && !isExpanded) {
-      // Another panel is expanded - hide this iframe
-      wrapper.style.visibility = "hidden";
-      wrapper.style.pointerEvents = "none";
-    } else {
-      // This panel is expanded OR no panel is expanded - show iframe
-      wrapper.style.visibility = "visible";
-      wrapper.style.pointerEvents = "auto";
-    }
-  }, [type, position, isExpanded, isAnyPanelExpanded]);
+  // NOTE: iframe wrapper visibility is now controlled solely by PersistentIframe component
+  // via isExpanded and isAnyPanelExpanded props. Removed duplicate visibility management
+  // here to prevent flickering caused by competing useEffect hooks.
 
   const handleDragStart = useCallback((e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = "move";

--- a/apps/client/src/components/persistent-iframe.tsx
+++ b/apps/client/src/components/persistent-iframe.tsx
@@ -102,9 +102,15 @@ export function PersistentIframe({
   const [, forceRender] = useState(0);
   const loadTimeoutRef = useRef<number | null>(null);
   const preflightErrorRef = useRef<string | null>(null);
+  const previousSrcRef = useRef<string | null>(null);
 
+  // Only reset to loading when the src actually changes (not on initial mount with same src)
+  // This prevents unnecessary flickering when the component re-renders
   useEffect(() => {
-    setStatus("loading");
+    if (previousSrcRef.current !== null && previousSrcRef.current !== src) {
+      setStatus("loading");
+    }
+    previousSrcRef.current = src;
   }, [persistKey, src]);
 
   const clearLoadTimeout = useCallback(() => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -3,7 +3,7 @@ import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { convexQuery } from "@convex-dev/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import z from "zod";
 import type { PersistentIframeStatus } from "@/components/persistent-iframe";
 import { PersistentWebView } from "@/components/persistent-webview";
@@ -100,8 +100,18 @@ function VSCodeComponent() {
 
   const [iframeStatus, setIframeStatus] =
     useState<PersistentIframeStatus>("loading");
+  const previousWorkspaceUrlRef = useRef<string | null>(null);
+
+  // Only reset to loading when the workspaceUrl actually changes (not on re-renders)
+  // This prevents unnecessary flickering, especially for local workspaces
   useEffect(() => {
-    setIframeStatus("loading");
+    if (
+      previousWorkspaceUrlRef.current !== null &&
+      previousWorkspaceUrlRef.current !== workspaceUrl
+    ) {
+      setIframeStatus("loading");
+    }
+    previousWorkspaceUrlRef.current = workspaceUrl;
   }, [workspaceUrl]);
 
   const onLoad = useCallback(() => {


### PR DESCRIPTION
can you investigate why the vscode instances for local workspaces keep flickering. there is some sort of refresh state that may be caused by some useEffect. aalso it could be because we show the git diff and preview before on the sidebar but actively filter it out? those tabs should just never show in the first place? it should just be loading