### PR TITLE
Show loading indicators for cmux diff preview

### DIFF
--- a/apps/client/src/components/TaskRunGitDiffPanel.tsx
+++ b/apps/client/src/components/TaskRunGitDiffPanel.tsx
@@ -78,6 +78,7 @@ export function TaskRunGitDiffPanel({ task, selectedRun, teamSlugOrId, taskId, s
   );
 
   const screenshotSets = runDiffContext?.screenshotSets ?? [];
+  const previewRunStatus = runDiffContext?.previewRunStatus ?? null;
   const screenshotSetsLoading = runDiffContext === undefined && screenshotSets.length === 0;
 
   if (!selectedRun || !normalizedHeadBranch) {
@@ -122,6 +123,7 @@ export function TaskRunGitDiffPanel({ task, selectedRun, teamSlugOrId, taskId, s
         <RunScreenshotGallery
           screenshotSets={screenshotSets}
           highlightedSetId={selectedRun?.latestScreenshotSetId ?? null}
+          previewRunStatus={previewRunStatus}
         />
       )}
       <MonacoGitDiffViewer diffs={allDiffs} />

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -638,6 +638,7 @@ function RunDiffPage() {
   });
 
   const screenshotSets = runDiffContextQuery.data?.screenshotSets ?? [];
+  const previewRunStatus = runDiffContextQuery.data?.previewRunStatus ?? null;
   const screenshotSetsLoading =
     runDiffContextQuery.isLoading && screenshotSets.length === 0;
 
@@ -872,6 +873,7 @@ function RunDiffPage() {
               <RunScreenshotGallery
                 screenshotSets={screenshotSets}
                 highlightedSetId={selectedRun?.latestScreenshotSetId ?? null}
+                previewRunStatus={previewRunStatus}
               />
             )}
             <div className="flex-1 min-h-0 flex flex-col">

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",


### PR DESCRIPTION
in cmux diff viewer we have that it starts the preview screenshots job. we need to have loading indiciators to show that the screenshot agent is running. we need to be of a similar codepath as the screenshot agent for the github prs in which it shows if there is no ui changes or if there are images, it should show them in good taste with the captions (although it basically already does this). we just need to fix all of the bugs and make sure that it is very consistent.