### PR TITLE
Reserve CPU/RAM for VNC desktop and critical services

### DIFF
--- a/configs/systemd/bin/cmux-configure-memory
+++ b/configs/systemd/bin/cmux-configure-memory
@@ -95,7 +95,7 @@ before_free="$(capture_output free -h || true)"
 before_swapon="$(capture_output swapon --show=NAME,TYPE,SIZE,USED,PRIO || true)"
 before_zram="$(capture_output zramctl || true)"
 
-declare -a candidate_units=(ssh.service sshd.service cmux-ide.service cmux-openvscode.service code-server.service openvscode-server.service)
+declare -a candidate_units=(ssh.service sshd.service cmux-ide.service cmux-openvscode.service cmux-coder.service code-server.service openvscode-server.service cmux-tigervnc.service cmux-openbox.service cmux-vnc-proxy.service cmux-devtools.service cmux-xterm.service cmux-worker.service cmux-proxy.service cmux-cdp-proxy.service)
 declare -a report_units=()
 
 for unit in "${candidate_units[@]}"; do
@@ -396,13 +396,31 @@ sysctl -q -p /etc/sysctl.d/99-cmux-memory.conf >/dev/null 2>&1 || true
 summary+=("Set vm.swappiness to 70.")
 
 # Systemd drop-ins
+# Reserve memory (MemoryLow) and boost CPU/IO priority for interactive services.
+# This ensures UI remains responsive even when coding agents consume heavy resources.
 declare -A memory_low_map=(
+  # SSH - must never fail
   [ssh.service]="256M"
   [sshd.service]="256M"
+  # IDE services - primary user interface
   [cmux-ide.service]="2G"
   [cmux-openvscode.service]="2G"
+  [cmux-coder.service]="2G"
   [code-server.service]="2G"
   [openvscode-server.service]="2G"
+  # VNC/desktop services for snappy interaction
+  [cmux-tigervnc.service]="512M"
+  [cmux-openbox.service]="256M"
+  [cmux-vnc-proxy.service]="128M"
+  # Chrome DevTools browser (memory-hungry)
+  [cmux-devtools.service]="1G"
+  # Terminal service - direct user interaction
+  [cmux-xterm.service]="256M"
+  # Worker service - background operations
+  [cmux-worker.service]="512M"
+  # Proxy services - handle all HTTP traffic
+  [cmux-proxy.service]="256M"
+  [cmux-cdp-proxy.service]="128M"
 )
 
 managed_units=()

--- a/packages/shared/src/morph-snapshots.json
+++ b/packages/shared/src/morph-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2025-12-10T01:26:21Z",
+  "updatedAt": "2025-12-10T23:54:35Z",
   "presets": [
     {
       "presetId": "4vcpu_16gb_48gb",
@@ -123,6 +123,11 @@
           "version": 23,
           "snapshotId": "snapshot_vkfzdrxw",
           "capturedAt": "2025-12-10T01:26:47Z"
+        },
+        {
+          "version": 24,
+          "snapshotId": "snapshot_znlxt1yd",
+          "capturedAt": "2025-12-10T23:53:42Z"
         }
       ],
       "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
@@ -248,6 +253,11 @@
           "version": 23,
           "snapshotId": "snapshot_jqe2lrhp",
           "capturedAt": "2025-12-10T01:26:21Z"
+        },
+        {
+          "version": 24,
+          "snapshotId": "snapshot_3yzpq1lb",
+          "capturedAt": "2025-12-10T23:54:35Z"
         }
       ],
       "description": "Extra headroom for larger codebases or heavier workloads."


### PR DESCRIPTION
## Summary
- Add systemd MemoryLow guarantees to VNC/desktop services (cmux-tigervnc, cmux-openbox, cmux-vnc-proxy) and other critical services
- Set CPUWeight=200 and IOWeight=200 for scheduling priority boost
- Ensure interactive UI remains responsive when coding agents consume heavy resources

## Services Configured
| Service | MemoryLow | Purpose |
|---------|-----------|---------|
| cmux-tigervnc | 512M | TigerVNC X server |
| cmux-openbox | 256M | Openbox window manager |
| cmux-vnc-proxy | 128M | VNC websocket proxy |
| cmux-devtools | 1G | Chrome DevTools browser |
| cmux-xterm | 256M | Terminal service |
| cmux-worker | 512M | Background operations |
| cmux-proxy | 256M | Main HTTP proxy |
| cmux-cdp-proxy | 128M | Chrome DevTools Protocol proxy |
| cmux-coder | 2G | Coder IDE (added) |

## Test plan
- [ ] Deploy snapshot with changes
- [ ] Verify VNC remains responsive during heavy load
- [ ] Check systemd drop-ins applied: `systemctl show cmux-tigervnc.service -p MemoryLow,CPUWeight,IOWeight`