### PR TITLE
Open local tasks from correct Docker mount

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -1450,7 +1450,7 @@ function TaskRunTreeInner({
   // Generate VSCode URL if available - used for "Open with" actions
   const hasActiveVSCode = run.vscode?.status === "running";
   const vscodeUrl = useMemo(
-    () => (hasActiveVSCode && run.vscode?.url) || null,
+    () => (hasActiveVSCode && run.vscode?.workspaceUrl) || null,
     [hasActiveVSCode, run]
   );
 

--- a/apps/client/src/hooks/useOpenWithActions.ts
+++ b/apps/client/src/hooks/useOpenWithActions.ts
@@ -58,8 +58,13 @@ export function useOpenWithActions({
             vscodeUrl,
             localServeWebOrigin,
           );
-          const vscodeUrlWithWorkspace = `${normalizedUrl}?folder=/root/workspace`;
-          window.open(vscodeUrlWithWorkspace, "_blank", "noopener,noreferrer");
+          // If the URL already has a folder parameter, use it as-is.
+          // Otherwise, append the default /root/workspace folder.
+          const url = new URL(normalizedUrl);
+          if (!url.searchParams.has("folder")) {
+            url.searchParams.set("folder", "/root/workspace");
+          }
+          window.open(url.toString(), "_blank", "noopener,noreferrer");
           resolve();
         } else if (
           socket &&


### PR DESCRIPTION
we need to fix local tasks. currently our local tasks open up the workspace in the wrong place. we need to figure out where docker container is mounted and open it in that place. it is actually different from the place where we are opening local workspaces (which is why we have this issue). find the correct folder where the local tasks are starting from and open it from the correctly mounted place. ultrathink