### PR TITLE
Investigate and reduce iframe flicker in Chromium

### DIFF
--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -232,6 +232,7 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
   }, []);
 
   // Control iframe wrapper visibility based on this panel's expansion state
+  // Use opacity transitions to prevent white flash during panel expansion
   useEffect(() => {
     if (typeof document === "undefined" || !type) return;
 
@@ -251,12 +252,22 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
     if (!wrapper) return;
 
     if (isAnyPanelExpanded && !isExpanded) {
-      // Another panel is expanded - hide this iframe
-      wrapper.style.visibility = "hidden";
+      // Another panel is expanded - fade out and hide this iframe
+      wrapper.style.transition = "opacity 30ms ease-in";
+      wrapper.style.opacity = "0";
       wrapper.style.pointerEvents = "none";
+      // Fully hide after transition completes
+      const timeoutId = setTimeout(() => {
+        if (wrapper.style.opacity === "0") {
+          wrapper.style.visibility = "hidden";
+        }
+      }, 35);
+      return () => clearTimeout(timeoutId);
     } else {
-      // This panel is expanded OR no panel is expanded - show iframe
+      // This panel is expanded OR no panel is expanded - fade in
       wrapper.style.visibility = "visible";
+      wrapper.style.transition = "opacity 50ms ease-out";
+      wrapper.style.opacity = "1";
       wrapper.style.pointerEvents = "auto";
     }
   }, [type, position, isExpanded, isAnyPanelExpanded]);

--- a/apps/client/src/components/persistent-iframe.tsx
+++ b/apps/client/src/components/persistent-iframe.tsx
@@ -270,6 +270,7 @@ export function PersistentIframe({
   });
 
   // Hide non-expanded iframes when another panel is expanded
