### PR TITLE
Add ignore rule for beads socket lock

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -9,6 +9,7 @@ daemon.lock
 daemon.log
 daemon.pid
 bd.sock
+bd.sock.*
 
 # Merge artifacts
 beads.base.jsonl
@@ -20,5 +21,3 @@ beads.left.meta.json
 !issues.jsonl
 !metadata.json
 !config.json
-
-.beads/bd.sock.startlock


### PR DESCRIPTION
clone https://github.com/steveyegge/beads and lmk what default gitignore should bei see .beads/bd.sock.startlock in my git status like temporarily