### PR TITLE
fix: make .env file optional for direnv users

### DIFF
--- a/apps/www/vitest.config.ts
+++ b/apps/www/vitest.config.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
@@ -7,7 +8,12 @@ import { defineConfig } from "vitest/config";
 // In ESM, __dirname is not defined; derive it from import.meta.url
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+// Only load .env if it exists - supports both direnv users (no .env needed)
+// and traditional .env file users. dotenv won't override existing env vars.
+const envPath = path.resolve(__dirname, "../../.env");
+if (existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
 
 export default defineConfig({
   // Avoid Vite plugin type mismatches by setting alias directly


### PR DESCRIPTION
## Summary
- Support both direnv users (env vars pre-set) and traditional .env file users
- `vitest.config.ts`: Only load .env if file exists. dotenv won't override existing env vars.
- `staging.sh`: Remove hard requirement for .env file. If env vars are already set (via direnv), skip `--env-file` flag.

## Why
Enables using direnv for centralized env var management across multiple cmux directories while maintaining backward compatibility with .env files.

## Test plan
- [ ] Run `bun test` in apps/www with direnv (no .env file) - should work
- [ ] Run `bun test` in apps/www with .env file (no direnv) - should work  
- [ ] Run `./scripts/staging.sh` with direnv - should build without .env file
- [ ] Run `./scripts/staging.sh` with .env file - should work as before