### PR TITLE
Use morph vscode URLs in web mode

### DIFF
--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -2,6 +2,7 @@ import {
   LOCAL_VSCODE_PLACEHOLDER_HOST,
   isLoopbackHostname,
 } from "@cmux/shared";
+import { env } from "../client-env";
 
 const MORPH_HOST_REGEX = /^port-(\d+)-morphvm-([^.]+)\.http\.cloud\.morph\.so$/;
 
@@ -115,6 +116,11 @@ export function toProxyWorkspaceUrl(
     return normalizedUrl;
   }
 
+  // In web mode, use the Morph URLs directly without proxy rewriting
+  if (env.NEXT_PUBLIC_WEB_MODE) {
+    return normalizedUrl;
+  }
+
   const scope = "base"; // Default scope
   const proxiedUrl = new URL(components.url.toString());
   proxiedUrl.hostname = `cmux-${components.morphId}-${scope}-${components.port}.cmux.app`;
@@ -167,6 +173,15 @@ export function toMorphXtermBaseUrl(sourceUrl: string): string | null {
 
   if (!components) {
     return null;
+  }
+
+  // In web mode, use the Morph URLs directly without proxy rewriting
+  if (env.NEXT_PUBLIC_WEB_MODE) {
+    const morphUrl = createMorphPortUrl(components, 39383);
+    morphUrl.pathname = "/";
+    morphUrl.search = "";
+    morphUrl.hash = "";
+    return morphUrl.toString();
   }
 
   const scope = "base";

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",


### PR DESCRIPTION
if we're in web mode (NEXT_PUBLIC_WEB_MODE=true) for the vscode iframes, we don't want to rewrite the vscode urls to use the cmux.app proxy, instead we want to just use the morph vscode urls.