### PR TITLE
fix(global-proxy): WebSocket compatibility with HTTP/2 load balancers

### DIFF
--- a/apps/global-proxy/Cargo.lock
+++ b/apps/global-proxy/Cargo.lock
@@ -470,6 +470,7 @@ dependencies = [
  "hyper-rustls",
  "lol_html",
  "reqwest",
+ "rustls 0.21.12",
  "serde",
  "serde_json",
  "thiserror",

--- a/apps/global-proxy/Cargo.toml
+++ b/apps/global-proxy/Cargo.toml
@@ -9,6 +9,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.24", default-features = false, features = ["http1", "tokio-runtime", "webpki-roots"] }
+rustls = { version = "0.21", default-features = false }
 lol_html = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }


### PR DESCRIPTION
## Summary

Fixes WebSocket connections through the global proxy when accessed via Cloud Run/HTTP/2 load balancers.

### Changes

1. **Force HTTP/1.1 ALPN for outbound connections** (first commit)
   - WebSocket upgrade requires HTTP/1.1 - doesn't work over HTTP/2 since Connection/Upgrade headers are stripped
   - Explicitly sets `alpn_protocols = ["http/1.1"]` in the TLS config for connections to upstream servers

2. **Detect WebSocket via Sec-WebSocket-Key header** (second commit)
   - When requests come through HTTP/2 load balancers (like Cloud Run), the hop-by-hop headers (Connection, Upgrade) are stripped
   - However, WebSocket-specific headers (Sec-WebSocket-Key, Sec-WebSocket-Version) are preserved
   - Now detects WebSocket requests by presence of `Sec-WebSocket-Key` header as fallback
   - Ensures Connection/Upgrade headers are added to both incoming and backend requests

### Why this is needed

When a browser connects to cmux.app:
1. Browser → Cloud Run Load Balancer: ALPN negotiates HTTP/2
2. HTTP/2 strips `Connection: Upgrade` and `Upgrade: websocket` headers (hop-by-hop headers)
3. Cloud Run converts HTTP/2 → HTTP/1.1 for the container
4. Proxy receives request without upgrade headers but WITH Sec-WebSocket-Key/Version
5. Previously: Request wasn't detected as WebSocket, returned 404
6. Now: Request is detected via Sec-WebSocket-Key, WebSocket tunnel established

## Test plan

- [x] All 26 existing proxy tests pass
- [x] Standard HTTP/1.1 WebSocket upgrade continues to work
- [x] Build and format checks pass