### PR TITLE
Hide git worktrees from VS Code sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ out
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "git.showWorktrees": false
+}


### PR DESCRIPTION
## Summary
- Add VS Code setting `git.showWorktrees: false` to hide the 18 worktrees from the Git sidebar
- Only the main repository (https://github.com/manaflow-ai/cmux) will be shown

## Test plan
- Open the repo in VS Code and verify the Git sidebar no longer shows worktree entries