### PR TITLE
Fix navigation log by stringifying objects

### DIFF
--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -122,7 +122,7 @@ function RootComponent() {
   const location = useRouterState({
     select: (state) => state.location,
   });
-  const locationKey = `${location.pathname}${location.search}${location.hash}`;
+  const locationKey = `${location.pathname}${JSON.stringify(location.search)}${location.hash}`;
 
   useAutoUpdateNotifications();
 


### PR DESCRIPTION
[navigation] location-changed 
{location: '/manaflow/dashboard[object Object]', timestamp: '2025-12-19T05:42:49.370Z'}location: "/manaflow/dashboard[object Object]"timestamp: "2025-12-19T05:42:49.370Zthe log message has [object Object] which is sus, fix it