### PR TITLE
Run setup in parallel and detect main branch

### DIFF
--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -6,7 +6,11 @@
 #
 # This script runs in parallel:
 #   - bun install
-#   - git submodule update --init --recursive
+#   - git submodule update --init --recursive --depth 1
+#
+# Note: Submodules are cloned with --depth 1 for faster setup. Git submodules
+# work by commit SHA (not branch name), so this works regardless of whether
+# the upstream repo uses main, master, dev, or any other default branch.
 #
 
 set -e
@@ -38,8 +42,9 @@ GIT_EXIT=0
 (bun install) &
 BUN_PID=$!
 
-# Start git submodule update in background
-(git submodule update --init --recursive) &
+# Start git submodule update in background with shallow clone
+# Using --depth 1 for faster clones since we only need the latest state
+(git submodule update --init --recursive --depth 1) &
 GIT_PID=$!
 
 # Wait for both and capture exit codes

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -6,11 +6,12 @@
 #
 # This script runs in parallel:
 #   - bun install
-#   - git submodule update --init --recursive --depth 1
+#   - git submodule update --init --recursive --depth 1 --jobs 8
 #
-# Note: Submodules are cloned with --depth 1 for faster setup. Git submodules
-# work by commit SHA (not branch name), so this works regardless of whether
-# the upstream repo uses main, master, dev, or any other default branch.
+# Note: Submodules are cloned with --depth 1 for faster setup and --jobs 8
+# to clone multiple submodules in parallel. Git submodules work by commit SHA
+# (not branch name), so this works regardless of whether the upstream repo
+# uses main, master, dev, or any other default branch.
 #
 
 set -e
@@ -44,7 +45,8 @@ BUN_PID=$!
 
 # Start git submodule update in background with shallow clone
 # Using --depth 1 for faster clones since we only need the latest state
-(git submodule update --init --recursive --depth 1) &
+# Using --jobs 8 to clone multiple submodules in parallel
+(git submodule update --init --recursive --depth 1 --jobs 8) &
 GIT_PID=$!
 
 # Wait for both and capture exit codes


### PR DESCRIPTION
lawrencechen in ~/fun/cmux5 on preview-new-landing-ui-4 λ ./scripts/up.sh 
Setting up cmux...
Running bun install and git submodule update in parallel...
[0.20ms] ".env"
bun install v1.3.4 (5eb2145b)
Submodule 'dev-docs/beads' (https://github.com/steveyegge/beads) registered for path 'dev-docs/beads'
Submodule 'dev-docs/convex-js' (https://github.com/get-convex/convex-js) registered for path 'dev-docs/convex-js'
Submodule 'dev-docs/hono' (https://github.com/honojs/hono) registered for path 'dev-docs/hono'
Submodule 'dev-docs/nitro' (https://github.com/nitrojs/nitro) registered for path 'dev-docs/nitro'
Submodule 'dev-docs/opencode' (https://github.com/sst/opencode.git) registered for path 'dev-docs/opencode'
Submodule 'dev-docs/streamdown' (https://github.com/vercel/streamdown.git) registered for path 'dev-docs/streamdown'
Submodule 'dev-docs/tanstack-query' (https://github.com/tanstack/query) registered for path 'dev-docs/tanstack-query'
Submodule 'dev-docs/tanstack-router' (https://github.com/tanstack/router) registered for path 'dev-docs/tanstack-router'
Submodule 'dev-docs/vercel-workflow' (https://github.com/vercel/workflow.git) registered for path 'dev-docs/vercel-workflow'
Cloning into '/Users/lawrencechen/fun/cmux5/dev-docs/beads'...
  📦 Installing [866/3133] Cloning into '/Users/lawrencechen/fun/cmux5/dev-docs/convex-js'...
  📦 Installing [1164/3133] Cloning into '/Users/lawrencechen/fun/cmux5/dev-docs/hono'...
  📦 Installing [1675/3133] Cloning into '/Users/lawrencechen/fun/cmux5/dev-docs/nitro'...
  ⚙️  e... Cloning into '/Users/lawrencechen/fun/cmux5/dev-docs/opencode'...
  📦 Installing [2715/3133] 
make sure @scripts/up.sh does all in parallel, ideally depth 1 since we only care about the "main" branch. does it support if origin main is called something else (like master or dev?) make sure it does!