### PR TITLE
Use OAuth token for Claude Code GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/packages/shared/src/apiKeys.ts
+++ b/packages/shared/src/apiKeys.ts
@@ -6,6 +6,12 @@ export const ANTHROPIC_API_KEY: AgentConfigApiKey = {
   description: "Anthropic API Key",
 };
 
+export const CLAUDE_CODE_OAUTH_TOKEN: AgentConfigApiKey = {
+  envVar: "CLAUDE_CODE_OAUTH_TOKEN",
+  displayName: "Claude Code OAuth Token",
+  description: "OAuth token for Claude Code authentication",
+};
+
 export const OPENAI_API_KEY: AgentConfigApiKey = {
   envVar: "OPENAI_API_KEY",
   displayName: "OpenAI API Key",

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -1,5 +1,5 @@
 import type { AgentConfig } from "../../agentConfig";
-import { ANTHROPIC_API_KEY } from "../../apiKeys";
+import { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN } from "../../apiKeys";
 import { checkClaudeRequirements } from "./check-requirements";
 import { startClaudeCompletionDetector } from "./completion-detector";
 import {
@@ -24,7 +24,7 @@ export const CLAUDE_SONNET_4_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -42,7 +42,7 @@ export const CLAUDE_OPUS_4_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -60,7 +60,7 @@ export const CLAUDE_OPUS_4_1_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -78,7 +78,7 @@ export const CLAUDE_OPUS_4_5_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -96,7 +96,7 @@ export const CLAUDE_SONNET_4_5_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -114,7 +114,7 @@ export const CLAUDE_HAIKU_4_5_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };


### PR DESCRIPTION
## Summary
- Switch from `ANTHROPIC_API_KEY` to `CLAUDE_CODE_OAUTH_TOKEN` for authenticating the Claude Code GitHub Action

## Test plan
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` as a repository secret
- [ ] Trigger the workflow by mentioning `@claude` in an issue/PR