### PR TITLE
Add CLAUDE_CODE_OAUTH_TOKEN support and precedence over keys

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -747,13 +747,15 @@ function SettingsComponent() {
 
                       {/* Group API keys by provider for better organization */}
                       {apiKeys.map((key) => {
-                        const getProviderInfo = (envVar: string) => {
+                        const getProviderInfo = (
+                          envVar: string
+                        ): { url: string | null; instructions?: string } | null => {
                           switch (envVar) {
                             case "CLAUDE_CODE_OAUTH_TOKEN":
                               return {
                                 url: null,
                                 instructions:
-                                  "Run 'claude setup-token' in your terminal and paste the output here. This takes precedence over ANTHROPIC_API_KEY.",
+                                  "Run 'claude setup-token' in your terminal and paste the output here. Takes precedence over ANTHROPIC_API_KEY.",
                               };
                             case "ANTHROPIC_API_KEY":
                               return {
@@ -878,26 +880,15 @@ function SettingsComponent() {
                                     </svg>
                                   </a>
                                 )}
-                                {"instructions" in (providerInfo ?? {}) &&
-                                  (
-                                    providerInfo as {
-                                      instructions?: string;
-                                    }
-                                  )?.instructions && (
-                                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                                      {
-                                        (
-                                          providerInfo as {
-                                            instructions?: string;
-                                          }
-                                        ).instructions
-                                      }
-                                    </p>
-                                  )}
                               </div>
                             </div>
 
                             <div className="md:w-[min(100%,480px)] md:flex-shrink-0 self-start">
+                              {providerInfo?.instructions && (
+                                <p className="text-xs text-amber-600 dark:text-amber-400 mb-1 pb-1">
+                                  {providerInfo.instructions}
+                                </p>
+                              )}
                               <div className="relative">
                                 <input
                                   type={

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -749,6 +749,12 @@ function SettingsComponent() {
                       {apiKeys.map((key) => {
                         const getProviderInfo = (envVar: string) => {
                           switch (envVar) {
+                            case "CLAUDE_CODE_OAUTH_TOKEN":
+                              return {
+                                url: null,
+                                instructions:
+                                  "Run 'claude setup-token' in your terminal and paste the output here. This takes precedence over ANTHROPIC_API_KEY.",
+                              };
                             case "ANTHROPIC_API_KEY":
                               return {
                                 url: "https://console.anthropic.com/settings/keys",
@@ -872,6 +878,22 @@ function SettingsComponent() {
                                     </svg>
                                   </a>
                                 )}
+                                {"instructions" in (providerInfo ?? {}) &&
+                                  (
+                                    providerInfo as {
+                                      instructions?: string;
+                                    }
+                                  )?.instructions && (
+                                    <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                                      {
+                                        (
+                                          providerInfo as {
+                                            instructions?: string;
+                                          }
+                                        ).instructions
+                                      }
+                                    </p>
+                                  )}
                               </div>
                             </div>
 
@@ -891,13 +913,15 @@ function SettingsComponent() {
                                   }
                                   className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs"
                                   placeholder={
-                                    key.envVar === "ANTHROPIC_API_KEY"
-                                      ? "sk-ant-api03-..."
-                                      : key.envVar === "OPENAI_API_KEY"
-                                        ? "sk-proj-..."
-                                        : key.envVar === "OPENROUTER_API_KEY"
-                                          ? "sk-or-v1-..."
-                                          : `Enter your ${key.displayName}`
+                                    key.envVar === "CLAUDE_CODE_OAUTH_TOKEN"
+                                      ? "sk-ant-oat-..."
+                                      : key.envVar === "ANTHROPIC_API_KEY"
+                                        ? "sk-ant-api03-..."
+                                        : key.envVar === "OPENAI_API_KEY"
+                                          ? "sk-proj-..."
+                                          : key.envVar === "OPENROUTER_API_KEY"
+                                            ? "sk-or-v1-..."
+                                            : `Enter your ${key.displayName}`
                                   }
                                 />
                                 <button

--- a/packages/shared/src/apiKeys.ts
+++ b/packages/shared/src/apiKeys.ts
@@ -47,3 +47,10 @@ export const XAI_API_KEY: AgentConfigApiKey = {
   displayName: "xAI API Key",
   description: "API key for xAI Grok models",
 };
+
+export const CLAUDE_CODE_OAUTH_TOKEN: AgentConfigApiKey = {
+  envVar: "CLAUDE_CODE_OAUTH_TOKEN",
+  displayName: "Claude Code OAuth Token",
+  description:
+    "OAuth token from 'claude setup-token'. Takes precedence over ANTHROPIC_API_KEY.",
+};

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -1,5 +1,5 @@
 import type { AgentConfig } from "../../agentConfig";
-import { ANTHROPIC_API_KEY } from "../../apiKeys";
+import { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN } from "../../apiKeys";
 import { checkClaudeRequirements } from "./check-requirements";
 import { startClaudeCompletionDetector } from "./completion-detector";
 import {
@@ -24,7 +24,7 @@ export const CLAUDE_SONNET_4_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -42,7 +42,7 @@ export const CLAUDE_OPUS_4_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -60,7 +60,7 @@ export const CLAUDE_OPUS_4_1_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -78,7 +78,7 @@ export const CLAUDE_OPUS_4_5_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -96,7 +96,7 @@ export const CLAUDE_SONNET_4_5_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };
@@ -114,7 +114,7 @@ export const CLAUDE_HAIKU_4_5_CONFIG: AgentConfig = {
   ],
   environment: getClaudeEnvironment,
   checkRequirements: checkClaudeRequirements,
-  apiKeys: [ANTHROPIC_API_KEY],
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
   applyApiKeys: applyClaudeApiKeys,
   completionDetector: startClaudeCompletionDetector,
 };

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -116,17 +116,6 @@ export type GithubReposResponse = {
     repos: Array<GithubRepo>;
 };
 
-export type FrameworkPreset = 'other' | 'next' | 'vite' | 'remix' | 'nuxt' | 'sveltekit' | 'angular' | 'cra' | 'vue';
-
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
-
-export type FrameworkDetectionResponse = {
-    framework: FrameworkPreset;
-    packageManager: PackageManager;
-    maintenanceScript: string;
-    devScript: string;
-};
-
 export type GithubPullRequestItem = {
     id: number;
     number: number;
@@ -367,23 +356,6 @@ export type GithubOAuthTokenResponse = {
     error: string | null;
 };
 
-export type GithubDefaultBranchResponse = {
-    defaultBranch: string | null;
-    error: string | null;
-};
-
-export type GithubBranch = {
-    name: string;
-    lastCommitSha?: string;
-    isDefault?: boolean;
-};
-
-export type GithubBranchesResponse = {
-    branches: Array<GithubBranch>;
-    defaultBranch: string | null;
-    error: string | null;
-};
-
 export type ResumeTaskRunResponse = {
     resumed: true;
 };
@@ -420,7 +392,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_vkfzdrxw' | 'snapshot_jqe2lrhp' | 'snapshot_pcmfvjra');
+    snapshotId?: string | ('snapshot_st54kpzd' | 'snapshot_6isj88bc' | 'snapshot_pcmfvjra');
 };
 
 export type CreateEnvironmentResponse = {
@@ -527,7 +499,6 @@ export type StartSandboxResponse = {
     vscodeUrl: string;
     workerUrl: string;
     provider?: 'morph';
-    vscodePersisted?: boolean;
 };
 
 export type StartSandboxBody = {
@@ -1154,38 +1125,6 @@ export type GetApiIntegrationsGithubReposResponses = {
 
 export type GetApiIntegrationsGithubReposResponse = GetApiIntegrationsGithubReposResponses[keyof GetApiIntegrationsGithubReposResponses];
 
-export type GetApiIntegrationsGithubFrameworkDetectionData = {
-    body?: never;
-    path?: never;
-    query: {
-        /**
-         * Full repository name (owner/repo)
-         */
-        repo: string;
-    };
-    url: '/api/integrations/github/framework-detection';
-};
-
-export type GetApiIntegrationsGithubFrameworkDetectionErrors = {
-    /**
-     * Bad request
-     */
-    400: unknown;
-    /**
-     * Unauthorized
-     */
-    401: unknown;
-};
-
-export type GetApiIntegrationsGithubFrameworkDetectionResponses = {
-    /**
-     * OK
-     */
-    200: FrameworkDetectionResponse;
-};
-
-export type GetApiIntegrationsGithubFrameworkDetectionResponse = GetApiIntegrationsGithubFrameworkDetectionResponses[keyof GetApiIntegrationsGithubFrameworkDetectionResponses];
-
 export type GetApiIntegrationsGithubPrsData = {
     body?: never;
     path?: never;
@@ -1719,70 +1658,6 @@ export type GetApiIntegrationsGithubOauthTokenResponses = {
 };
 
 export type GetApiIntegrationsGithubOauthTokenResponse = GetApiIntegrationsGithubOauthTokenResponses[keyof GetApiIntegrationsGithubOauthTokenResponses];
-
-export type GetApiIntegrationsGithubDefaultBranchData = {
-    body?: never;
-    path?: never;
-    query: {
-        /**
-         * Repository full name (owner/repo)
-         */
-        repo: string;
-    };
-    url: '/api/integrations/github/default-branch';
-};
-
-export type GetApiIntegrationsGithubDefaultBranchErrors = {
-    /**
-     * Unauthorized
-     */
-    401: unknown;
-};
-
-export type GetApiIntegrationsGithubDefaultBranchResponses = {
-    /**
-     * Default branch response
-     */
-    200: GithubDefaultBranchResponse;
-};
-
-export type GetApiIntegrationsGithubDefaultBranchResponse = GetApiIntegrationsGithubDefaultBranchResponses[keyof GetApiIntegrationsGithubDefaultBranchResponses];
-
-export type GetApiIntegrationsGithubBranchesData = {
-    body?: never;
-    path?: never;
-    query: {
-        /**
-         * Repository full name (owner/repo)
-         */
-        repo: string;
-        /**
-         * Optional search term to filter branches by name
-         */
-        search?: string;
-        /**
-         * Max branches to return (default 30, max 100)
-         */
-        limit?: number;
-    };
-    url: '/api/integrations/github/branches';
-};
-
-export type GetApiIntegrationsGithubBranchesErrors = {
-    /**
-     * Unauthorized
-     */
-    401: unknown;
-};
-
-export type GetApiIntegrationsGithubBranchesResponses = {
-    /**
-     * Branches list response
-     */
-    200: GithubBranchesResponse;
-};
-
-export type GetApiIntegrationsGithubBranchesResponse = GetApiIntegrationsGithubBranchesResponses[keyof GetApiIntegrationsGithubBranchesResponses];
 
 export type PostApiMorphTaskRunsByTaskRunIdResumeData = {
     body: ResumeTaskRunBody;


### PR DESCRIPTION
rg for CLAUDE_CODE_OAUTH_TOKEN -- we use it in rust codei want to offer it in settings as alternative to ANTHROPIC_API_KEY, so user should be able to fill it in the settings.in the description, we should instruction user to run claude setup-token and paste the output back here.
if CLAUDE_CODE_OAUTH_TOKEN we should always prefer it over ANTHROPIC_API_KEY or even the hosted cmux anthropic api key. think of how CLAUDE_CODE_OAUTH_TOKEN will interact with our anthropic proxy in apps/www as well, and ultrathink edge cases we need to handle.