### PR TITLE
fix: remove honoIntegration from Sentry config

### DIFF
--- a/apps/www/sentry.server.config.ts
+++ b/apps/www/sentry.server.config.ts
@@ -3,14 +3,16 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { honoIntegration } from "@sentry/node";
 import { SENTRY_RELEASE } from "@/lib/sentry-release";
 
 Sentry.init({
   dsn: "https://96214f39aa409867381a22a79ff3e6a4@o4507547940749312.ingest.us.sentry.io/4510308518854656",
   release: SENTRY_RELEASE,
 
-  integrations: [honoIntegration()],
+  // Note: honoIntegration() is NOT used here because it requires Node's --import flag
+  // for ESM loader hooks, which is not supported in Vercel/Next.js serverless functions.
+  // Instead, we use setupHonoErrorHandler(app) in hono-app.ts for manual error capture.
+  // See: https://docs.sentry.io/platforms/javascript/guides/hono/install/esm/
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/apps/www/sentry.server.config.ts
+++ b/apps/www/sentry.server.config.ts
@@ -1,26 +1,10 @@
-// This file configures the initialization of Sentry on the server.
-// The config you add here will be used whenever the server handles a request.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from "@sentry/nextjs";
 import { SENTRY_RELEASE } from "@/lib/sentry-release";
 
 Sentry.init({
   dsn: "https://96214f39aa409867381a22a79ff3e6a4@o4507547940749312.ingest.us.sentry.io/4510308518854656",
   release: SENTRY_RELEASE,
-
-  // Note: honoIntegration() is NOT used here because it requires Node's --import flag
-  // for ESM loader hooks, which is not supported in Vercel/Next.js serverless functions.
-  // Instead, we use setupHonoErrorHandler(app) in hono-app.ts for manual error capture.
-  // See: https://docs.sentry.io/platforms/javascript/guides/hono/install/esm/
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
   enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
 });


### PR DESCRIPTION
## Summary
- Remove `honoIntegration()` from Sentry server config to fix the "[Sentry] hono is not instrumented" warning in Vercel logs
- `honoIntegration` requires Node's `--import` flag for ESM loader hooks, which Vercel/Next.js serverless functions don't support

## Test plan
- [ ] Deploy to Vercel preview and verify the warning no longer appears in logs
- [ ] Verify errors are still captured via `setupHonoErrorHandler` in hono-app.ts