### PR TITLE
Only run morph pause cron in production

### DIFF
--- a/packages/convex/_shared/convex-env.ts
+++ b/packages/convex/_shared/convex-env.ts
@@ -19,6 +19,7 @@ export const env = createEnv({
     ANTHROPIC_API_KEY: z.string().min(1).optional(),
     MORPH_API_KEY: z.string().min(1).optional(),
     CMUX_IS_STAGING: z.string().optional(),
+    CONVEX_IS_PRODUCTION: z.string().optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/packages/convex/convex/morphInstanceMaintenance.ts
+++ b/packages/convex/convex/morphInstanceMaintenance.ts
@@ -20,6 +20,12 @@ const BATCH_SIZE = 5;
 export const pauseOldMorphInstances = internalAction({
   args: {},
   handler: async () => {
+    // Only run in production to avoid dev crons affecting prod instances
+    if (!env.CONVEX_IS_PRODUCTION) {
+      console.log("[morphInstanceMaintenance] Skipping: not in production");
+      return;
+    }
+
     const morphApiKey = env.MORPH_API_KEY;
     if (!morphApiKey) {
       console.error("[morphInstanceMaintenance] MORPH_API_KEY not configured");


### PR DESCRIPTION
## Summary
- Add `CONVEX_IS_PRODUCTION` env var check to the morph instance pause cron
- Prevents dev/staging crons from accidentally affecting production Morph instances

## Test plan
- [ ] Set `CONVEX_IS_PRODUCTION=true` in production Convex environment
- [ ] Verify cron skips execution in dev mode (check logs for "Skipping: not in production")
- [ ] Verify cron runs normally in production