### PR TITLE
Optimize rust builds with cargo-chef

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1054,6 +1054,7 @@ COPY configs/systemd/cmux-cdp-proxy.service /usr/lib/systemd/system/cmux-cdp-pro
 COPY configs/systemd/cmux-pty.service /usr/lib/systemd/system/cmux-pty.service
 COPY configs/systemd/cmux-memory-setup.service /usr/lib/systemd/system/cmux-memory-setup.service
 COPY configs/systemd/cmux-ide.service.template /usr/lib/systemd/system/cmux-ide.service.template
+COPY configs/systemd/cmux.target.docker.drop-in.conf /usr/lib/systemd/system/cmux.target.docker.drop-in.conf
 COPY configs/systemd/bin/configure-openvscode /usr/local/lib/cmux/configure-openvscode
 COPY configs/systemd/bin/configure-coder /usr/local/lib/cmux/configure-coder
 COPY configs/systemd/bin/configure-cmux-code /usr/local/lib/cmux/configure-cmux-code
@@ -1079,7 +1080,11 @@ touch /usr/local/lib/cmux/dockerd.flag
 mkdir -p /var/log/cmux
 mkdir -p /etc/systemd/system/multi-user.target.wants
 mkdir -p /etc/systemd/system/cmux.target.wants
+mkdir -p /etc/systemd/system/cmux.target.d
 mkdir -p /etc/systemd/system/swap.target.wants
+
+# Install Docker-specific drop-in for cmux.target (removes cmux-devtools.service from Requires)
+cp /usr/lib/systemd/system/cmux.target.docker.drop-in.conf /etc/systemd/system/cmux.target.d/10-docker.conf
 
 # Copy the correct IDE env file based on provider
 if [ "${IDE_PROVIDER}" = "cmux-code" ]; then
@@ -1100,10 +1105,10 @@ ln -sf /usr/lib/systemd/system/cmux-ide.service /etc/systemd/system/cmux.target.
 ln -sf /usr/lib/systemd/system/cmux-worker.service /etc/systemd/system/cmux.target.wants/cmux-worker.service
 ln -sf /usr/lib/systemd/system/cmux-proxy.service /etc/systemd/system/cmux.target.wants/cmux-proxy.service
 ln -sf /usr/lib/systemd/system/cmux-dockerd.service /etc/systemd/system/cmux.target.wants/cmux-dockerd.service
-ln -sf /usr/lib/systemd/system/cmux-devtools.service /etc/systemd/system/cmux.target.wants/cmux-devtools.service
+# Note: cmux-devtools.service not enabled in Docker (requires cmux-openbox.service which is not available)
 ln -sf /usr/lib/systemd/system/cmux-tigervnc.service /etc/systemd/system/cmux.target.wants/cmux-tigervnc.service
 ln -sf /usr/lib/systemd/system/cmux-vnc-proxy.service /etc/systemd/system/cmux.target.wants/cmux-vnc-proxy.service
-ln -sf /usr/lib/systemd/system/cmux-cdp-proxy.service /etc/systemd/system/cmux.target.wants/cmux-cdp-proxy.service
+# Note: cmux-cdp-proxy.service not enabled in Docker (requires cmux-devtools.service)
 ln -sf /usr/lib/systemd/system/cmux-pty.service /etc/systemd/system/cmux.target.wants/cmux-pty.service
 ln -sf /usr/lib/systemd/system/cmux-pty.service /etc/systemd/system/multi-user.target.wants/cmux-pty.service
 ln -sf /usr/lib/systemd/system/${IDE_SERVICE} /etc/systemd/system/multi-user.target.wants/${IDE_SERVICE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ COPY --from=rust-chef /cmux/recipe-pty.json /cmux/recipe-pty.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/cmux/target \
+  export CARGO_BUILD_JOBS="$(nproc)" && \
   if [ "$TARGETPLATFORM" = "linux/amd64" ] && [ "$BUILDPLATFORM" != "linux/amd64" ]; then \
   # Cross-compile to x86_64 when building on a non-amd64 builder
   export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc && \
@@ -111,6 +112,7 @@ COPY crates ./crates
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/cmux/target \
+  export CARGO_BUILD_JOBS="$(nproc)" && \
   if [ "$TARGETPLATFORM" = "linux/amd64" ] && [ "$BUILDPLATFORM" != "linux/amd64" ]; then \
   export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc && \
   export CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc && \

--- a/configs/systemd/cmux.target.docker.drop-in.conf
+++ b/configs/systemd/cmux.target.docker.drop-in.conf
@@ -1,0 +1,6 @@
+# Docker-specific override for cmux.target
+# Removes cmux-devtools.service from Requires because Docker doesn't have openbox/X11 stack
+[Unit]
+# Reset Requires first (systemd merges additively, so we must clear before setting)
+Requires=
+Requires=cmux-ide.service cmux-worker.service cmux-vnc-proxy.service cmux-tigervnc.service

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1957,6 +1957,7 @@ async def task_build_rust_binaries(ctx: TaskContext) -> None:
         export CARGO_HOME=/usr/local/cargo
         export CARGO_TARGET_DIR={repo}/target
         export PATH="${{CARGO_HOME}}/bin:$PATH"
+        export CARGO_BUILD_JOBS="$(nproc)"
         cargo build --locked --release --manifest-path {repo}/crates/cmux-env/Cargo.toml
         cargo build --locked --release --manifest-path {repo}/crates/cmux-proxy/Cargo.toml
         cargo build --locked --release --manifest-path {repo}/crates/cmux-pty/Cargo.toml


### PR DESCRIPTION
## Summary
- add cargo-chef caching for per-crate Rust builds in the Dockerfile
- build/install Rust binaries from a shared target directory to reduce repeated compilation
- update snapshot Rust build step to use a shared target directory

## Testing
- /usr/bin/time -p docker build -t cmux-rust-before:baseline .
- /usr/bin/time -p docker build -t cmux-rust-after:chef .
- /usr/bin/time -p docker build -t cmux-rust-after:warm .
- STACK_SECRET_SERVER_KEY=12345678901234567890123456789012 STACK_SUPER_SECRET_ADMIN_KEY=12345678901234567890123456789012 STACK_DATA_VAULT_SECRET=12345678901234567890123456789012 CMUX_GITHUB_APP_PRIVATE_KEY=12345678901234567890123456789012 MORPH_API_KEY=12345678901234567890123456789012 ANTHROPIC_API_KEY=12345678901234567890123456789012 CMUX_TASK_RUN_JWT_SECRET=12345678901234567890123456789012 NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=12345678901234567890123456789012 bun check