### PR TITLE
Add Command-K quick bar to main dashboard

### DIFF
--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -5,6 +5,7 @@ import { useExpandTasks } from "@/contexts/expand-tasks/ExpandTasksContext";
 import { useSocket } from "@/contexts/socket/use-socket";
 import { isElectron } from "@/lib/electron";
 import { copyAllElectronLogs } from "@/lib/electron-logs/electron-logs";
+import { COMMAND_PALETTE_OPEN_EVENT } from "@/lib/command-palette-events";
 import { setLastTeamSlugOrId } from "@/lib/lastTeam";
 import { stackClientApp } from "@/lib/stack";
 import { preloadTaskRunIframes } from "@/lib/preloadTaskRunIframes";
@@ -445,6 +446,21 @@ export function CommandBar({
     setOpenedWithShift(false);
     scheduleCommandStateReset();
   }, [commandContainerRef, scheduleCommandStateReset, setOpen, setOpenedWithShift]);
+
+  const openCommandPalette = useCallback(
+    (shouldToggle: boolean) => {
+      if (openRef.current) {
+        if (shouldToggle) {
+          closeCommand();
+        }
+        return;
+      }
+      setOpenedWithShift(false);
+      captureFocusBeforeOpen();
+      setOpen(true);
+    },
+    [captureFocusBeforeOpen, closeCommand, setOpen, setOpenedWithShift]
+  );
 
   const handleEscape = useCallback(() => {
     skipNextCloseRef.current = false;
@@ -1043,13 +1059,7 @@ export function CommandBar({
     if (isElectron) {
       const off = window.cmux.on("shortcut:cmd-k", () => {
         // Only handle Cmd+K (no shift/ctrl variations)
-        if (openRef.current) {
-          closeCommand();
-          return;
-        }
-        setOpenedWithShift(false);
-        captureFocusBeforeOpen();
-        setOpen(true);
+        openCommandPalette(true);
       });
       return () => {
         // Unsubscribe if available
@@ -1068,18 +1078,23 @@ export function CommandBar({
         !e.ctrlKey
       ) {
         e.preventDefault();
-        if (openRef.current) {
-          closeCommand();
-          return;
-        }
-        setOpenedWithShift(false);
-        captureFocusBeforeOpen();
-        setOpen(true);
+        openCommandPalette(true);
       }
     };
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [captureFocusBeforeOpen, closeCommand]);
+  }, [openCommandPalette]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const handleOpen = () => {
+      openCommandPalette(false);
+    };
+    document.addEventListener(COMMAND_PALETTE_OPEN_EVENT, handleOpen);
+    return () => {
+      document.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, handleOpen);
+    };
+  }, [openCommandPalette]);
 
   // Track and restore focus across open/close, including iframes/webviews.
   useEffect(() => {

--- a/apps/client/src/components/dashboard/DashboardTopBar.tsx
+++ b/apps/client/src/components/dashboard/DashboardTopBar.tsx
@@ -1,0 +1,88 @@
+import type { CSSProperties } from "react";
+import { useCallback, useMemo } from "react";
+import { Command as CommandIcon, Search } from "lucide-react";
+
+import { AgentLogo } from "@/components/icons/agent-logos";
+import { requestOpenCommandPalette } from "@/lib/command-palette-events";
+
+type DashboardTopBarProps = {
+  agentNames: string[];
+};
+
+const dragStyle = { WebkitAppRegion: "drag" } as CSSProperties;
+const noDragStyle = { WebkitAppRegion: "no-drag" } as CSSProperties;
+
+const vendorKey = (agentName: string): string => {
+  const lower = agentName.toLowerCase();
+  if (lower.startsWith("codex/")) return "openai";
+  if (lower.startsWith("claude/")) return "claude";
+  if (lower.startsWith("gemini/")) return "gemini";
+  if (lower.startsWith("opencode/")) return "opencode";
+  if (lower.startsWith("qwen/")) return "qwen";
+  if (lower.startsWith("cursor/")) return "cursor";
+  if (lower.startsWith("amp")) return "amp";
+  return "other";
+};
+
+export function DashboardTopBar({ agentNames }: DashboardTopBarProps) {
+  const displayAgents = useMemo(() => {
+    const seen = new Set<string>();
+    const uniqueAgents: string[] = [];
+
+    for (const agent of agentNames) {
+      const key = vendorKey(agent);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      uniqueAgents.push(agent);
+      if (uniqueAgents.length >= 4) break;
+    }
+
+    return uniqueAgents;
+  }, [agentNames]);
+
+  const handleOpen = useCallback(() => {
+    requestOpenCommandPalette();
+  }, []);
+
+  return (
+    <div
+      className="min-h-[52px] border-b border-neutral-200/70 dark:border-neutral-800/50 flex items-center justify-center relative select-none"
+      style={dragStyle}
+    >
+      <div className="absolute left-0 w-20 h-full" style={dragStyle} />
+      <div className="w-full max-w-[560px] px-3" style={noDragStyle}>
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="group flex h-10 w-full items-center gap-3 rounded-full border border-neutral-200/80 dark:border-neutral-700/70 bg-neutral-100/80 dark:bg-neutral-800/70 px-3 text-sm text-neutral-600 dark:text-neutral-300 shadow-sm transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400/40 dark:focus-visible:ring-neutral-600/40"
+        >
+          <span className="flex items-center gap-2">
+            <Search className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
+            <span className="text-sm font-medium">Command + K</span>
+          </span>
+          <span className="ml-auto flex items-center gap-2">
+            {displayAgents.length > 0 ? (
+              <span className="flex items-center -space-x-2">
+                {displayAgents.map((agent) => (
+                  <span
+                    key={agent}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-neutral-200/70 bg-white/80 dark:border-neutral-700/70 dark:bg-neutral-900/70"
+                  >
+                    <AgentLogo
+                      agentName={agent}
+                      className="h-3.5 w-3.5 text-neutral-900 dark:text-neutral-100"
+                    />
+                  </span>
+                ))}
+              </span>
+            ) : null}
+            <span className="inline-flex items-center gap-1 rounded-md border border-neutral-200/70 bg-white/70 px-2 py-0.5 text-[11px] font-semibold text-neutral-500 dark:border-neutral-700/70 dark:bg-neutral-900/70 dark:text-neutral-300">
+              <CommandIcon className="h-3 w-3" />
+              <span>K</span>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/lib/command-palette-events.ts
+++ b/apps/client/src/lib/command-palette-events.ts
@@ -1,0 +1,6 @@
+export const COMMAND_PALETTE_OPEN_EVENT = "cmux:command-palette-open";
+
+export const requestOpenCommandPalette = () => {
+  if (typeof document === "undefined") return;
+  document.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT));
+};

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -6,13 +6,13 @@ import {
 import { DashboardInputControls } from "@/components/dashboard/DashboardInputControls";
 import { DashboardInputFooter } from "@/components/dashboard/DashboardInputFooter";
 import { DashboardStartTaskButton } from "@/components/dashboard/DashboardStartTaskButton";
+import { DashboardTopBar } from "@/components/dashboard/DashboardTopBar";
 import { TaskList } from "@/components/dashboard/TaskList";
 import { WorkspaceCreationButtons } from "@/components/dashboard/WorkspaceCreationButtons";
 import { FloatingPane } from "@/components/floating-pane";
 import { WorkspaceSetupPanel } from "@/components/WorkspaceSetupPanel";
 import { GitHubIcon } from "@/components/icons/github";
 import { useTheme } from "@/components/theme/use-theme";
-import { TitleBar } from "@/components/TitleBar";
 import type { SelectOption } from "@/components/ui/searchable-select";
 import {
   Tooltip,
@@ -998,7 +998,7 @@ function DashboardComponent() {
   ]);
 
   return (
-    <FloatingPane header={<TitleBar title="cmux" />}>
+    <FloatingPane header={<DashboardTopBar agentNames={selectedAgents} />}>
       <div className="flex flex-col grow relative">
         {/* Main content area */}
         <div className="flex-1 flex flex-col pt-32 pb-0">


### PR DESCRIPTION
image.png add this top bar thing instead make it command + k with the icons to the cmux main dashboard page. we need it instead of the cmux t4ext. you can make the top bar height bigger to fit this in but just have the search bar and it opens the command + k menu.