### PR TITLE
Post one GitHub comment and update it

### DIFF
--- a/apps/worker/src/screenshotCollector/claudeScreenshotCollector.ts
+++ b/apps/worker/src/screenshotCollector/claudeScreenshotCollector.ts
@@ -212,9 +212,14 @@ If no UI changes exist: Set hasUiChanges=false, take ZERO screenshots, and expla
 <PHASE_2_CAPTURE>
 If UI changes exist, capture screenshots:
 
-1. Read CLAUDE.md or AGENTS.md (may be one level deeper) and install dependencies if needed
-2. Run tmux ls to check if the dev server is running. Dev server should be running on default. Otherwise, start the dev server. Look for instructions in README.md, CLAUDE.md, or framework-specific files (package.json, Makefile, Gemfile, composer.json, requirements.txt, etc.). Use dev_command above if provided.
-3. Look for a list of ports you need to check in the repo. Wait for the server to be ready (curl -s -o /dev/null -w "%{http_code}" http://localhost:PORT should return 200)
+1. FIRST, check if the dev server is ALREADY RUNNING:
+   - Run \`tmux list-windows\` and \`tmux capture-pane -p -t <window>\` to see running processes and their logs
+   - Check if there's a dev server process starting up or already running in any tmux window
+   - The dev server is typically started automatically in this environment - BE PATIENT and monitor the logs
+   - If you see the server is starting/compiling, WAIT for it to finish - do NOT kill it or restart it
+   - Use \`ss -tlnp | grep LISTEN\` to see what ports have servers listening
+2. ONLY if no server is running anywhere: Read CLAUDE.md, README.md, or package.json for setup instructions. Install dependencies if needed, then start the dev server.
+3. BE PATIENT - servers can take time to compile. Monitor tmux logs to see progress. A response from curl (even 404) means the server is up. Do NOT restart the server if it's still compiling.
 4. Navigate to the pages/components modified in the PR
 5. Capture screenshots of the changes, including:
    - The default/resting state of changed components
@@ -224,7 +229,7 @@ If UI changes exist, capture screenshots:
    - Responsive layouts if the PR includes responsive changes
 6. Save screenshots to ${outputDir} with descriptive names like "component-state-${branch}.png"
 7. After taking a screenshot, always open the image to verify that the capture is expected
-8. If screenshot seems outdated, refresh the page and taking the screenshot again.
+8. If screenshot seems outdated, refresh the page and take the screenshot again.
 9. Delete any screenshot files from the filesystem that you do not want included
 </PHASE_2_CAPTURE>
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",

--- a/packages/convex/convex/github_pr_comments.ts
+++ b/packages/convex/convex/github_pr_comments.ts
@@ -341,6 +341,299 @@ export const addPrReaction = internalAction({
 });
 
 /**
+ * Posts an initial "in progress" preview comment to a GitHub PR.
+ * This is called early in the preview process to give users immediate feedback
+ * with the diff heatmap link while screenshots are still being captured.
+ *
+ * Returns the comment ID and URL which should be stored for later updates.
+ */
+export const postInitialPreviewComment = internalAction({
+  args: {
+    installationId: v.number(),
+    repoFullName: v.string(),
+    prNumber: v.number(),
+    previewRunId: v.id("previewRuns"),
+  },
+  handler: async (ctx, args): Promise<{ ok: true; commentId: number; commentUrl: string } | { ok: false; error: string }> => {
+    const { installationId, repoFullName, prNumber, previewRunId } = args;
+
+    try {
+      const accessToken = await fetchInstallationAccessToken(installationId);
+      if (!accessToken) {
+        console.error(
+          "[github_pr_comments] Failed to get access token for initial preview comment",
+          { installationId },
+        );
+        return { ok: false, error: "Failed to get access token" };
+      }
+
+      const repo = parseRepoFullName(repoFullName);
+      if (!repo) {
+        console.error("[github_pr_comments] Invalid repo full name", {
+          repoFullName,
+        });
+        return { ok: false, error: "Invalid repository name" };
+      }
+
+      const octokit = createOctokit(accessToken);
+
+      // Build the initial comment with diff heatmap link and loading state
+      const commentSections: string[] = ["## Preview Screenshots"];
+
+      // Add diff heatmap link (available immediately)
+      const heatmapUrl = `https://github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap`;
+      commentSections.push(`<a href="${heatmapUrl}" target="_blank">Open Diff Heatmap</a>`);
+
+      // Show loading state for screenshots
+      commentSections.push(
+        "⏳ **Preview screenshots are being captured...**",
+        "",
+        "_Workspace and dev browser links will appear here once the preview environment is ready._",
+      );
+
+      commentSections.push("---", PREVIEW_SIGNATURE);
+      const commentBody = commentSections.join("\n\n");
+
+      const { data } = await octokit.rest.issues.createComment({
+        owner: repo.owner,
+        repo: repo.repo,
+        issue_number: prNumber,
+        body: commentBody,
+      });
+
+      console.log("[github_pr_comments] Posted initial preview comment", {
+        installationId,
+        repoFullName,
+        prNumber,
+        commentId: data.id,
+        commentUrl: data.html_url,
+      });
+
+      // Store the comment ID on the preview run for later updates
+      await ctx.runMutation(internal.previewRuns.updateStatus, {
+        previewRunId,
+        status: "running",
+        githubCommentUrl: data.html_url,
+        githubCommentId: data.id,
+      });
+
+      return { ok: true, commentId: data.id, commentUrl: data.html_url };
+    } catch (error) {
+      console.error(
+        "[github_pr_comments] Unexpected error posting initial preview comment",
+        {
+          installationId,
+          repoFullName,
+          prNumber,
+          error,
+        },
+      );
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+});
+
+/**
+ * Updates an existing preview comment with screenshot results and workspace links.
+ * This is called after screenshots are captured to update the initial "in progress" comment.
+ */
+export const updatePreviewComment = internalAction({
+  args: {
+    installationId: v.number(),
+    repoFullName: v.string(),
+    prNumber: v.number(),
+    commentId: v.number(),
+    screenshotSetId: v.id("taskRunScreenshotSets"),
+    previewRunId: v.id("previewRuns"),
+    // Optional links
+    workspaceUrl: v.optional(v.string()),
+    devServerUrl: v.optional(v.string()),
+    // Previous runs for history
+    includePreviousRuns: v.optional(v.boolean()),
+    previewConfigId: v.optional(v.id("previewConfigs")),
+  },
+  handler: async (ctx, args): Promise<{ ok: true } | { ok: false; error: string }> => {
+    const {
+      installationId,
+      repoFullName,
+      prNumber,
+      commentId,
+      screenshotSetId,
+      previewRunId,
+      workspaceUrl,
+      devServerUrl,
+      includePreviousRuns = false,
+      previewConfigId,
+    } = args;
+
+    try {
+      const accessToken = await fetchInstallationAccessToken(installationId);
+      if (!accessToken) {
+        console.error(
+          "[github_pr_comments] Failed to get access token for update preview comment",
+          { installationId },
+        );
+        return { ok: false, error: "Failed to get access token" };
+      }
+
+      const repo = parseRepoFullName(repoFullName);
+      if (!repo) {
+        console.error("[github_pr_comments] Invalid repo full name", {
+          repoFullName,
+        });
+        return { ok: false, error: "Invalid repository name" };
+      }
+
+      const octokit = createOctokit(accessToken);
+
+      const screenshotSet = await ctx.runQuery(
+        internal.previewScreenshots.getScreenshotSet,
+        { screenshotSetId },
+      );
+
+      if (!screenshotSet) {
+        console.error("[github_pr_comments] Screenshot set not found for update", {
+          screenshotSetId,
+        });
+        return { ok: false, error: "Screenshot set not found" };
+      }
+
+      // Build comment sections
+      const commentSections: string[] = ["## Preview Screenshots"];
+
+      // Build links row (under the heading)
+      const linkParts: string[] = [];
+      if (workspaceUrl) {
+        linkParts.push(`<a href="${workspaceUrl}?${UTM_PARAMS}&utm_content=workspace" target="_blank">Open Workspace (1 hr expiry)</a>`);
+      }
+      if (devServerUrl) {
+        linkParts.push(`<a href="${devServerUrl}?${UTM_PARAMS}&utm_content=dev_browser" target="_blank">Open Dev Browser (1 hr expiry)</a>`);
+      }
+      linkParts.push(`<a href="https://github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
+
+      if (linkParts.length > 0) {
+        commentSections.push(linkParts.join(" · "));
+      }
+
+      // Render the main screenshot section
+      const latestHeading = includePreviousRuns
+        ? `### Latest commit ${formatCommitLabel(screenshotSet)}`
+        : "";
+      const latestSection = await renderScreenshotSetMarkdown(
+        ctx,
+        screenshotSet,
+        latestHeading,
+      );
+
+      commentSections.push(latestSection);
+
+      // Fetch and render previous runs if requested
+      if (includePreviousRuns && previewConfigId) {
+        const previousRuns =
+          (await ctx.runQuery(internal.previewRuns.listByConfigAndPr, {
+            previewConfigId,
+            prNumber,
+            limit: MAX_PREVIOUS_SCREENSHOT_SETS + 1,
+          })) ?? [];
+
+        const previousSetEntries: Array<{
+          run: PreviewRunDoc;
+          set: ScreenshotSetDoc;
+        }> = [];
+        for (const run of previousRuns) {
+          if (run._id === previewRunId) continue;
+          if (!run.screenshotSetId) continue;
+          const priorSet = await ctx.runQuery(
+            internal.previewScreenshots.getScreenshotSet,
+            { screenshotSetId: run.screenshotSetId },
+          );
+          if (!priorSet) continue;
+          previousSetEntries.push({ run, set: priorSet });
+          if (previousSetEntries.length >= MAX_PREVIOUS_SCREENSHOT_SETS) {
+            break;
+          }
+        }
+
+        if (previousSetEntries.length > 0) {
+          const collapsedSections: string[] = [];
+          for (const entry of previousSetEntries) {
+            const sectionHeading = `#### ${summarizeSet(entry.set, entry.run)}`;
+            collapsedSections.push(
+              await renderScreenshotSetMarkdown(ctx, entry.set, sectionHeading),
+            );
+          }
+
+          const previousBlock = [
+            "<details>",
+            `<summary>Previous preview runs (${previousSetEntries.length})</summary>`,
+            "",
+            collapsedSections.join("\n\n---\n\n"),
+            "",
+            "</details>",
+          ].join("\n");
+
+          commentSections.push(previousBlock);
+        }
+      }
+
+      commentSections.push("---", PREVIEW_SIGNATURE);
+      const commentBody = commentSections.join("\n\n");
+
+      // Update the existing comment
+      await octokit.rest.issues.updateComment({
+        owner: repo.owner,
+        repo: repo.repo,
+        comment_id: commentId,
+        body: commentBody,
+      });
+
+      console.log("[github_pr_comments] Updated preview comment with screenshots", {
+        installationId,
+        repoFullName,
+        prNumber,
+        commentId,
+      });
+
+      // Update the preview run status
+      await ctx.runMutation(internal.previewRuns.updateStatus, {
+        previewRunId,
+        status: screenshotSet.status as "completed" | "failed" | "skipped",
+        screenshotSetId,
+      });
+
+      // Collapse older preview comments
+      await collapseOlderPreviewComments({
+        octokit,
+        owner: repo.owner,
+        repo: repo.repo,
+        prNumber,
+        latestCommentId: commentId,
+      });
+
+      return { ok: true };
+    } catch (error) {
+      console.error(
+        "[github_pr_comments] Unexpected error updating preview comment",
+        {
+          installationId,
+          repoFullName,
+          prNumber,
+          commentId,
+          error,
+        },
+      );
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+});
+
+/**
  * Unified function to post preview comments to GitHub PRs.
  *
  * Options:
@@ -419,7 +712,7 @@ export const postPreviewComment = internalAction({
       if (devServerUrl) {
         linkParts.push(`<a href="${devServerUrl}?${UTM_PARAMS}&utm_content=dev_browser" target="_blank">Open Dev Browser (1 hr expiry)</a>`);
       }
-      linkParts.push(`<a href="https://0github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
+      linkParts.push(`<a href="https://github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
 
       if (linkParts.length > 0) {
         commentSections.push(linkParts.join(" · "));

--- a/packages/convex/convex/github_pr_comments.ts
+++ b/packages/convex/convex/github_pr_comments.ts
@@ -381,7 +381,7 @@ export const postInitialPreviewComment = internalAction({
       const commentSections: string[] = ["## Preview Screenshots"];
 
       // Add diff heatmap link (available immediately)
-      const heatmapUrl = `https://github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap`;
+      const heatmapUrl = `https://0github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap`;
       commentSections.push(`<a href="${heatmapUrl}" target="_blank">Open Diff Heatmap</a>`);
 
       // Show loading state for screenshots
@@ -512,7 +512,7 @@ export const updatePreviewComment = internalAction({
       if (devServerUrl) {
         linkParts.push(`<a href="${devServerUrl}?${UTM_PARAMS}&utm_content=dev_browser" target="_blank">Open Dev Browser (1 hr expiry)</a>`);
       }
-      linkParts.push(`<a href="https://github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
+      linkParts.push(`<a href="https://0github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
 
       if (linkParts.length > 0) {
         commentSections.push(linkParts.join(" · "));
@@ -712,7 +712,7 @@ export const postPreviewComment = internalAction({
       if (devServerUrl) {
         linkParts.push(`<a href="${devServerUrl}?${UTM_PARAMS}&utm_content=dev_browser" target="_blank">Open Dev Browser (1 hr expiry)</a>`);
       }
-      linkParts.push(`<a href="https://github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
+      linkParts.push(`<a href="https://0github.com/${repoFullName}/pull/${prNumber}?${UTM_PARAMS}&utm_content=diff_heatmap" target="_blank">Open Diff Heatmap</a>`);
 
       if (linkParts.length > 0) {
         commentSections.push(linkParts.join(" · "));

--- a/packages/convex/convex/github_pr_comments.ts
+++ b/packages/convex/convex/github_pr_comments.ts
@@ -274,6 +274,116 @@ async function collapseOlderPreviewComments({
   }
 }
 
+/**
+ * Finds an existing cmux preview comment on a PR by checking for signature markers.
+ * This is used as a fallback when githubCommentId is not stored on the preview run.
+ * Returns the most recent non-collapsed comment if found.
+ */
+export const findExistingPreviewComment = internalAction({
+  args: {
+    installationId: v.number(),
+    repoFullName: v.string(),
+    prNumber: v.number(),
+  },
+  handler: async (
+    _ctx,
+    { installationId, repoFullName, prNumber },
+  ): Promise<{ ok: true; commentId: number | null } | { ok: false; error: string }> => {
+    try {
+      const accessToken = await fetchInstallationAccessToken(installationId);
+      if (!accessToken) {
+        console.error(
+          "[github_pr_comments] Failed to get access token for finding preview comment",
+          { installationId },
+        );
+        return { ok: false, error: "Failed to get access token" };
+      }
+
+      const repo = parseRepoFullName(repoFullName);
+      if (!repo) {
+        console.error("[github_pr_comments] Invalid repo full name", {
+          repoFullName,
+        });
+        return { ok: false, error: "Invalid repository name" };
+      }
+
+      const octokit = createOctokit(accessToken);
+
+      // Search through comments to find a cmux preview comment that hasn't been collapsed
+      // We want the most recent non-collapsed comment to update
+      const iterator = octokit.paginate.iterator(
+        octokit.rest.issues.listComments,
+        {
+          owner: repo.owner,
+          repo: repo.repo,
+          issue_number: prNumber,
+          per_page: 50,
+        },
+      );
+
+      let candidateComment: { id: number; createdAt: string } | null = null;
+
+      for await (const { data } of iterator) {
+        for (const comment of data) {
+          const { body } = comment;
+          if (!body) continue;
+
+          // Check if this is a cmux comment by signature
+          const hasSignature = COMMENT_SIGNATURE_MATCHERS.some((signature) =>
+            body.includes(signature),
+          );
+          if (!hasSignature) continue;
+
+          // Skip comments that have been collapsed (they have the collapse marker)
+          if (body.includes(COLLAPSE_MARKER)) continue;
+
+          // Keep track of the most recent non-collapsed cmux comment
+          if (
+            !candidateComment ||
+            new Date(comment.created_at) > new Date(candidateComment.createdAt)
+          ) {
+            candidateComment = {
+              id: comment.id,
+              createdAt: comment.created_at,
+            };
+          }
+        }
+      }
+
+      if (candidateComment) {
+        console.log("[github_pr_comments] Found existing preview comment to update", {
+          installationId,
+          repoFullName,
+          prNumber,
+          commentId: candidateComment.id,
+        });
+        return { ok: true, commentId: candidateComment.id };
+      }
+
+      console.log("[github_pr_comments] No existing preview comment found", {
+        installationId,
+        repoFullName,
+        prNumber,
+      });
+      return { ok: true, commentId: null };
+    } catch (error) {
+      console.error(
+        "[github_pr_comments] Unexpected error finding preview comment",
+        {
+          installationId,
+          repoFullName,
+          prNumber,
+          error,
+        },
+      );
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+});
+
 export const addPrReaction = internalAction({
   args: {
     installationId: v.number(),

--- a/packages/convex/convex/preview_jobs_http.ts
+++ b/packages/convex/convex/preview_jobs_http.ts
@@ -359,7 +359,7 @@ export const completePreviewJob = httpAction(async (ctx, req) => {
       imageCount: taskScreenshotSet.images.length,
     });
 
-    // Post GitHub comment if we have installation ID
+    // Post or update GitHub comment if we have installation ID
     if (previewRun.repoInstallationId) {
       const team = await ctx.runQuery(internal.teams.getByTeamIdInternal, {
         teamId: taskRun.teamId,
@@ -368,44 +368,101 @@ export const completePreviewJob = httpAction(async (ctx, req) => {
       const workspaceUrl = `https://www.cmux.sh/${teamSlug}/task/${taskRun.taskId}`;
       const devServerUrl = `https://www.cmux.sh/${teamSlug}/task/${taskRun.taskId}/run/${taskRunId}/browser`;
 
-      const commentResult = await ctx.runAction(
-        internal.github_pr_comments.postPreviewComment,
-        {
-          installationId: previewRun.repoInstallationId,
-          repoFullName: previewRun.repoFullName,
-          prNumber: previewRun.prNumber,
-          screenshotSetId: taskRun.latestScreenshotSetId,
+      // Check if we have an existing comment to update (from initial posting)
+      if (previewRun.githubCommentId) {
+        console.log("[preview-jobs-http] Updating existing GitHub comment", {
+          taskRunId,
           previewRunId: previewRun._id,
-          workspaceUrl,
-          devServerUrl,
+          commentId: previewRun.githubCommentId,
+        });
+
+        const updateResult = await ctx.runAction(
+          internal.github_pr_comments.updatePreviewComment,
+          {
+            installationId: previewRun.repoInstallationId,
+            repoFullName: previewRun.repoFullName,
+            prNumber: previewRun.prNumber,
+            commentId: previewRun.githubCommentId,
+            screenshotSetId: taskRun.latestScreenshotSetId,
+            previewRunId: previewRun._id,
+            workspaceUrl,
+            devServerUrl,
+          }
+        );
+
+        if (updateResult.ok) {
+          console.log("[preview-jobs-http] Successfully updated GitHub comment", {
+            taskRunId,
+            previewRunId: previewRun._id,
+            commentId: previewRun.githubCommentId,
+          });
+
+          const taskCompletion = await markPreviewTaskCompleted(ctx, taskRun, task);
+
+          return jsonResponse({
+            success: true,
+            commentUrl: previewRun.githubCommentUrl,
+            runStatusUpdated: taskCompletion.runStatusUpdated,
+            alreadyCompleted: taskCompletion.taskAlreadyCompleted,
+          });
+        } else {
+          console.error("[preview-jobs-http] Failed to update GitHub comment", {
+            taskRunId,
+            previewRunId: previewRun._id,
+            commentId: previewRun.githubCommentId,
+            error: updateResult.error,
+          });
+          return jsonResponse({
+            success: false,
+            error: `Failed to update GitHub comment: ${updateResult.error}`,
+          }, 500);
         }
-      );
-
-      if (commentResult.ok) {
-        console.log("[preview-jobs-http] Successfully posted GitHub comment", {
-          taskRunId,
-          previewRunId: previewRun._id,
-          commentUrl: commentResult.commentUrl,
-        });
-
-        const taskCompletion = await markPreviewTaskCompleted(ctx, taskRun, task);
-
-        return jsonResponse({
-          success: true,
-          commentUrl: commentResult.commentUrl,
-          runStatusUpdated: taskCompletion.runStatusUpdated,
-          alreadyCompleted: taskCompletion.taskAlreadyCompleted,
-        });
       } else {
-        console.error("[preview-jobs-http] Failed to post GitHub comment", {
+        // No existing comment - create a new one (fallback)
+        console.log("[preview-jobs-http] Posting new GitHub comment (no existing comment found)", {
           taskRunId,
           previewRunId: previewRun._id,
-          error: commentResult.error,
         });
-        return jsonResponse({
-          success: false,
-          error: `Failed to post GitHub comment: ${commentResult.error}`,
-        }, 500);
+
+        const commentResult = await ctx.runAction(
+          internal.github_pr_comments.postPreviewComment,
+          {
+            installationId: previewRun.repoInstallationId,
+            repoFullName: previewRun.repoFullName,
+            prNumber: previewRun.prNumber,
+            screenshotSetId: taskRun.latestScreenshotSetId,
+            previewRunId: previewRun._id,
+            workspaceUrl,
+            devServerUrl,
+          }
+        );
+
+        if (commentResult.ok) {
+          console.log("[preview-jobs-http] Successfully posted GitHub comment", {
+            taskRunId,
+            previewRunId: previewRun._id,
+            commentUrl: commentResult.commentUrl,
+          });
+
+          const taskCompletion = await markPreviewTaskCompleted(ctx, taskRun, task);
+
+          return jsonResponse({
+            success: true,
+            commentUrl: commentResult.commentUrl,
+            runStatusUpdated: taskCompletion.runStatusUpdated,
+            alreadyCompleted: taskCompletion.taskAlreadyCompleted,
+          });
+        } else {
+          console.error("[preview-jobs-http] Failed to post GitHub comment", {
+            taskRunId,
+            previewRunId: previewRun._id,
+            error: commentResult.error,
+          });
+          return jsonResponse({
+            success: false,
+            error: `Failed to post GitHub comment: ${commentResult.error}`,
+          }, 500);
+        }
       }
     } else {
       console.log("[preview-jobs-http] No GitHub installation ID, skipping comment", {

--- a/packages/shared/src/morph-snapshots.json
+++ b/packages/shared/src/morph-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2025-12-10T01:26:21Z",
+  "updatedAt": "2025-12-10T05:09:05Z",
   "presets": [
     {
       "presetId": "4vcpu_16gb_48gb",
@@ -123,6 +123,11 @@
           "version": 23,
           "snapshotId": "snapshot_vkfzdrxw",
           "capturedAt": "2025-12-10T01:26:47Z"
+        },
+        {
+          "version": 24,
+          "snapshotId": "snapshot_eezx6d0u",
+          "capturedAt": "2025-12-10T05:09:22Z"
         }
       ],
       "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
@@ -248,6 +253,11 @@
           "version": 23,
           "snapshotId": "snapshot_jqe2lrhp",
           "capturedAt": "2025-12-10T01:26:21Z"
+        },
+        {
+          "version": 24,
+          "snapshotId": "snapshot_8mklccsm",
+          "capturedAt": "2025-12-10T05:09:05Z"
         }
       ],
       "description": "Extra headroom for larger codebases or heavier workloads."

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -420,7 +420,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_vkfzdrxw' | 'snapshot_jqe2lrhp' | 'snapshot_pcmfvjra');
+    snapshotId?: string | ('snapshot_eezx6d0u' | 'snapshot_8mklccsm' | 'snapshot_pcmfvjra');
 };
 
 export type CreateEnvironmentResponse = {


### PR DESCRIPTION
for the preview screenshot agent, we need to be posting cmux comment first and then update that specific github comment after (just a comment about Preview Screenshots being in progress, give link to the git diff heatmap (Open Diff Heatmap) so the user can play around with that while they wait for the other things, then populate it with the Open Workspace and Open Dev Browser links as well as the screenshots (or the no ui changes dialog) after... make sure you are writing 1 github comment, not 2. you need to update the github comment that gets initially posted....