### PR TITLE
Add web version button on landing page linking to cmux.sh

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -4,6 +4,7 @@ import {
   ArrowRight,
   Cloud,
   GitPullRequest,
+  Globe,
   Layers,
   Settings,
   Terminal,
@@ -215,11 +216,20 @@ export default async function LandingPage() {
                   </p>
                 </div>
               </div>
-              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <a
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 bg-white px-4 py-3 text-sm font-semibold text-black shadow-xl transition hover:bg-neutral-100"
+                  href="https://cmux.sh"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <Globe className="h-4 w-4" aria-hidden />
+                  Try Web version
+                </a>
                 <MacDownloadLink
                   autoDetect
                   fallbackUrl={fallbackUrl}
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 bg-white px-4 py-3 text-sm font-semibold text-black shadow-xl transition hover:bg-neutral-100"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-neutral-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800"
                   title={
                     latestVersion
                       ? `Download cmux ${latestVersion} for macOS`
@@ -239,38 +249,6 @@ export default async function LandingPage() {
                     <span>Download for macOS</span>
                   </span>
                 </MacDownloadLink>
-                <a
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/10"
-                  href="https://cmux.sh"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Try web version
-                  <svg
-                    className="h-4 w-4"
-                    aria-hidden
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A8.966 8.966 0 0 1 3 12c0-1.97.633-3.794 1.707-5.278" />
-                  </svg>
-                </a>
-                <Link
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/10"
-                  href="https://github.com/manaflow-ai/cmux"
-                >
-                  See GitHub repo
-                  <svg
-                    className="h-4 w-4"
-                    aria-hidden
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                  </svg>
-                </Link>
               </div>
               {latestVersion ? (
                 <p className="text-xs text-neutral-400">

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -215,7 +215,7 @@ export default async function LandingPage() {
                   </p>
                 </div>
               </div>
-              <div className="flex flex-col gap-3 sm:flex-row">
+              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                 <MacDownloadLink
                   autoDetect
                   fallbackUrl={fallbackUrl}
@@ -239,6 +239,24 @@ export default async function LandingPage() {
                     <span>Download for macOS</span>
                   </span>
                 </MacDownloadLink>
+                <a
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/10"
+                  href="https://cmux.sh"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Try web version
+                  <svg
+                    className="h-4 w-4"
+                    aria-hidden
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A8.966 8.966 0 0 1 3 12c0-1.97.633-3.794 1.707-5.278" />
+                  </svg>
+                </a>
                 <Link
                   className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/10"
                   href="https://github.com/manaflow-ai/cmux"

--- a/apps/www/components/site-header.tsx
+++ b/apps/www/components/site-header.tsx
@@ -4,7 +4,7 @@ import CmuxLogo from "@/components/logo/cmux-logo";
 import { MacDownloadLink } from "@/components/mac-download-link";
 import type { MacDownloadUrls } from "@/lib/releases";
 import clsx from "clsx";
-import { Download } from "lucide-react";
+import { Download, Globe } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -138,7 +138,7 @@ export function SiteHeader({
             <MacDownloadLink
               autoDetect
               fallbackUrl={fallbackUrl}
-              className="hidden md:inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-black shadow-sm transition hover:bg-neutral-100"
+              className="hidden md:inline-flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-neutral-800"
               title={
                 latestVersion
                   ? `Download cmux ${latestVersion} for macOS`
@@ -150,6 +150,15 @@ export function SiteHeader({
               <span>Download</span>
             </MacDownloadLink>
           ) : null}
+          <a
+            className="hidden md:inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-black shadow-sm transition hover:bg-neutral-100"
+            href="https://cmux.sh"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <Globe className="h-4 w-4" aria-hidden />
+            <span>Web</span>
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
add a web version button in the front page in between see github repo and download for mac... it should be Try web version and link to cmux.sh instead. in the front landing page of cmux.dev