### PR TITLE
link cmux release to GitHub releases page

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -256,7 +256,16 @@ export default async function LandingPage() {
               </div>
               {latestVersion ? (
                 <p className="text-xs text-neutral-400">
-                  Latest release: cmux {latestVersion}. Need another build? Visit the GitHub release page for all downloads.
+                  Latest release: cmux {latestVersion}. Need another build? Visit the{" "}
+                  <a
+                    href="https://github.com/manaflow-ai/cmux/releases"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-neutral-300"
+                  >
+                    GitHub release page
+                  </a>{" "}
+                  for all downloads.
                 </p>
               ) : (
                 <p className="text-xs text-neutral-400">


### PR DESCRIPTION
for apps/www front page make sure "
Latest release: cmux 1.0.191. Need another build? Visit the GitHub release page for all downloads.
will link to https://github.com/manaflow-ai/cmux/releases