### PR TITLE
Disable sidebar movement on click

### DIFF
--- a/apps/client/src/components/SidebarToggleButton.tsx
+++ b/apps/client/src/components/SidebarToggleButton.tsx
@@ -29,7 +29,7 @@ export function SidebarToggleButton({
     >
       <ChevronRight
         className={clsx(
-          "transition-transform w-3 h-3",
+          "w-3 h-3",
           isExpanded && "rotate-90",
           iconClassName
         )}


### PR DESCRIPTION
when i click on the sidebar. the position of it moves too quickly, make it so that it doesn't move the sidebar position at all...