+  // Use opacity transitions to prevent white flash
   useEffect(() => {
     const wrapper = document.querySelector(
       `[data-iframe-key="${persistKey}"]`
@@ -277,12 +278,23 @@ export function PersistentIframe({
     if (!wrapper) return;
 
     if (isAnyPanelExpanded && !isExpanded) {
-      // Another panel is expanded - hide this iframe completely
-      wrapper.style.visibility = "hidden";
+      // Another panel is expanded - fade out and hide this iframe
+      wrapper.style.transition = "opacity 30ms ease-in";
+      wrapper.style.opacity = "0";
       wrapper.style.pointerEvents = "none";
+      // Fully hide after transition
+      const timeoutId = setTimeout(() => {
+        // Check if still should be hidden
+        if (wrapper.style.opacity === "0") {
+          wrapper.style.visibility = "hidden";
+        }
+      }, 35);
+      return () => clearTimeout(timeoutId);
     } else {
-      // This panel is expanded OR no panel is expanded - show normally
+      // This panel is expanded OR no panel is expanded - fade in
       wrapper.style.visibility = "visible";
+      wrapper.style.transition = "opacity 50ms ease-out";
+      wrapper.style.opacity = "1";
       wrapper.style.pointerEvents = "auto";
     }
   }, [persistKey, isExpanded, isAnyPanelExpanded]);

--- a/apps/client/src/lib/persistentIframeManager.ts
+++ b/apps/client/src/lib/persistentIframeManager.ts
@@ -159,11 +159,14 @@ class PersistentIframeManager {
     }
 
     // Create wrapper div
+    // Use opacity for transitions to prevent white flash on visibility toggle
+    // will-change and contain promote to compositor layer for smoother rendering
     const wrapper = document.createElement("div");
     wrapper.style.cssText = `
       position: fixed;
       top: 0;
       left: 0;
+      opacity: 0;
       visibility: hidden;
       pointer-events: none;
       overflow: hidden;
@@ -173,18 +176,23 @@ class PersistentIframeManager {
       backface-visibility: hidden;
       z-index: var(--z-iframe);
       isolation: isolate;
+      will-change: transform, opacity;
+      contain: strict;
+      content-visibility: auto;
     `;
     wrapper.setAttribute("data-iframe-key", key);
     wrapper.setAttribute("data-drag-disable-pointer", "");
 
     // Create iframe
+    // Use transparent background to prevent white flash before content loads
     const iframe = document.createElement("iframe");
     iframe.style.cssText = `
       width: 100%;
       height: 100%;
       border: 0;
-      background: white;
+      background: transparent;
       display: block;
+      color-scheme: normal;
     `;
 
     // Apply permissions if provided
@@ -246,53 +254,64 @@ class PersistentIframeManager {
       entry.wrapper.className = options.className;
     }
 
-    // First sync position while hidden
-    this.syncIframePosition(key);
+    // First sync position while hidden (synchronously to ensure correct position)
+    this.syncIframePositionSync(key);
 
-    // Then make visible after a microtask to ensure position is set
-    requestAnimationFrame(() => {
-      // Apply base styles without clobbering layout-related properties (width/height/transform)
-      entry.wrapper.style.position = "fixed";
-      entry.wrapper.style.top = "0";
-      entry.wrapper.style.left = "0";
-      entry.wrapper.style.right = "";
-      entry.wrapper.style.bottom = "";
-      entry.wrapper.style.visibility = "visible";
-      entry.wrapper.style.pointerEvents = "auto";
-      entry.wrapper.style.overflow = "hidden";
-      entry.wrapper.style.backfaceVisibility = "hidden";
+    // Apply base styles without clobbering layout-related properties (width/height/transform)
+    entry.wrapper.style.position = "fixed";
+    entry.wrapper.style.top = "0";
+    entry.wrapper.style.left = "0";
+    entry.wrapper.style.right = "";
+    entry.wrapper.style.bottom = "";
+    entry.wrapper.style.overflow = "hidden";
+    entry.wrapper.style.backfaceVisibility = "hidden";
+    entry.wrapper.style.willChange = "transform, opacity";
+    entry.wrapper.style.contain = "strict";
 
-      // Apply custom styles (including z-index if provided)
-      if (options?.style) {
-        for (const [styleKey, styleValue] of Object.entries(options.style)) {
-          if (styleValue === undefined || styleValue === null) {
-            continue;
-          }
-
-          const cssKey = styleKey.replace(
-            /[A-Z]/g,
-            (match) => `-${match.toLowerCase()}`
-          );
-          const cssValue =
-            typeof styleValue === "number" &&
-            !UNITLESS_CSS_PROPERTIES.has(cssKey)
-              ? `${styleValue}px`
-              : String(styleValue);
-          entry.wrapper.style.setProperty(cssKey, cssValue);
+    // Apply custom styles (including z-index if provided)
+    if (options?.style) {
+      for (const [styleKey, styleValue] of Object.entries(options.style)) {
+        if (styleValue === undefined || styleValue === null) {
+          continue;
         }
+
+        const cssKey = styleKey.replace(
+          /[A-Z]/g,
+          (match) => `-${match.toLowerCase()}`
+        );
+        const cssValue =
+          typeof styleValue === "number" &&
+          !UNITLESS_CSS_PROPERTIES.has(cssKey)
+            ? `${styleValue}px`
+            : String(styleValue);
+        entry.wrapper.style.setProperty(cssKey, cssValue);
       }
+    }
 
-      // Set default z-index if not provided in options
-      if (!options?.style?.zIndex) {
-        entry.wrapper.style.zIndex = "var(--z-iframe)";
-        entry.wrapper.style.isolation = "isolate";
-      }
+    // Set default z-index if not provided in options
+    if (!options?.style?.zIndex) {
+      entry.wrapper.style.zIndex = "var(--z-iframe)";
+      entry.wrapper.style.isolation = "isolate";
+    }
 
-      // Ensure the iframe wrapper reflects any layout changes triggered by new styles
-      this.syncIframePosition(key);
+    // Use double RAF to ensure layout is complete before showing
+    // First RAF: browser processes style changes
+    // Second RAF: safe to make visible with correct position
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        // Final position sync before becoming visible
+        this.syncIframePositionSync(key);
 
-      entry.isVisible = true;
-      if (this.debugMode) console.log(`[Mount] Iframe ${key} is now visible`);
+        // Make visible with opacity transition to prevent flash
+        entry.wrapper.style.visibility = "visible";
+        entry.wrapper.style.pointerEvents = "auto";
+        // Use a tiny delay before opacity to ensure visibility is processed first
+        entry.wrapper.style.transition = "opacity 50ms ease-out";
+        entry.wrapper.style.opacity = "1";
+
+        entry.isVisible = true;
+        if (this.debugMode) console.log(`[Mount] Iframe ${key} is now visible`);
+      });
     });
 
     entry.lastUsed = Date.now();
@@ -318,9 +337,21 @@ class PersistentIframeManager {
       if (this.debugMode) console.log(`[Unmount] Starting unmount for ${key}`);
 
       targetElement.removeAttribute("data-iframe-target");
-      entry.wrapper.style.visibility = "hidden";
+
+      // Fade out with transition to prevent flash
+      entry.wrapper.style.transition = "opacity 30ms ease-in";
+      entry.wrapper.style.opacity = "0";
       entry.wrapper.style.pointerEvents = "none";
       entry.isVisible = false;
+
+      // After transition, fully hide
+      setTimeout(() => {
+        if (!entry.isVisible) {
+          entry.wrapper.style.visibility = "hidden";
+          entry.wrapper.style.transition = "";
+          this.moveIframeOffscreen(entry);
+        }
+      }, 35);
 
       this.resizeObserver.unobserve(targetElement);
       scrollableParents.forEach((parent) => {
@@ -331,9 +362,30 @@ class PersistentIframeManager {
   }
 
   /**
-   * Sync iframe position with target element
+   * Sync iframe position with target element (async, batched via RAF)
    */
   private syncIframePosition(key: string) {
+    const entry = this.iframes.get(key);
+    if (!entry) return;
+
+    // Use requestAnimationFrame to batch position updates and prevent flashing
+    const existingTimeout = this.syncTimeouts.get(key);
+    if (existingTimeout !== undefined) {
+      cancelAnimationFrame(existingTimeout);
+    }
+
+    const rafId = requestAnimationFrame(() => {
+      this.syncTimeouts.delete(key);
+      this.syncIframePositionSync(key);
+    });
+
+    this.syncTimeouts.set(key, rafId);
+  }
+
+  /**
+   * Sync iframe position with target element (synchronous, for use during mount)
+   */
+  private syncIframePositionSync(key: string) {
     const entry = this.iframes.get(key);
     if (!entry) return;
 
@@ -361,21 +413,10 @@ class PersistentIframeManager {
       return;
     }
 
-    // Use requestAnimationFrame to batch position updates and prevent flashing
-    const existingTimeout = this.syncTimeouts.get(key);
-    if (existingTimeout !== undefined) {
-      cancelAnimationFrame(existingTimeout);
-    }
-
-    const rafId = requestAnimationFrame(() => {
-      this.syncTimeouts.delete(key);
-      // Update wrapper position using transform, keeping resize handles unobstructed
-      entry.wrapper.style.transform = `translate(${rect.left + borderLeft}px, ${rect.top + borderTop}px)`;
-      entry.wrapper.style.width = `${width}px`;
-      entry.wrapper.style.height = `${height}px`;
-    });
-
-    this.syncTimeouts.set(key, rafId);
+    // Update wrapper position using transform, keeping resize handles unobstructed
+    entry.wrapper.style.transform = `translate(${rect.left + borderLeft}px, ${rect.top + borderTop}px)`;
+    entry.wrapper.style.width = `${width}px`;
+    entry.wrapper.style.height = `${height}px`;
   }
 
   /**
@@ -407,7 +448,7 @@ class PersistentIframeManager {
   }
 
   /**
-   * Hide iframe
+   * Hide iframe with opacity transition to prevent flash
    */
   unmountIframe(key: string): void {
     const entry = this.iframes.get(key);
@@ -420,10 +461,21 @@ class PersistentIframeManager {
       this.syncTimeouts.delete(key);
     }
 
-    entry.wrapper.style.visibility = "hidden";
+    // Fade out first, then hide
+    entry.wrapper.style.transition = "opacity 30ms ease-in";
+    entry.wrapper.style.opacity = "0";
     entry.wrapper.style.pointerEvents = "none";
-    this.moveIframeOffscreen(entry);
     entry.isVisible = false;
+
+    // After transition completes, fully hide and move offscreen
+    setTimeout(() => {
+      // Check if still unmounted (not remounted during transition)
+      if (!entry.isVisible) {
+        entry.wrapper.style.visibility = "hidden";
+        entry.wrapper.style.transition = "";
+        this.moveIframeOffscreen(entry);
+      }
+    }, 35);
   }
 
   /**


### PR DESCRIPTION
The Chromium iframe flickering bug, especially with many iframes, often stems from hardware acceleration, driver issues, or complex CSS/JS rendering, causing white flashes during content loading; fixes involve disabling hardware acceleration, updating drivers, using CSS to hide iframes until load (visibility: hidden), or employing AJAX to load content, though it's a known browser-specific problem with ongoing user reports on Chromium Issue trackers. we have this bug sometimes, which i think is because of rendering too many iframes but i could be wrong. can you investigate and reduce this from happening. figure out why this is happening and find a way to reduce the probability of it happening, even if it's not fully our fault -- it's on chromium's side.