### PR TITLE
chore: morph snapshot v36 with updated IDE deps

### DIFF
--- a/.github/workflows/morph-snapshot.yml
+++ b/.github/workflows/morph-snapshot.yml
@@ -1,0 +1,109 @@
+name: Daily Morph Snapshot
+
+on:
+  schedule:
+    - cron: "0 18 * * *" # 10am PST / 11am PDT
+  workflow_dispatch:
+
+concurrency:
+  group: morph-snapshot
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: "24"
+  BUN_VERSION: "1.2.21"
+  GO_VERSION: "1.23"
+
+jobs:
+  morph-snapshot:
+    name: Build Morph Snapshot
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-install-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-install-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run morph snapshot
+        env:
+          MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
+        run: uv run ./scripts/snapshot.py
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git user
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create branch and commit
+        if: steps.changes.outputs.has_changes == 'true'
+        id: commit
+        run: |
+          BRANCH_NAME="morph-snapshot-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          git add configs/ide-deps.json packages/shared/src/morph-snapshots.json
+          git commit -m "chore: daily morph snapshot update"
+          git push -u origin "$BRANCH_NAME"
+          echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore: daily morph snapshot update" \
+            --body "Automated daily morph snapshot update.
+
+          ## Changes
+          - Updated morph snapshots to latest version
+          - Updated IDE extension and CLI package versions
+
+          ## Test plan
+          - [ ] Verify new snapshots work by starting a sandbox session" \
+            --head "${{ steps.commit.outputs.branch }}" \
+            --base main

--- a/configs/ide-deps.json
+++ b/configs/ide-deps.json
@@ -3,36 +3,36 @@
     {
       "publisher": "anthropic",
       "name": "claude-code",
-      "version": "2.0.70"
+      "version": "2.0.74"
     },
     {
       "publisher": "openai",
       "name": "chatgpt",
-      "version": "0.5.52"
+      "version": "0.5.54"
     },
     {
       "publisher": "ms-vscode",
       "name": "vscode-typescript-next",
-      "version": "6.0.20251215"
+      "version": "6.0.20251218"
     },
     {
       "publisher": "ms-python",
       "name": "python",
-      "version": "2025.21.2025121501"
+      "version": "2025.21.2025121801"
     },
     {
       "publisher": "ms-python",
       "name": "debugpy",
-      "version": "2025.17.2025121501"
+      "version": "2025.19.2025121701"
     }
   ],
   "packages": {
-    "@openai/codex": "0.73.0",
-    "@anthropic-ai/claude-code": "2.0.70",
-    "@google/gemini-cli": "0.20.2",
-    "opencode-ai": "1.0.162",
-    "codebuff": "1.0.551",
+    "@openai/codex": "0.75.0",
+    "@anthropic-ai/claude-code": "2.0.73",
+    "@google/gemini-cli": "0.21.3",
+    "opencode-ai": "1.0.169",
+    "codebuff": "1.0.552",
     "@devcontainers/cli": "0.80.3",
-    "@sourcegraph/amp": "0.0.1765858276-g8d78e4"
+    "@sourcegraph/amp": "0.0.1766117434-gebf7c3"
   }
 }

--- a/packages/shared/src/morph-snapshots.json
+++ b/packages/shared/src/morph-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2025-12-16T07:55:53Z",
+  "updatedAt": "2025-12-19T06:04:48Z",
   "presets": [
     {
       "presetId": "4vcpu_16gb_48gb",
@@ -183,6 +183,11 @@
           "version": 35,
           "snapshotId": "snapshot_n53wv98d",
           "capturedAt": "2025-12-16T07:55:53Z"
+        },
+        {
+          "version": 36,
+          "snapshotId": "snapshot_adpauztr",
+          "capturedAt": "2025-12-19T06:05:43Z"
         }
       ],
       "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
@@ -368,6 +373,11 @@
           "version": 35,
           "snapshotId": "snapshot_wgp0rrue",
           "capturedAt": "2025-12-16T07:55:28Z"
+        },
+        {
+          "version": 36,
+          "snapshotId": "snapshot_r0bk3bi9",
+          "capturedAt": "2025-12-19T06:04:48Z"
         }
       ],
       "description": "Extra headroom for larger codebases or heavier workloads."


### PR DESCRIPTION
## Summary
- Updates morph snapshots to version 36
- Updates IDE extension and CLI package versions
- **Adds daily morph snapshot GitHub Actions workflow** (runs at 10am PST)

### Updated packages:
- claude-code: 2.0.70 → 2.0.74
- chatgpt: 0.5.52 → 0.5.54
- codex: 0.73.0 → 0.75.0
- gemini-cli: 0.20.2 → 0.21.3
- opencode-ai: 1.0.162 → 1.0.169
- amp: updated to latest

## Test plan
- [ ] Verify new snapshots work by starting a sandbox session
- [ ] Workflow can be manually triggered via workflow_dispatch