### PR TITLE
cron: pause 20h-old convex instances via OpenAPI morph

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as codeReviewActions from "../codeReviewActions.js";
 import type * as codeReview_http from "../codeReview_http.js";
 import type * as comments from "../comments.js";
 import type * as containerSettings from "../containerSettings.js";
+import type * as crons from "../crons.js";
 import type * as crown from "../crown.js";
 import type * as crown_actions from "../crown/actions.js";
 import type * as crown_http from "../crown_http.js";
@@ -39,6 +40,7 @@ import type * as hostScreenshotCollector_http from "../hostScreenshotCollector_h
 import type * as http from "../http.js";
 import type * as localWorkspaces from "../localWorkspaces.js";
 import type * as migrations from "../migrations.js";
+import type * as morphInstanceMaintenance from "../morphInstanceMaintenance.js";
 import type * as previewConfigs from "../previewConfigs.js";
 import type * as previewRuns from "../previewRuns.js";
 import type * as previewScreenshots from "../previewScreenshots.js";
@@ -79,6 +81,7 @@ declare const fullApi: ApiFromModules<{
   codeReview_http: typeof codeReview_http;
   comments: typeof comments;
   containerSettings: typeof containerSettings;
+  crons: typeof crons;
   crown: typeof crown;
   "crown/actions": typeof crown_actions;
   crown_http: typeof crown_http;
@@ -103,6 +106,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   localWorkspaces: typeof localWorkspaces;
   migrations: typeof migrations;
+  morphInstanceMaintenance: typeof morphInstanceMaintenance;
   previewConfigs: typeof previewConfigs;
   previewRuns: typeof previewRuns;
   previewScreenshots: typeof previewScreenshots;

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -1,0 +1,17 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+// Pause Morph instances older than 20 hours
+// Runs daily at 5 AM Pacific Time
+// 5 AM PST = 13:00 UTC (during standard time)
+// 5 AM PDT = 12:00 UTC (during daylight saving)
+// Using 13:00 UTC means it runs at 5 AM PST or 6 AM PDT
+crons.daily(
+  "pause old morph instances",
+  { hourUTC: 13, minuteUTC: 0 },
+  internal.morphInstanceMaintenance.pauseOldMorphInstances
+);
+
+export default crons;

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -4,13 +4,13 @@ import { internal } from "./_generated/api";
 const crons = cronJobs();
 
 // Pause Morph instances older than 20 hours
-// Runs daily at 5 AM Pacific Time
-// 5 AM PST = 13:00 UTC (during standard time)
-// 5 AM PDT = 12:00 UTC (during daylight saving)
-// Using 13:00 UTC means it runs at 5 AM PST or 6 AM PDT
+// Runs daily at 4 AM Pacific Time
+// 4 AM PST = 12:00 UTC (during standard time)
+// 4 AM PDT = 11:00 UTC (during daylight saving)
+// Using 12:00 UTC means it runs at 4 AM PST or 5 AM PDT
 crons.daily(
   "pause old morph instances",
-  { hourUTC: 13, minuteUTC: 0 },
+  { hourUTC: 12, minuteUTC: 0 },
   internal.morphInstanceMaintenance.pauseOldMorphInstances
 );
 

--- a/packages/convex/convex/morphInstanceMaintenance.ts
+++ b/packages/convex/convex/morphInstanceMaintenance.ts
@@ -1,0 +1,116 @@
+"use node";
+
+import { internalAction } from "./_generated/server";
+import { env } from "../_shared/convex-env";
+import {
+  createMorphCloudClient,
+  listInstancesInstanceGet,
+  pauseInstanceInstanceInstanceIdPausePost,
+  type InstanceModel,
+} from "@cmux/morphcloud-openapi-client";
+
+const HOURS_THRESHOLD = 20;
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+
+/**
+ * Pauses all Morph instances that have been running for more than 20 hours.
+ * Called by the daily cron job at 5 AM Pacific Time.
+ */
+export const pauseOldMorphInstances = internalAction({
+  args: {},
+  handler: async () => {
+    const morphApiKey = env.MORPH_API_KEY;
+    if (!morphApiKey) {
+      console.error("[morphInstanceMaintenance] MORPH_API_KEY not configured");
+      return;
+    }
+
+    const morphClient = createMorphCloudClient({
+      auth: morphApiKey,
+    });
+
+    // List all instances
+    const listResponse = await listInstancesInstanceGet({
+      client: morphClient,
+    });
+
+    if (listResponse.error) {
+      console.error(
+        "[morphInstanceMaintenance] Failed to list instances:",
+        listResponse.error
+      );
+      return;
+    }
+
+    const instances = listResponse.data?.data ?? [];
+    if (instances.length === 0) {
+      console.log("[morphInstanceMaintenance] No instances found");
+      return;
+    }
+
+    const now = Date.now();
+    const thresholdMs = HOURS_THRESHOLD * MILLISECONDS_PER_HOUR;
+
+    // Filter for ready instances older than the threshold
+    const staleActiveInstances = instances
+      .filter((instance: InstanceModel) => instance.status === "ready")
+      .filter((instance: InstanceModel) => {
+        const createdMs = instance.created * 1000;
+        return now - createdMs > thresholdMs;
+      })
+      .sort((a: InstanceModel, b: InstanceModel) => a.created - b.created);
+
+    if (staleActiveInstances.length === 0) {
+      console.log(
+        `[morphInstanceMaintenance] No active instances older than ${HOURS_THRESHOLD} hours`
+      );
+      return;
+    }
+
+    console.log(
+      `[morphInstanceMaintenance] Found ${staleActiveInstances.length} active instance(s) older than ${HOURS_THRESHOLD} hours`
+    );
+
+    let successCount = 0;
+    let failureCount = 0;
+
+    // Process instances sequentially to avoid rate limiting
+    for (const instance of staleActiveInstances) {
+      const ageHours = Math.floor(
+        (now - instance.created * 1000) / MILLISECONDS_PER_HOUR
+      );
+      console.log(
+        `[morphInstanceMaintenance] Pausing ${instance.id} (${ageHours}h old)...`
+      );
+
+      try {
+        const pauseResponse = await pauseInstanceInstanceInstanceIdPausePost({
+          client: morphClient,
+          path: { instance_id: instance.id },
+        });
+
+        if (pauseResponse.error) {
+          failureCount++;
+          console.error(
+            `[morphInstanceMaintenance] Failed to pause ${instance.id}:`,
+            pauseResponse.error
+          );
+        } else {
+          successCount++;
+          console.log(`[morphInstanceMaintenance] Paused ${instance.id}`);
+        }
+      } catch (error) {
+        failureCount++;
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[morphInstanceMaintenance] Error pausing ${instance.id}:`,
+          message
+        );
+      }
+    }
+
+    console.log(
+      `[morphInstanceMaintenance] Finished: ${successCount} paused, ${failureCount} failed`
+    );
+  },
+});

--- a/packages/convex/convex/morphInstanceMaintenance.ts
+++ b/packages/convex/convex/morphInstanceMaintenance.ts
@@ -14,7 +14,7 @@ const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
 
 /**
  * Pauses all Morph instances that have been running for more than 20 hours.
- * Called by the daily cron job at 5 AM Pacific Time.
+ * Called by the daily cron job at 4 AM Pacific Time.
  */
 export const pauseOldMorphInstances = internalAction({
   args: {},


### PR DESCRIPTION
make a convex cron job that runs every day at 5AM pacific time -- it needs to pause (NOT stop) all instances that are older than 20 hours. similar to @scripts/morph-pause-old-active-instances.ts but we need to use the openapi version of morph instead of the npm packag. and not stop the ones that fail to delete. make sure to console error if there's issues tho.