### PR TITLE
fix(global-proxy): use HTTP/1.1 only for all requests

### DIFF
--- a/apps/global-proxy/src/lib.rs
+++ b/apps/global-proxy/src/lib.rs
@@ -104,15 +104,15 @@ pub async fn spawn_proxy(config: ProxyConfig) -> Result<ProxyHandle, ProxyError>
     listener.set_nonblocking(true)?;
     let local_addr = listener.local_addr()?;
 
-    // HTTP/2-capable client for regular requests (better performance via multiplexing)
+    // HTTP/1.1-only client for regular requests (matches original behavior)
+    // Note: hyper has issues with HTTP/2 to morph backend, so we stick with HTTP/1.1
     let mut http_connector = HttpConnector::new();
     http_connector.enforce_http(false);
     let mut tls_config = ClientConfig::builder()
         .with_safe_defaults()
         .with_webpki_roots()
         .with_no_client_auth();
-    // Advertise both HTTP/2 and HTTP/1.1 for regular requests
-    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
     let https: HttpsConnector<HttpConnector> = (http_connector, tls_config).into();
     let client: HttpClient = Client::builder().build(https);
 


### PR DESCRIPTION
## Summary
- Fix "Upstream fetch failed" errors caused by the previous PR's HTTP/2 ALPN change
- Revert to HTTP/1.1 only for regular requests (matching original behavior)
- Keep HTTP/1.1 only for WebSocket connections (for upgrade compatibility)

## Problem
PR #1226 inadvertently changed the regular HTTP client from HTTP/1.1 only to HTTP/2 + HTTP/1.1. This caused the morph backend connections to fail with hyper's HTTP/2 implementation.

## Test plan
- [ ] Verify `https://cmux-8ttwgidu-base-39378.cmux.app/?folder=/root/workspace` loads successfully after deployment
- [ ] Verify WebSocket connections still work