### PR TITLE
Fix native select colors in snapshot tests

### DIFF
--- a/configs/gtk-2.0/gtkrc
+++ b/configs/gtk-2.0/gtkrc
@@ -1,0 +1,15 @@
+gtk-theme-name="Adwaita"
+gtk-icon-theme-name="Adwaita"
+gtk-font-name="Sans 10"
+gtk-cursor-theme-name="Adwaita"
+gtk-cursor-theme-size=24
+gtk-toolbar-style=GTK_TOOLBAR_BOTH_HORIZ
+gtk-toolbar-icon-size=GTK_ICON_SIZE_LARGE_TOOLBAR
+gtk-button-images=1
+gtk-menu-images=1
+gtk-enable-event-sounds=0
+gtk-enable-input-feedback-sounds=0
+gtk-xft-antialias=1
+gtk-xft-hinting=1
+gtk-xft-hintstyle="hintslight"
+gtk-xft-rgba="rgb"

--- a/configs/gtk-3.0/settings.ini
+++ b/configs/gtk-3.0/settings.ini
@@ -1,0 +1,17 @@
+[Settings]
+gtk-theme-name=Adwaita
+gtk-icon-theme-name=Adwaita
+gtk-font-name=Sans 10
+gtk-cursor-theme-name=Adwaita
+gtk-cursor-theme-size=24
+gtk-toolbar-style=GTK_TOOLBAR_BOTH_HORIZ
+gtk-toolbar-icon-size=GTK_ICON_SIZE_LARGE_TOOLBAR
+gtk-button-images=1
+gtk-menu-images=1
+gtk-enable-event-sounds=0
+gtk-enable-input-feedback-sounds=0
+gtk-xft-antialias=1
+gtk-xft-hinting=1
+gtk-xft-hintstyle=hintslight
+gtk-xft-rgba=rgb
+gtk-application-prefer-dark-theme=0

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -393,6 +393,8 @@ def _build_preset_plans(args: argparse.Namespace) -> tuple[SnapshotPresetPlan, .
         memory_mib=args.standard_memory,
         disk_size_mib=args.standard_disk_size,
     )
+    if getattr(args, "standard_only", False):
+        return (standard_plan,)
     boosted_plan = SnapshotPresetPlan(
         preset_id=_preset_id_from_resources(
             args.boosted_vcpus, args.boosted_memory, args.boosted_disk_size
@@ -2716,6 +2718,11 @@ def parse_args() -> argparse.Namespace:
         choices=(IDE_PROVIDER_CODER, IDE_PROVIDER_OPENVSCODE),
         default=DEFAULT_IDE_PROVIDER,
         help=f"IDE provider to install (default: {DEFAULT_IDE_PROVIDER})",
+    )
+    parser.add_argument(
+        "--standard-only",
+        action="store_true",
+        help="Only build the standard preset (skip boosted)",
     )
     return parser.parse_args()
 

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -919,7 +919,10 @@ async def task_install_base_packages(ctx: TaskContext) -> None:
             gh \
             zsh \
             zsh-autosuggestions \
-            ripgrep
+            ripgrep \
+            adwaita-icon-theme \
+            gnome-themes-extra \
+            gtk2-engines-pixbuf
 
 
         # Download and install Chrome
@@ -1533,13 +1536,6 @@ async def task_configure_openbox(ctx: TaskContext) -> None:
         f"""
         set -eux
 
-        # Install GTK theme packages for proper native widget styling (select dropdowns, etc.)
-        DEBIAN_FRONTEND=noninteractive apt-get update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            adwaita-icon-theme \
-            gnome-themes-extra \
-            gtk2-engines-pixbuf
-
         # Install openbox menu configuration
         mkdir -p /root/.config/openbox
         install -Dm0644 {repo}/configs/openbox/menu.xml /root/.config/openbox/menu.xml
@@ -1561,8 +1557,6 @@ async def task_configure_openbox(ctx: TaskContext) -> None:
 GTK_THEME=Adwaita
 GTK2_RC_FILES=/etc/gtk-2.0/gtkrc
 EOF
-
-        rm -rf /var/lib/apt/lists/*
         """
     )
     await ctx.run("configure-openbox", cmd)


### PR DESCRIPTION
for openbox, when i have a website with a native <select> the text colors/backgrounds suck. it's like white on white until you hover on it. help me update @scripts/snapshot.py to fix it, and set up a fake html page for me to test it.