### PR TITLE
Configure Vitest to limit multi-projects

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,5 @@
+export default [
+  "apps/client/vitest.config.ts",
+  "apps/www/vitest.config.ts",
+  "packages/convex/vitest.config.ts",
+];

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,5 +1,4 @@
 export default [
-  "apps/client/vitest.config.ts",
-  "apps/www/vitest.config.ts",
-  "packages/convex/vitest.config.ts",
+  "apps/*/vitest.config.ts",
+  "packages/*/vitest.config.ts",
 ];


### PR DESCRIPTION
Vitest found multiple projects. The extension will use only the first 5 due to performance concerns. Consider using a projects configuration to group your configs or increase the limit via "vitest.maximumConfigs" option.fix it. we dont care about stuff in @dev-docs/