### PR TITLE
Hide cmdk after sign-out enter

### DIFF
--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -1379,6 +1379,7 @@ export function CommandBar({
           }
         }
       } else if (value === "sign-out") {
+        closeCommand();
         try {
           if (stackUser) {
             await stackUser.signOut({
@@ -1390,8 +1391,8 @@ export function CommandBar({
         } catch (error) {
           console.error("Sign out failed", error);
           toast.error("Unable to sign out");
-          return;
         }
+        return;
       } else if (value === "theme-light") {
         setTheme("light");
       } else if (value === "theme-dark") {


### PR DESCRIPTION
cmd+k after pressing enter on sign out, we need to hide the cmdk interface. rn it will go back to main one.