### PR TITLE
ci: add daily morph snapshot workflow

### DIFF
--- a/.github/workflows/morph-snapshot.yml
+++ b/.github/workflows/morph-snapshot.yml
@@ -57,10 +57,27 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run morph snapshot
+      - name: Run morph snapshot (with retry)
         env:
           MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
-        run: uv run ./scripts/snapshot.py
+        run: |
+          max_attempts=3
+          attempt=1
+          while [ $attempt -le $max_attempts ]; do
+            echo "Attempt $attempt of $max_attempts"
+            if uv run ./scripts/snapshot.py; then
+              echo "Snapshot completed successfully"
+              exit 0
+            fi
+            echo "Attempt $attempt failed"
+            if [ $attempt -lt $max_attempts ]; then
+              echo "Waiting 30 seconds before retry..."
+              sleep 30
+            fi
+            attempt=$((attempt + 1))
+          done
+          echo "All $max_attempts attempts failed"
+          exit 1
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically builds morph snapshots daily at 10am PST.

### Features:
- Runs daily at 10am PST (11am PDT)
- Can be manually triggered via workflow_dispatch
- Includes retry logic (3 attempts with 30s delays) for transient network failures
- Automatically creates a PR with snapshot updates

### What it does:
1. Installs dependencies (bun, uv, Go)
2. Runs `uv run ./scripts/snapshot.py`
3. Creates a PR if there are changes

## Test plan
- [x] Workflow ran successfully (first attempt failed due to transient network error, confirming retry logic is needed)
- [ ] Manually trigger workflow to verify it works