### PR TITLE
set main area min-width to viewport with snap

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -198,14 +198,15 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
   return (
     <div
       ref={containerRef}
-      className="relative bg-neutral-50 dark:bg-black flex flex-col shrink-0 h-dvh grow pr-1"
+      className="relative bg-neutral-50 dark:bg-black flex flex-col shrink-0 h-dvh grow pr-1 min-w-full snap-start snap-always md:min-w-0 md:snap-align-none"
       style={{
         display: isHidden ? "none" : "flex",
-        width: `${width}px`,
-        minWidth: `${width}px`,
-        maxWidth: `${width}px`,
+        width: undefined,
+        minWidth: undefined,
+        maxWidth: undefined,
         userSelect: isResizing ? ("none" as const) : undefined,
-      }}
+        "--sidebar-width": `${width}px`,
+      } as CSSProperties}
     >
       <div
         className={`h-[38px] flex items-center pr-1.5 shrink-0 ${isElectron ? "" : "pl-3"}`}

--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -198,7 +198,7 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
   return (
     <div
       ref={containerRef}
-      className="relative bg-neutral-50 dark:bg-black flex flex-col shrink-0 h-dvh grow pr-1 min-w-full snap-start snap-always md:min-w-0 md:snap-align-none"
+      className="relative bg-neutral-50 dark:bg-black flex flex-col shrink-0 h-dvh grow pr-1 min-w-[75vw] snap-start snap-always md:min-w-0 md:snap-align-none"
       style={{
         display: isHidden ? "none" : "flex",
         width: undefined,

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -511,3 +511,12 @@ pre,
   -webkit-user-drag: none;
   user-drag: none;
 }
+
+/* Sidebar responsive width */
+@media (min-width: 768px) {
+  [style*="--sidebar-width"] {
+    width: var(--sidebar-width) !important;
+    min-width: var(--sidebar-width) !important;
+    max-width: var(--sidebar-width) !important;
+  }
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.tsx
@@ -75,14 +75,14 @@ function LayoutComponent() {
     <ExpandTasksProvider>
       <CommandBar teamSlugOrId={teamSlugOrId} />
 
-      <div className="flex flex-row grow min-h-0 h-dvh bg-white dark:bg-black">
+      <div className="flex flex-row grow min-h-0 h-dvh bg-white dark:bg-black overflow-x-auto snap-x snap-mandatory md:overflow-x-visible md:snap-none">
         <Sidebar tasks={displayTasks} teamSlugOrId={teamSlugOrId} />
 
-        {/* <div className="flex flex-col grow overflow-hidden bg-white dark:bg-neutral-950"> */}
-        <Suspense fallback={<div>Loading...</div>}>
-          <Outlet />
-        </Suspense>
-        {/* </div> */}
+        <div className="min-w-full md:min-w-0 grow snap-start snap-always">
+          <Suspense fallback={<div>Loading...</div>}>
+            <Outlet />
+          </Suspense>
+        </div>
       </div>
 
       <button


### PR DESCRIPTION
let's support mobile better by making sure that on small viewports, the main area's min width is always the screen, so we can kinda scroll the sidebar out of the screen. we can do something fancy using horizontal scroll snap too, let's do that.