### PR TITLE
Investigate and fix workspace flicker in VSCode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",


### PR DESCRIPTION
can you investigate why the vscode instances for local workspaces keep flickering. there is some sort of refresh state that may be caused by some useEffect. aalso it could be because we show the git diff and preview before on the sidebar but actively filter it out? those tabs should just never show in the first place? it should just be loading