### PR TITLE
Investigate and fix workspace flicker in VSCode

### DIFF
--- a/apps/client/src/components/persistent-iframe.tsx
+++ b/apps/client/src/components/persistent-iframe.tsx
@@ -102,9 +102,20 @@ export function PersistentIframe({
   const [, forceRender] = useState(0);
   const loadTimeoutRef = useRef<number | null>(null);
   const preflightErrorRef = useRef<string | null>(null);
+  const prevPersistKeyRef = useRef<string>(persistKey);
+  const prevSrcRef = useRef<string>(src);
 
+  // Only reset to loading when persistKey or src actually changes to a different value
+  // This prevents flickering when references change but values are the same
   useEffect(() => {
-    setStatus("loading");
+    const persistKeyChanged = persistKey !== prevPersistKeyRef.current;
+    const srcChanged = src !== prevSrcRef.current;
+
+    if (persistKeyChanged || srcChanged) {
+      setStatus("loading");
+      prevPersistKeyRef.current = persistKey;
+      prevSrcRef.current = src;
+    }
   }, [persistKey, src]);
 
   const clearLoadTimeout = useCallback(() => {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -3,7 +3,7 @@ import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { convexQuery } from "@convex-dev/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import z from "zod";
 import type { PersistentIframeStatus } from "@/components/persistent-iframe";
 import { PersistentWebView } from "@/components/persistent-webview";
@@ -100,8 +100,19 @@ function VSCodeComponent() {
 
   const [iframeStatus, setIframeStatus] =
     useState<PersistentIframeStatus>("loading");
+  const prevWorkspaceUrlRef = useRef<string | null>(null);
+
+  // Only reset to loading when the URL actually changes to a different value
+  // This prevents flickering when the URL reference changes but the value is the same
   useEffect(() => {
-    setIframeStatus("loading");
+    if (workspaceUrl !== prevWorkspaceUrlRef.current) {
+      // Only reset to loading if we're transitioning to a new URL
+      // Don't reset if we're already loaded with the same URL
+      if (workspaceUrl !== null && prevWorkspaceUrlRef.current !== null) {
+        setIframeStatus("loading");
+      }
+      prevWorkspaceUrlRef.current = workspaceUrl;
+    }
   }, [workspaceUrl]);
 
   const onLoad = useCallback(() => {

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",


### PR DESCRIPTION
can you investigate why the vscode instances for local workspaces keep flickering. there is some sort of refresh state that may be caused by some useEffect. aalso it could be because we show the git diff and preview before on the sidebar but actively filter it out? those tabs should just never show in the first place? it should just be loading