### PR TITLE
fix(client): always use cmux.app proxy URL for vscode workspace URLs

### DIFF
--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -116,11 +116,7 @@ export function toProxyWorkspaceUrl(
     return normalizedUrl;
   }
 
-  // In web mode, use the Morph URLs directly without proxy rewriting
-  if (env.NEXT_PUBLIC_WEB_MODE) {
-    return normalizedUrl;
-  }
-
+  // Always use the cmux.app proxy URL for vscode/workspace URLs
   const scope = "base"; // Default scope
   const proxiedUrl = new URL(components.url.toString());
   proxiedUrl.hostname = `cmux-${components.morphId}-${scope}-${components.port}.cmux.app`;


### PR DESCRIPTION
## Summary
- Remove the web mode check that was bypassing proxy URL rewriting for vscode workspace URLs
- The `toProxyWorkspaceUrl` function now always returns the cmux.app proxy URL format regardless of `NEXT_PUBLIC_WEB_MODE` setting

## Test plan
- [ ] Verify VSCode iframe loads correctly in web mode using `cmux-{morphId}-base-{port}.cmux.app` URLs
- [ ] Verify VSCode iframe still works in non-web mode (desktop app)