### PR TITLE
Migrate Docker registry from Docker Hub to GHCR

### DIFF
--- a/apps/server/src/scripts/debug-container-crash.ts
+++ b/apps/server/src/scripts/debug-container-crash.ts
@@ -9,7 +9,7 @@ async function main() {
 
   const container = await docker.createContainer({
     name: containerName,
-    Image: "cmux-worker:0.0.1",
+    Image: process.env.WORKER_IMAGE_NAME || "ghcr.io/manaflow-ai/cmux:latest",
     Env: ["NODE_ENV=production", "WORKER_PORT=39377"],
     HostConfig: {
       AutoRemove: false, // Don't auto-remove so we can inspect logs

--- a/apps/server/src/scripts/spawn-vscode-minimal.ts
+++ b/apps/server/src/scripts/spawn-vscode-minimal.ts
@@ -14,7 +14,7 @@ interface ContainerInfo {
 
 async function spawnVSCodeContainer(docker: Docker): Promise<ContainerInfo> {
   const containerName = `cmux-vscode-minimal-${Date.now()}`;
-  const imageName = "cmux-worker:0.0.1";
+  const imageName = process.env.WORKER_IMAGE_NAME || "ghcr.io/manaflow-ai/cmux:latest";
 
   console.log(`Creating container ${containerName}...`);
 

--- a/apps/server/src/vscode/DockerVSCodeInstance.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.ts
@@ -77,7 +77,7 @@ export class DockerVSCodeInstance extends VSCodeInstance {
   constructor(config: VSCodeInstanceConfig) {
     super(config);
     this.containerName = `cmux-${this.taskRunId}`;
-    this.imageName = process.env.WORKER_IMAGE_NAME || "cmux-worker:0.0.1";
+    this.imageName = process.env.WORKER_IMAGE_NAME || "ghcr.io/manaflow-ai/cmux:latest";
     dockerLogger.info(`WORKER_IMAGE_NAME: ${process.env.WORKER_IMAGE_NAME}`);
     dockerLogger.info(`this.imageName: ${this.imageName}`);
     // Register this instance

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -187,8 +187,8 @@ const Terminal = xtermHeadless.Terminal;
 // Configuration
 const WORKER_ID = process.env.WORKER_ID || `worker-${Date.now()}`;
 const WORKER_PORT = parseInt(process.env.WORKER_PORT || "39377", 10);
-const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || "cmux-worker";
-const CONTAINER_VERSION = process.env.CONTAINER_VERSION || "0.0.1";
+const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || "ghcr.io/manaflow-ai/cmux";
+const CONTAINER_VERSION = process.env.CONTAINER_VERSION || "latest";
 
 // Create Express app
 const app = express();

--- a/configs/nfpm/cmux.yaml
+++ b/configs/nfpm/cmux.yaml
@@ -9,7 +9,7 @@ maintainer: cmux <eng@cmux.dev>
 description: |
   cmux host runtime and services packaged for native installation.
 license: MIT
-homepage: https://github.com/lawrencecchen/cmux
+homepage: https://github.com/manaflow-ai/cmux
 depends:
   - systemd
   - bash

--- a/packages/cmux/package.json
+++ b/packages/cmux/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lawrencecchen/cmux"
+    "url": "https://github.com/manaflow-ai/cmux"
   },
   "bin": {
     "cmux": "./dist/cli.js"

--- a/packages/shared/src/providers/common/check-docker.ts
+++ b/packages/shared/src/providers/common/check-docker.ts
@@ -320,7 +320,7 @@ export async function checkDockerStatus(): Promise<DockerStatus> {
     }
   }
 
-  const imageName = process.env.WORKER_IMAGE_NAME ?? "cmux-worker:0.0.1";
+  const imageName = process.env.WORKER_IMAGE_NAME ?? "ghcr.io/manaflow-ai/cmux:latest";
 
   try {
     await execAsync(`docker image inspect "${imageName.replace(/"/g, '\\"')}"`);

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -7,7 +7,7 @@
   "publisher": "cmux",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lawrencecchen/cmux"
+    "url": "https://github.com/manaflow-ai/cmux"
   },
   "engines": {
     "vscode": "^1.101.2"

--- a/scripts/build-cli.ts
+++ b/scripts/build-cli.ts
@@ -203,7 +203,7 @@ const VERSION = cmuxPackageJson.version;
 
 // bun build the cli
 log(`Building CLI binary with version ${VERSION}...`);
-await $`bun build ./packages/cmux/src/cli.ts --compile --define VERSION="\"${VERSION}\"" --define process.env.WORKER_IMAGE_NAME="\"docker.io/lawrencecchen/cmux:${VERSION}\"" --define process.env.NODE_ENV="\"production\"" --outfile cmux-cli --target bun`;
+await $`bun build ./packages/cmux/src/cli.ts --compile --define VERSION="\"${VERSION}\"" --define process.env.WORKER_IMAGE_NAME="\"ghcr.io/manaflow-ai/cmux:${VERSION}\"" --define process.env.NODE_ENV="\"production\"" --outfile cmux-cli --target bun`;
 log("Successfully built cmux-cli binary");
 
 // Ensure all output is flushed

--- a/scripts/daytona-worker.ts
+++ b/scripts/daytona-worker.ts
@@ -7,7 +7,7 @@ const daytona = new Daytona();
 console.log("Creating sandbox...");
 const sandbox = await daytona.create(
   {
-    image: "cmux-worker:0.0.1",
+    image: process.env.WORKER_IMAGE_NAME || "ghcr.io/manaflow-ai/cmux:latest",
     public: true,
   },
   {

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -156,7 +156,8 @@ fi
 
 # Build Docker image (different logic for devcontainer vs host)
 # Allow overriding the build platform for cross-architecture builds
-DOCKER_BUILD_ARGS=(-t cmux-worker:0.0.1)
+# Tag with both local dev name and ghcr name for compatibility
+DOCKER_BUILD_ARGS=(-t cmux-worker:0.0.1 -t ghcr.io/manaflow-ai/cmux:latest)
 if [ -n "${CMUX_DOCKER_PLATFORM:-}" ]; then
     DOCKER_BUILD_ARGS+=(--platform "${CMUX_DOCKER_PLATFORM}")
 fi

--- a/scripts/docker-build-multiplatform.sh
+++ b/scripts/docker-build-multiplatform.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Docker Hub repository
-REPO="lawrencecchen/cmux"
+# GitHub Container Registry repository
+REPO="ghcr.io/manaflow-ai/cmux"
 
 # Get version from argument or use 'latest'
 VERSION=${1:-latest}
@@ -18,5 +18,5 @@ docker buildx build \
   --push \
   .
 
-echo "Successfully built and pushed multi-platform image to Docker Hub!"
+echo "Successfully built and pushed multi-platform image to GHCR!"
 echo "Users can now run: docker pull ${REPO}:latest"

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Docker Hub repository
-REPO="lawrencecchen/cmux"
+# GitHub Container Registry repository
+REPO="ghcr.io/manaflow-ai/cmux"
 
 # Get version from package.json or use 'latest'
 VERSION=${1:-latest}

--- a/scripts/docker-push-simple.sh
+++ b/scripts/docker-push-simple.sh
@@ -9,8 +9,8 @@ log() {
     echo "[$(date +"%Y-%m-%d %H:%M:%S")] $1"
 }
 
-# Docker Hub repository
-REPO="lawrencecchen/cmux"
+# GitHub Container Registry repository
+REPO="ghcr.io/manaflow-ai/cmux"
 
 # Get version from argument or use 'latest'
 VERSION=${1:-latest}
@@ -58,7 +58,7 @@ attempt_push() {
     kill -9 $pid 2>/dev/null || true
     wait $pid 2>/dev/null || true
     
-    # Check if it actually made it to Docker Hub despite timeout
+    # Check if it actually made it to GHCR despite timeout
     if docker manifest inspect ${REPO}:${tag} >/dev/null 2>&1; then
         log "Push appears successful for ${REPO}:${tag} (image is accessible)"
         return 0

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -15,9 +15,9 @@ done
 ./scripts/clean.sh
 
 if [ "$NO_CACHE" = true ]; then
-  docker build -t cmux-worker:0.0.1 . --no-cache &
+  docker build -t cmux-worker:0.0.1 -t ghcr.io/manaflow-ai/cmux:latest . --no-cache &
 else
-  docker build -t cmux-worker:0.0.1 . &
+  docker build -t cmux-worker:0.0.1 -t ghcr.io/manaflow-ai/cmux:latest . &
 fi
 
 bun i --frozen-lockfile &

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -156,7 +156,7 @@ echo "----------------------------------------"
 # Don't fail on Docker push issues as they're often transient with OrbStack
 if [ $? -ne 0 ]; then
   warning "Docker push had issues (common with OrbStack)"
-  warning "You may need to manually push later: docker push lawrencecchen/cmux:$NEW_VERSION"
+  warning "You may need to manually push later: docker push ghcr.io/manaflow-ai/cmux:$NEW_VERSION"
 else
   success "Docker build and push complete"
 fi
@@ -188,4 +188,4 @@ echo ""
 echo "Next steps:"
 echo "  - Verify the package on npm: https://www.npmjs.com/package/cmux"
 echo "  - Test installation: npm install -g cmux@$NEW_VERSION"
-echo "  - Verify Docker image: docker pull lawrencecchen/cmux:$NEW_VERSION"
+echo "  - Verify Docker image: docker pull ghcr.io/manaflow-ai/cmux:$NEW_VERSION"


### PR DESCRIPTION
## Summary

- Migrate all Docker image references from `docker.io/lawrencecchen/cmux` to `ghcr.io/manaflow-ai/cmux`
- Update default fallbacks from `cmux-worker:0.0.1` to `ghcr.io/manaflow-ai/cmux:latest`
- Update all build/push scripts for GHCR authentication
- Update GitHub URLs in package.json files to `manaflow-ai/cmux`

## Why GHCR over Docker Hub?

- No pull rate limits for authenticated GitHub users
- Integrated with GitHub Actions for CI/CD
- One less account/credential to manage
- Free for public repos

## Changes

| File | Change |
|------|--------|
| `scripts/docker-*.sh` | Change repo to `ghcr.io/manaflow-ai/cmux` |
| `scripts/build-cli.ts` | Bake `ghcr.io/manaflow-ai/cmux:VERSION` into production CLI |
| `check-docker.ts`, `DockerVSCodeInstance.ts` | Change default fallback to `ghcr.io/manaflow-ai/cmux:latest` |
| `dev.sh`, `maintenance.sh` | Tag local builds with both names for compat |
| `package.json` files | Update GitHub URLs |

## Test plan

- [ ] Build Docker image locally: `./scripts/docker-build.sh`
- [ ] Verify image tags: `docker images | grep manaflow`
- [ ] Test push to GHCR (requires `docker login ghcr.io`)
- [ ] Run dev server and verify Docker provider works