### PR TITLE
Improve setup scripts to check env vars instead of .env file

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -347,7 +347,7 @@ fi
 # Start convex dev (works the same in both environments)
 if [ "$CONVEX_AGENT_MODE" = "true" ]; then
     echo -e "${GREEN}Starting convex dev in agent mode...${NC}"
-    (cd "$APP_DIR/packages/convex" && exec bash -c 'trap "kill -9 0" EXIT; source ~/.nvm/nvm.sh 2>/dev/null || true; CONVEX_AGENT_MODE=anonymous npx convex dev 2>&1 | tee "$LOG_DIR/convex-dev.log" | prefix_output "CONVEX-DEV" "$BLUE"') &
+    (cd "$APP_DIR/packages/convex" && exec bash -c 'trap "kill -9 0" EXIT; source ~/.nvm/nvm.sh 2>/dev/null || true; CONVEX_DEPLOYMENT= CONVEX_AGENT_MODE=anonymous bunx convex dev 2>&1 | tee "$LOG_DIR/convex-dev.log" | prefix_output "CONVEX-DEV" "$BLUE"') &
 else
     (cd "$APP_DIR/packages/convex" && exec bash -c 'trap "kill -9 0" EXIT; source ~/.nvm/nvm.sh 2>/dev/null || true; bunx convex dev 2>&1 | tee "$LOG_DIR/convex-dev.log" | prefix_output "CONVEX-DEV" "$BLUE"') &
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,24 +6,39 @@ mkdir -p ./logs
 DATETIME="$(date '+%Y%m%d-%H%M%S')"
 
 echo "Starting setup..."
+echo "Logs: ./logs/*-$DATETIME.log"
+echo ""
 
 # Run bun install and uv sync in parallel
-echo "Installing dependencies..."
+echo "[1/2] Installing dependencies (bun install + uv sync)..."
 bun install >"./logs/bun-install-$DATETIME.log" 2>&1 &
 BUN_PID=$!
-
 uv sync >"./logs/uv-sync-$DATETIME.log" 2>&1 &
 UV_PID=$!
 
-# Wait for both to complete
-wait $BUN_PID
-echo "bun install completed"
+BUN_OK=0
+UV_OK=0
+wait $BUN_PID || BUN_OK=1
+wait $UV_PID || UV_OK=1
 
-wait $UV_PID
-echo "uv sync completed"
+if [ $BUN_OK -ne 0 ]; then
+  echo "      bun install failed (see ./logs/bun-install-$DATETIME.log)"
+  exit 1
+fi
+if [ $UV_OK -ne 0 ]; then
+  echo "      uv sync failed (see ./logs/uv-sync-$DATETIME.log)"
+  exit 1
+fi
+echo "      done"
 
-# Run convex setup
-echo "Setting up Convex..."
-bun run convex:setup
+# Run convex setup (depends on bun install)
+echo "[2/2] convex setup..."
+if bun run convex:setup >"./logs/convex-setup-$DATETIME.log" 2>&1; then
+  echo "      done"
+else
+  echo "      failed (see ./logs/convex-setup-$DATETIME.log)"
+  exit 1
+fi
 
-echo "Setup complete!"
+echo ""
+echo "Setup complete! Run ./scripts/dev.sh to start the dev server."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p ./logs
+DATETIME="$(date '+%Y%m%d-%H%M%S')"
+
+echo "Starting setup..."
+
+# Run bun install and uv sync in parallel
+echo "Installing dependencies..."
+bun install >"./logs/bun-install-$DATETIME.log" 2>&1 &
+BUN_PID=$!
+
+uv sync >"./logs/uv-sync-$DATETIME.log" 2>&1 &
+UV_PID=$!
+
+# Wait for both to complete
+wait $BUN_PID
+echo "bun install completed"
+
+wait $UV_PID
+echo "uv sync completed"
+
+# Run convex setup
+echo "Setting up Convex..."
+bun run convex:setup
+
+echo "Setup complete!"


### PR DESCRIPTION
## Summary
- Update setup.sh to run bun install and uv sync in parallel
- Add better progress output with step numbers and log file locations
- Update convex setup.ts to check for required Stack Auth env vars from process.env
- Fall back to syncing env vars from process.env when .env file doesn't exist

## Test plan
- [ ] Run `./scripts/setup.sh` with env vars set in shell (no .env file)
- [ ] Run `./scripts/setup.sh` with .env file
- [ ] Verify error message when missing required env vars