### PR TITLE
Auto-detect browser language for tooltip language picker

### DIFF
--- a/apps/www/components/pr/pull-request-diff-viewer.tsx
+++ b/apps/www/components/pr/pull-request-diff-viewer.tsx
@@ -100,7 +100,7 @@ import {
   HEATMAP_MODEL_QUERY_KEY,
   HEATMAP_LANGUAGE_QUERY_KEY,
   TOOLTIP_LANGUAGE_OPTIONS,
-  DEFAULT_TOOLTIP_LANGUAGE,
+  detectBrowserLanguage,
   type HeatmapModelQueryValue,
   type TooltipLanguageValue,
 } from "@/lib/services/code-review/model-config";
@@ -590,7 +590,7 @@ export function PullRequestDiffViewer({
   const [tooltipLanguagePreference, setTooltipLanguagePreference] =
     useLocalStorage<TooltipLanguageValue>({
       key: "cmux-tooltip-language",
-      defaultValue: DEFAULT_TOOLTIP_LANGUAGE,
+      defaultValue: detectBrowserLanguage(),
     });
   const heatmapModelPreferenceRef = useRef<HeatmapModelOptionValue>(
     heatmapModelPreference

--- a/apps/www/lib/services/code-review/model-config.ts
+++ b/apps/www/lib/services/code-review/model-config.ts
@@ -39,6 +39,73 @@ export type TooltipLanguageValue =
 
 export const DEFAULT_TOOLTIP_LANGUAGE: TooltipLanguageValue = "en";
 
+// Map browser language codes to supported tooltip languages
+// Handles both full codes (e.g., "zh-Hans") and base codes (e.g., "zh" -> "zh-Hans")
+const BROWSER_LANGUAGE_MAP: Record<string, TooltipLanguageValue> = {
+  // Direct mappings for supported languages
+  en: "en",
+  "zh-hans": "zh-Hans",
+  "zh-hant": "zh-Hant",
+  "zh-cn": "zh-Hans",
+  "zh-tw": "zh-Hant",
+  "zh-hk": "zh-Hant",
+  "zh-sg": "zh-Hans",
+  zh: "zh-Hans", // Default Chinese to Simplified
+  ja: "ja",
+  ko: "ko",
+  es: "es",
+  fr: "fr",
+  de: "de",
+  pt: "pt",
+  ru: "ru",
+  hi: "hi",
+  bn: "bn",
+  te: "te",
+  mr: "mr",
+  ta: "ta",
+  gu: "gu",
+  kn: "kn",
+  ml: "ml",
+  pa: "pa",
+  ar: "ar",
+  vi: "vi",
+  th: "th",
+  id: "id",
+};
+
+/**
+ * Detects the user's preferred language from the browser and maps it to a supported tooltip language.
+ * Falls back to English if no supported language is detected.
+ * This should only be called on the client side.
+ */
+export function detectBrowserLanguage(): TooltipLanguageValue {
+  if (typeof navigator === "undefined") {
+    return DEFAULT_TOOLTIP_LANGUAGE;
+  }
+
+  // Get browser languages in order of preference
+  const browserLanguages = navigator.languages ?? [navigator.language];
+
+  for (const lang of browserLanguages) {
+    if (!lang) continue;
+
+    const normalized = lang.toLowerCase();
+
+    // Try exact match first (e.g., "zh-Hans", "zh-TW")
+    if (normalized in BROWSER_LANGUAGE_MAP) {
+      return BROWSER_LANGUAGE_MAP[normalized];
+    }
+
+    // Try base language code (e.g., "en-US" -> "en")
+    const baseCode = normalized.split("-")[0];
+    if (baseCode in BROWSER_LANGUAGE_MAP) {
+      return BROWSER_LANGUAGE_MAP[baseCode];
+    }
+  }
+
+  return DEFAULT_TOOLTIP_LANGUAGE;
+}
+
 export function normalizeTooltipLanguage(
   raw: string | null | undefined
 ): TooltipLanguageValue {


### PR DESCRIPTION
## Summary
- Adds automatic browser language detection for the code review tooltip language picker
- New users will have the language picker pre-selected to their browser's preferred language (if supported)
- Falls back to English for unsupported languages or SSR

## Changes
- Added `detectBrowserLanguage()` function to `model-config.ts` that maps browser language codes to supported tooltip languages
- Handles regional variants (e.g., `zh-CN` → Simplified Chinese, `zh-TW` → Traditional Chinese)
- Updated `pull-request-diff-viewer.tsx` to use detected language as the default for `useLocalStorage`

## Test plan
- [ ] Verify language picker defaults to browser language for new users (clear localStorage)
- [ ] Verify existing user preferences are preserved (stored value takes precedence)
- [ ] Test with different browser language settings