### PR TITLE
Remove OpenVSCode Server keybind notification

### DIFF
--- a/configs/systemd/bin/configure-openvscode
+++ b/configs/systemd/bin/configure-openvscode
@@ -22,6 +22,7 @@ SETTINGS=$(jq -n \
     "workbench.startupEditor": "none",
     "workbench.secondarySideBar.defaultVisibility": "hidden",
     "terminal.integrated.shellIntegration.enabled": false,
+    "terminal.integrated.showTerminalConfigPrompt": false,
     "terminal.integrated.macOptionClickForcesSelection": true,
     "terminal.integrated.shell.linux": "/usr/bin/zsh",
     "terminal.integrated.shellArgs.linux": ["-l"],


### PR DESCRIPTION
get rid of "Some keybindings don't go to the terminal by default and are handled by OpenVSCode Server instead." notification from vscode