### PR TITLE
Upload zsh history when NEXT_PUBLIC_WEB_MODE is off non-blocking

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -10,6 +10,9 @@ import type {
   WorkerTerminalFailed,
 } from "@cmux/shared/worker-schemas";
 import { parse as parseDotenv } from "dotenv";
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { sanitizeTmuxSessionName } from "./sanitizeTmuxSessionName";
 import {
   generateNewBranchName,
@@ -38,6 +41,64 @@ import rawSwitchBranchScript from "./utils/switch-branch.ts?raw";
 const SWITCH_BRANCH_BUN_SCRIPT = rawSwitchBranchScript;
 
 const { getApiEnvironmentsByIdVars } = await getWwwOpenApiModule();
+
+/**
+ * Upload the user's zsh history to the sandbox for autosuggestions.
+ * This is a non-blocking operation that should be called after the terminal is created.
+ * Only runs when NOT in web mode (i.e., when running locally with access to user's home dir).
+ */
+async function uploadZshHistory(params: {
+  workerUrl: string;
+  taskRunJwt: string;
+}): Promise<void> {
+  const { workerUrl, taskRunJwt } = params;
+
+  try {
+    const zshHistoryPath = join(homedir(), ".zsh_history");
+
+    // Check if the file exists
+    try {
+      await fs.access(zshHistoryPath);
+    } catch {
+      serverLogger.info("[AgentSpawner] No zsh history file found, skipping upload");
+      return;
+    }
+
+    // Read the zsh history file
+    const historyContent = await fs.readFile(zshHistoryPath);
+
+    // Create form data for upload
+    const formData = new FormData();
+    const blob = new Blob([historyContent], { type: "application/octet-stream" });
+    formData.append("file", blob, ".zsh_history");
+    formData.append("path", "/root/.zsh_history");
+
+    const uploadUrl = `${workerUrl}/upload-file`;
+
+    serverLogger.info(`[AgentSpawner] Uploading zsh history to ${uploadUrl}`);
+
+    const response = await fetch(uploadUrl, {
+      method: "POST",
+      headers: {
+        "x-cmux-token": taskRunJwt,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Upload failed: ${error}`);
+    }
+
+    const result = await response.json();
+    serverLogger.info(
+      `[AgentSpawner] Successfully uploaded zsh history: ${result.path} (${result.size} bytes)`
+    );
+  } catch (error) {
+    // Log error but don't throw - this is a non-blocking enhancement
+    serverLogger.error("[AgentSpawner] Failed to upload zsh history:", error);
+  }
+}
 
 export interface AgentSpawnResult {
   agentName: string;
@@ -957,6 +1018,31 @@ exit $EXIT_CODE
         `[AgentSpawner] Emitted worker:create-terminal at ${new Date().toISOString()}`
       );
     });
+
+    // Upload zsh history for autosuggestions (non-blocking, only when NOT in web mode)
+    // In web mode, we don't have access to the user's local files
+    if (!env.NEXT_PUBLIC_WEB_MODE) {
+      // Get the worker URL for the upload
+      let workerUrl: string | null = null;
+      if (vscodeInstance instanceof CmuxVSCodeInstance) {
+        workerUrl = vscodeInstance.getWorkerUrl();
+      } else if (vscodeInstance instanceof DockerVSCodeInstance) {
+        const workerPort = vscodeInstance.getPorts()?.worker;
+        if (workerPort) {
+          workerUrl = `http://localhost:${workerPort}`;
+        }
+      }
+
+      if (workerUrl) {
+        // Fire-and-forget: don't await, don't block the return
+        void uploadZshHistory({
+          workerUrl,
+          taskRunJwt,
+        }).catch((err) => {
+          serverLogger.error("[AgentSpawner] Zsh history upload failed:", err);
+        });
+      }
+    }
 
     return {
       agentName: agent.name,

--- a/apps/server/src/vscode/CmuxVSCodeInstance.ts
+++ b/apps/server/src/vscode/CmuxVSCodeInstance.ts
@@ -185,4 +185,8 @@ export class CmuxVSCodeInstance extends VSCodeInstance {
   getName(): string {
     return this.sandboxId || this.instanceId;
   }
+
+  getWorkerUrl(): string | null {
+    return this.workerUrl;
+  }
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -222,6 +222,11 @@ const upload = multer({
 
 const ALLOWED_UPLOAD_ROOT = "/root/prompt";
 
+// Additional paths that can be uploaded via /upload-file endpoint
+const ALLOWED_FILE_PATHS = new Set([
+  "/root/.zsh_history",
+]);
+
 // File upload endpoint
 app.post("/upload-image", upload.single("image"), async (req, res) => {
   try {
@@ -278,6 +283,69 @@ app.post("/upload-image", upload.single("image"), async (req, res) => {
     });
   } catch (error) {
     log("ERROR", "Failed to upload image", error);
+    res.status(500).json({
+      error: error instanceof Error ? error.message : "Upload failed",
+    });
+  }
+});
+
+// Generic file upload endpoint for allowed paths (e.g., zsh history)
+app.post("/upload-file", upload.single("file"), async (req, res) => {
+  try {
+    const token = req.header("x-cmux-token");
+    const secret = process.env.CMUX_TASK_RUN_JWT_SECRET;
+    if (!token || !secret) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    try {
+      await verifyTaskRunToken(token, secret);
+    } catch (error) {
+      log("ERROR", "Invalid task run token for upload-file", error);
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    if (!req.file) {
+      return res.status(400).json({ error: "No file uploaded" });
+    }
+
+    const { path: filePath } = req.body;
+    if (!filePath) {
+      return res.status(400).json({ error: "No path specified" });
+    }
+
+    const resolvedPath = path.resolve(String(filePath));
+
+    // Only allow specific whitelisted paths
+    if (!ALLOWED_FILE_PATHS.has(resolvedPath)) {
+      return res.status(400).json({ error: "Path not allowed" });
+    }
+
+    log("INFO", `Received file upload request for path: ${resolvedPath}`, {
+      size: req.file.size,
+      mimetype: req.file.mimetype,
+      originalname: req.file.originalname,
+    });
+
+    // Ensure directory exists
+    const dir = path.dirname(resolvedPath);
+    await fs.mkdir(dir, { recursive: true });
+
+    // Write the file
+    await fs.writeFile(resolvedPath, req.file.buffer);
+
+    log("INFO", `Successfully wrote file: ${resolvedPath}`);
+
+    // Verify file was created
+    const stats = await fs.stat(resolvedPath);
+
+    res.json({
+      success: true,
+      path: resolvedPath,
+      size: stats.size,
+    });
+  } catch (error) {
+    log("ERROR", "Failed to upload file", error);
     res.status(500).json({
       error: error instanceof Error ? error.message : "Upload failed",
     });

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1572,7 +1572,6 @@ async def task_configure_zsh(ctx: TaskContext) -> None:
           fi
         fi
         mkdir -p /root
-        autosuggestions="/usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
         cat > /root/.zshrc <<EOF
 export SHELL="${zsh_path}"
 export PATH="/usr/local/bin:/usr/local/cargo/bin:\$HOME/.local/bin:\$PATH"
@@ -1600,19 +1599,17 @@ precmd() {
 }
 
 PROMPT='%F{cyan}%n%f %F{green}%~%f\${vcs_info_msg_0_:+ \${vcs_info_msg_0_}} %# '
-EOF
-        if [ -f "${autosuggestions}" ]; then
-          cat >> /root/.zshrc <<'EOF'
 
-if [ -f "${autosuggestions}" ]; then
-  source "${autosuggestions}"
+# zsh-autosuggestions
+if [ -f /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
+  source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
   bindkey '^ ' autosuggest-accept
 fi
-EOF
-        fi
-        cat >> /root/.zshrc <<'EOF'
+
 HISTFILE=~/.zsh_history
-setopt HIST_IGNORE_DUPS HIST_VERIFY
+HISTSIZE=10000
+SAVEHIST=10000
+setopt APPEND_HISTORY SHARE_HISTORY HIST_IGNORE_DUPS HIST_VERIFY
 EOF
         cat > /root/.zprofile <<'EOF'
 [[ -f ~/.zshrc ]] && source ~/.zshrc


### PR DESCRIPTION
preinstall and set up zsh-autosuggestions in @Dockerfile and @scripts/snapshot.py in apps/server if NEXT_PUBLIC_WEB_MODE is not on, we should upload the user's zsh historythis needs to be non-blocking the main stuff (like spawning the agent)