### PR TITLE
fix(global-proxy): force HTTP/1.1 ALPN for WebSocket compatibility

### DIFF
--- a/apps/global-proxy/Cargo.lock
+++ b/apps/global-proxy/Cargo.lock
@@ -470,6 +470,7 @@ dependencies = [
  "hyper-rustls",
  "lol_html",
  "reqwest",
+ "rustls 0.21.12",
  "serde",
  "serde_json",
  "thiserror",

--- a/apps/global-proxy/Cargo.toml
+++ b/apps/global-proxy/Cargo.toml
@@ -9,6 +9,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.24", default-features = false, features = ["http1", "tokio-runtime", "webpki-roots"] }
+rustls = { version = "0.21", default-features = false }
 lol_html = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }


### PR DESCRIPTION
## Summary
- Fixes WebSocket connections through the global proxy
- Uses **dual HTTP clients** for optimal protocol selection:
  - Regular HTTP requests: HTTP/2 (`h2` + `http/1.1` ALPN) for multiplexing performance
  - WebSocket connections: HTTP/1.1-only client (required for upgrade handshake)

## Root Cause
The proxy was not using HTTP/1.1 for WebSocket connections to morph backend. When ALPN negotiates HTTP/2, the `Connection` and `Upgrade` headers are stripped (they're hop-by-hop in HTTP/2), breaking WebSocket handshakes.

Cloud Run logs showed:
- `upstream websocket request error err=connection error: Connection reset by peer (os error 104)` - Backend rejecting HTTP/2 WebSocket
- `websocket tunnel error err=unexpected end of file` - Tunnel failing after handshake

## Changes
- Added `ws_client` field to `AppState` for HTTP/1.1-only WebSocket connections
- Regular `client` now advertises `h2` + `http/1.1` ALPN for HTTP/2 performance
- `handle_websocket` uses `ws_client` instead of `client`

## Test plan
- [ ] Merge and deploy to Cloud Run
- [ ] Test WebSocket connection to `wss://cmux-8ttwgidu-base-39378.cmux.app/`
- [ ] Verify OpenVSCode editor connects successfully
- [ ] Verify regular HTTP requests still work (no performance regression)