### PR TITLE
Exclude subdirectories via pyrightconfig to speed up workspaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,18 @@ dependencies = ["cdp-use>=1.4.1", "morphcloud>=0.1.91", "requests>=2.32.4"]
 
 [tool.basedpyright]
 reportUnusedCallResult = false
+exclude = [
+    "node_modules",
+    ".git",
+    "logs",
+    "crates",
+    "apps",
+    "packages",
+    "configs",
+    "docs",
+    "docs-ai",
+    "dev-docs",
+    "data",
+    "evals",
+    "prompts",
+]


### PR DESCRIPTION
Enumeration of workspace source files is taking longer than 10 seconds.
This may be because:
* You have opened your home directory or entire hard drive as a workspace
* Your workspace contains a very large number of directories and files
* Your workspace contains a symlink to a directory with many files
* Your workspace is remote, and file enumeration is slow
To reduce this time, open a workspace directory with fewer files or add a pyrightconfig.json configuration file with an "exclude" section to exclude subdirectories from your workspace. For more details, refer to https://docs.basedpyright.com/v1.32.1/configuration/config-filesfix it