### PR TITLE
Inject auth.json into morph VM settings

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -895,7 +895,7 @@ function SettingsComponent() {
                                     }
                                     rows={4}
                                     className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y"
-                                    placeholder='{"token": "...", ...}'
+                                    placeholder='{"tokens": {"id_token": "...", "access_token": "...", "refresh_token": "...", "account_id": "..."}, "last_refresh": "..."}'
                                   />
                                 </div>
                               ) : (

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -884,19 +884,28 @@ function SettingsComponent() {
                             <div className="md:w-[min(100%,480px)] md:flex-shrink-0 self-start">
                               {key.envVar === "CODEX_AUTH_JSON" ? (
                                 <div className="relative">
-                                  <textarea
-                                    id={key.envVar}
-                                    value={apiKeyValues[key.envVar] || ""}
-                                    onChange={(e) =>
-                                      handleApiKeyChange(
-                                        key.envVar,
-                                        e.target.value
-                                      )
-                                    }
-                                    rows={4}
-                                    className={`w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y ${!showKeys[key.envVar] && apiKeyValues[key.envVar] ? "blur-sm select-none" : ""}`}
-                                    placeholder='{"tokens": {"id_token": "...", "access_token": "...", "refresh_token": "...", "account_id": "..."}, "last_refresh": "..."}'
-                                  />
+                                  {showKeys[key.envVar] ? (
+                                    <textarea
+                                      id={key.envVar}
+                                      value={apiKeyValues[key.envVar] || ""}
+                                      onChange={(e) =>
+                                        handleApiKeyChange(
+                                          key.envVar,
+                                          e.target.value
+                                        )
+                                      }
+                                      rows={4}
+                                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y"
+                                      placeholder='{"tokens": {"id_token": "...", "access_token": "...", "refresh_token": "...", "account_id": "..."}, "last_refresh": "..."}'
+                                    />
+                                  ) : (
+                                    <div
+                                      onClick={() => toggleShowKey(key.envVar)}
+                                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs cursor-pointer min-h-[6rem]"
+                                    >
+                                      {apiKeyValues[key.envVar] ? "••••••••••••••••••••••••••••••••" : <span className="text-neutral-400">{"Click to edit"}</span>}
+                                    </div>
+                                  )}
                                   <button
                                     type="button"
                                     onClick={() => toggleShowKey(key.envVar)}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -36,6 +36,10 @@ const PROVIDER_INFO: Record<string, ProviderInfo> = {
   OPENAI_API_KEY: {
     url: "https://platform.openai.com/api-keys",
   },
+  CODEX_AUTH_JSON: {
+    helpText:
+      "Paste the contents of ~/.codex/auth.json here. This allows Codex to use your OpenAI authentication.",
+  },
   OPENROUTER_API_KEY: {
     url: "https://openrouter.ai/keys",
   },
@@ -878,6 +882,23 @@ function SettingsComponent() {
                             </div>
 
                             <div className="md:w-[min(100%,480px)] md:flex-shrink-0 self-start">
+                              {key.envVar === "CODEX_AUTH_JSON" ? (
+                                <div className="relative">
+                                  <textarea
+                                    id={key.envVar}
+                                    value={apiKeyValues[key.envVar] || ""}
+                                    onChange={(e) =>
+                                      handleApiKeyChange(
+                                        key.envVar,
+                                        e.target.value
+                                      )
+                                    }
+                                    rows={4}
+                                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y"
+                                    placeholder='{"token": "...", ...}'
+                                  />
+                                </div>
+                              ) : (
                               <div className="relative">
                                 <input
                                   type={
@@ -946,6 +967,7 @@ function SettingsComponent() {
                                   )}
                                 </button>
                               </div>
+                              )}
                               {originalApiKeyValues[key.envVar] && (
                                 <div className="flex items-center gap-1 mt-1">
                                   <svg

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -894,9 +894,50 @@ function SettingsComponent() {
                                       )
                                     }
                                     rows={4}
-                                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y"
+                                    className={`w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y ${!showKeys[key.envVar] && apiKeyValues[key.envVar] ? "blur-sm select-none" : ""}`}
                                     placeholder='{"tokens": {"id_token": "...", "access_token": "...", "refresh_token": "...", "account_id": "..."}, "last_refresh": "..."}'
                                   />
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleShowKey(key.envVar)}
+                                    className="absolute top-2 right-2 p-1 text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+                                  >
+                                    {showKeys[key.envVar] ? (
+                                      <svg
+                                        className="h-5 w-5"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth={2}
+                                          d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                                        />
+                                      </svg>
+                                    ) : (
+                                      <svg
+                                        className="h-5 w-5"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth={2}
+                                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                                        />
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth={2}
+                                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                                        />
+                                      </svg>
+                                    )}
+                                  </button>
                                 </div>
                               ) : (
                               <div className="relative">

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -901,7 +901,7 @@ function SettingsComponent() {
                                   ) : (
                                     <div
                                       onClick={() => toggleShowKey(key.envVar)}
-                                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs cursor-pointer min-h-[6rem]"
+                                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs cursor-pointer h-[82px]"
                                     >
                                       {apiKeyValues[key.envVar] ? "••••••••••••••••••••••••••••••••" : <span className="text-neutral-400">{"Click to edit"}</span>}
                                     </div>

--- a/apps/server/src/utils/providerStatus.ts
+++ b/apps/server/src/utils/providerStatus.ts
@@ -99,6 +99,10 @@ export async function checkAllProvidersStatusWebMode(options: {
       // Special handling for Claude agents: CLAUDE_CODE_OAUTH_TOKEN OR ANTHROPIC_API_KEY
       // (OAuth token is preferred, but API key works too)
       const isClaudeAgent = agent.name.startsWith("claude/");
+      // Special handling for Codex agents: CODEX_AUTH_JSON OR OPENAI_API_KEY
+      // (auth.json with OAuth tokens is preferred, but API key works too)
+      const isCodexAgent = agent.name.startsWith("codex/");
+
       if (isClaudeAgent) {
         const hasOAuthToken =
           apiKeys.CLAUDE_CODE_OAUTH_TOKEN &&
@@ -109,6 +113,14 @@ export async function checkAllProvidersStatusWebMode(options: {
           missingRequirements.push(
             "Claude OAuth Token or Anthropic API Key"
           );
+        }
+      } else if (isCodexAgent) {
+        const hasAuthJson =
+          apiKeys.CODEX_AUTH_JSON && apiKeys.CODEX_AUTH_JSON.trim() !== "";
+        const hasApiKey =
+          apiKeys.OPENAI_API_KEY && apiKeys.OPENAI_API_KEY.trim() !== "";
+        if (!hasAuthJson && !hasApiKey) {
+          missingRequirements.push("Codex Auth JSON or OpenAI API Key");
         }
       } else {
         // For other agents, check all required keys

--- a/packages/shared/src/apiKeys.ts
+++ b/packages/shared/src/apiKeys.ts
@@ -54,3 +54,10 @@ export const CLAUDE_CODE_OAUTH_TOKEN: AgentConfigApiKey = {
   description:
     "OAuth token from Claude Code CLI. Run `claude setup-token` and paste the output here. Preferred over Anthropic API key when set.",
 };
+
+export const CODEX_AUTH_JSON: AgentConfigApiKey = {
+  envVar: "CODEX_AUTH_JSON",
+  displayName: "Codex Auth JSON",
+  description:
+    "Contents of ~/.codex/auth.json. Copy and paste the full JSON contents here.",
+};

--- a/packages/shared/src/providers/openai/configs.ts
+++ b/packages/shared/src/providers/openai/configs.ts
@@ -1,9 +1,9 @@
 import type { AgentConfig } from "../../agentConfig";
-import { OPENAI_API_KEY } from "../../apiKeys";
+import { CODEX_AUTH_JSON, OPENAI_API_KEY } from "../../apiKeys";
 import { checkOpenAIRequirements } from "./check-requirements";
 // Lazy-load Node-only completion detector to avoid bundling fs in browser
 import { startCodexCompletionDetector } from "./completion-detector";
-import { getOpenAIEnvironment } from "./environment";
+import { applyCodexApiKeys, getOpenAIEnvironment } from "./environment";
 
 export const CODEX_GPT_5_2_CODEX_XHIGH_REASONING_CONFIG: AgentConfig = {
   name: "codex/gpt-5.2-codex-xhigh",
@@ -22,7 +22,8 @@ export const CODEX_GPT_5_2_CODEX_XHIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -43,7 +44,8 @@ export const CODEX_GPT_5_2_CODEX_HIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -64,7 +66,8 @@ export const CODEX_GPT_5_2_CODEX_MEDIUM_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -85,7 +88,8 @@ export const CODEX_GPT_5_2_CODEX_LOW_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -104,7 +108,8 @@ export const CODEX_GPT_5_2_CODEX_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -125,7 +130,8 @@ export const CODEX_GPT_5_1_CODEX_MAX_XHIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -146,7 +152,8 @@ export const CODEX_GPT_5_1_CODEX_MAX_HIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -167,7 +174,8 @@ export const CODEX_GPT_5_1_CODEX_MAX_MEDIUM_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -188,7 +196,8 @@ export const CODEX_GPT_5_1_CODEX_MAX_LOW_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -207,7 +216,8 @@ export const CODEX_GPT_5_1_CODEX_MAX_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -226,7 +236,8 @@ export const CODEX_GPT_5_1_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -245,7 +256,8 @@ export const CODEX_GPT_5_1_CODEX_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -264,7 +276,8 @@ export const CODEX_GPT_5_1_CODEX_MINI_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -285,7 +298,8 @@ export const CODEX_GPT_5_1_CODEX_HIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -304,7 +318,8 @@ export const CODEX_GPT_5_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -325,7 +340,8 @@ export const CODEX_GPT_5_HIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -346,7 +362,8 @@ export const CODEX_GPT_5_MEDIUM_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -367,7 +384,8 @@ export const CODEX_GPT_5_LOW_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -388,7 +406,8 @@ export const CODEX_GPT_5_MINIMAL_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -407,7 +426,8 @@ export const CODEX_O3_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -426,7 +446,8 @@ export const CODEX_O4_MINI_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -445,7 +466,8 @@ export const CODEX_GPT_4_1_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -464,7 +486,8 @@ export const CODEX_GPT_5_CODEX_MINI_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -485,7 +508,8 @@ export const CODEX_GPT_5_CODEX_LOW_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -506,7 +530,8 @@ export const CODEX_GPT_5_CODEX_MEDIUM_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -527,7 +552,8 @@ export const CODEX_GPT_5_CODEX_HIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -546,7 +572,8 @@ export const CODEX_GPT_5_2_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -567,7 +594,8 @@ export const CODEX_GPT_5_2_LOW_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -588,7 +616,8 @@ export const CODEX_GPT_5_2_MEDIUM_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };
 
@@ -609,6 +638,7 @@ export const CODEX_GPT_5_2_HIGH_REASONING_CONFIG: AgentConfig = {
   ],
   environment: getOpenAIEnvironment,
   checkRequirements: checkOpenAIRequirements,
-  apiKeys: [OPENAI_API_KEY],
+  apiKeys: [OPENAI_API_KEY, CODEX_AUTH_JSON],
+  applyApiKeys: applyCodexApiKeys,
   completionDetector: startCodexCompletionDetector,
 };

--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -3,6 +3,34 @@ import type {
   EnvironmentResult,
 } from "../common/environment-result";
 
+/**
+ * Apply API keys for OpenAI Codex.
+ * If CODEX_AUTH_JSON is provided, inject it as ~/.codex/auth.json.
+ * This takes precedence over any local auth.json file.
+ */
+export function applyCodexApiKeys(
+  keys: Record<string, string>
+): Partial<EnvironmentResult> {
+  const files: EnvironmentResult["files"] = [];
+
+  const authJson = keys.CODEX_AUTH_JSON;
+  if (authJson) {
+    // Validate that it's valid JSON before injecting
+    try {
+      JSON.parse(authJson);
+      files.push({
+        destinationPath: "$HOME/.codex/auth.json",
+        contentBase64: Buffer.from(authJson).toString("base64"),
+        mode: "600",
+      });
+    } catch {
+      console.warn("CODEX_AUTH_JSON is not valid JSON, skipping injection");
+    }
+  }
+
+  return { files };
+}
+
 export async function getOpenAIEnvironment(
   _ctx: EnvironmentContext
 ): Promise<EnvironmentResult> {


### PR DESCRIPTION
i want to add auth.json support to the settings for openai codex. basically users want to copy ~/.codex/auth.json and then paste the json outputs into cmux settings, and the expectation is that it will then be injected into the right file inside each morph vm.