### PR TITLE
Enable per-commit preview runs on PRs

### DIFF
--- a/packages/convex/convex/previewRuns.ts
+++ b/packages/convex/convex/previewRuns.ts
@@ -31,27 +31,27 @@ export const enqueueFromWebhook = internalMutation({
       ? normalizeRepoFullName(args.headRepoFullName)
       : undefined;
 
-    // Check if there's already a pending/running preview run for this PR
-    // This prevents duplicate preview jobs when:
-    // 1. Multiple webhooks fire for the same PR (e.g., synchronize events)
-    // 2. Crown worker tries to create a preview run while one already exists
-    const existingByPr = await ctx.db
+    // Check if there's already a pending/running preview run for this EXACT commit
+    // This prevents duplicate preview jobs when multiple webhooks fire for the same commit
+    const existingByCommit = await ctx.db
       .query("previewRuns")
-      .withIndex("by_config_pr", (q) =>
-        q.eq("previewConfigId", args.previewConfigId).eq("prNumber", args.prNumber),
+      .withIndex("by_config_head", (q) =>
+        q.eq("previewConfigId", args.previewConfigId).eq("headSha", args.headSha),
       )
-      .order("desc")
       .first();
 
-    if (existingByPr && (existingByPr.status === "pending" || existingByPr.status === "running")) {
-      console.log("[previewRuns] Returning existing pending/running preview run for PR", {
-        existingRunId: existingByPr._id,
+    if (
+      existingByCommit &&
+      existingByCommit.prNumber === args.prNumber &&
+      (existingByCommit.status === "pending" || existingByCommit.status === "running")
+    ) {
+      console.log("[previewRuns] Returning existing preview run for same commit", {
+        existingRunId: existingByCommit._id,
         prNumber: args.prNumber,
-        existingHeadSha: existingByPr.headSha,
-        newHeadSha: args.headSha,
-        status: existingByPr.status,
+        headSha: args.headSha,
+        status: existingByCommit.status,
       });
-      return existingByPr._id;
+      return existingByCommit._id;
     }
 
     const now = Date.now();
@@ -78,6 +78,37 @@ export const enqueueFromWebhook = internalMutation({
       createdAt: now,
       updatedAt: now,
     });
+
+    // Supersede any older pending runs for this PR (they have stale commits)
+    // This ensures only the latest commit's preview run will execute
+    const pendingRuns = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", args.previewConfigId).eq("prNumber", args.prNumber),
+      )
+      .collect();
+
+    let supersededCount = 0;
+    for (const run of pendingRuns) {
+      if (run._id !== runId && run.status === "pending") {
+        await ctx.db.patch(run._id, {
+          status: "superseded",
+          stateReason: "Newer commit pushed to PR",
+          completedAt: now,
+          updatedAt: now,
+        });
+        supersededCount++;
+      }
+    }
+
+    if (supersededCount > 0) {
+      console.log("[previewRuns] Superseded older pending runs for PR", {
+        newRunId: runId,
+        prNumber: args.prNumber,
+        headSha: args.headSha,
+        supersededCount,
+      });
+    }
 
     await ctx.db.patch(args.previewConfigId, {
       lastRunAt: now,
@@ -191,37 +222,41 @@ export const enqueueFromTaskRun = internalMutation({
       return { created: false, reason: `Preview config is ${previewConfig.status}` };
     }
 
-    // Check for existing pending/running preview run for this PR
-    const existingByPr = await ctx.db
+    // Extract headSha from newBranch or use a placeholder
+    // In crown worker flow, we may not have the exact commit SHA
+    const headSha = taskRun.newBranch ?? `taskrun-${args.taskRunId}`;
+
+    // Check for existing pending/running preview run for this EXACT commit
+    const existingByCommit = await ctx.db
       .query("previewRuns")
-      .withIndex("by_config_pr", (q) =>
-        q.eq("previewConfigId", previewConfig._id).eq("prNumber", prNumber),
+      .withIndex("by_config_head", (q) =>
+        q.eq("previewConfigId", previewConfig._id).eq("headSha", headSha),
       )
-      .order("desc")
       .first();
 
-    if (existingByPr && (existingByPr.status === "pending" || existingByPr.status === "running")) {
-      console.log("[previewRuns] Found existing active preview run for PR, linking taskRun", {
+    if (
+      existingByCommit &&
+      existingByCommit.prNumber === prNumber &&
+      (existingByCommit.status === "pending" || existingByCommit.status === "running")
+    ) {
+      console.log("[previewRuns] Found existing preview run for same commit, linking taskRun", {
         taskRunId: args.taskRunId,
-        existingRunId: existingByPr._id,
+        existingRunId: existingByCommit._id,
         prNumber,
-        status: existingByPr.status,
+        headSha,
+        status: existingByCommit.status,
       });
 
       // Link this taskRun to the existing preview run if it doesn't have one
-      if (!existingByPr.taskRunId) {
-        await ctx.db.patch(existingByPr._id, {
+      if (!existingByCommit.taskRunId) {
+        await ctx.db.patch(existingByCommit._id, {
           taskRunId: args.taskRunId,
           updatedAt: Date.now(),
         });
       }
 
-      return { created: true, previewRunId: existingByPr._id, isNew: false };
+      return { created: true, previewRunId: existingByCommit._id, isNew: false };
     }
-
-    // Extract headSha from newBranch or use a placeholder
-    // In crown worker flow, we may not have the exact commit SHA
-    const headSha = taskRun.newBranch ?? `taskrun-${args.taskRunId}`;
 
     // Try to get PR title from pullRequests table or task
     let prTitle: string | undefined;
@@ -266,6 +301,36 @@ export const enqueueFromTaskRun = internalMutation({
       updatedAt: now,
     });
 
+    // Supersede any older pending runs for this PR (they have stale commits)
+    const pendingRuns = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", previewConfig._id).eq("prNumber", prNumber),
+      )
+      .collect();
+
+    let supersededCount = 0;
+    for (const run of pendingRuns) {
+      if (run._id !== runId && run.status === "pending") {
+        await ctx.db.patch(run._id, {
+          status: "superseded",
+          stateReason: "Newer commit pushed to PR",
+          completedAt: now,
+          updatedAt: now,
+        });
+        supersededCount++;
+      }
+    }
+
+    if (supersededCount > 0) {
+      console.log("[previewRuns] Superseded older pending runs for PR (from task run)", {
+        newRunId: runId,
+        prNumber,
+        headSha,
+        supersededCount,
+      });
+    }
+
     await ctx.db.patch(previewConfig._id, {
       lastRunAt: now,
       updatedAt: now,
@@ -308,6 +373,7 @@ export const updateStatus = internalMutation({
       v.literal("completed"),
       v.literal("failed"),
       v.literal("skipped"),
+      v.literal("superseded"),
     ),
     screenshotSetId: v.optional(v.id("taskRunScreenshotSets")),
     githubCommentUrl: v.optional(v.string()),
@@ -326,7 +392,7 @@ export const updateStatus = internalMutation({
       githubCommentId: args.githubCommentId ?? run.githubCommentId,
       updatedAt: now,
     };
-    if (args.status === "completed" || args.status === "failed" || args.status === "skipped") {
+    if (args.status === "completed" || args.status === "failed" || args.status === "skipped" || args.status === "superseded") {
       patch.completedAt = now;
     } else if (args.status === "running" && !run.startedAt) {
       patch.startedAt = now;
@@ -392,6 +458,103 @@ export const getActiveByConfigAndPr = internalQuery({
       return run;
     }
     return null;
+  },
+});
+
+/**
+ * Check for an existing pending/running preview run for the same PR AND commit.
+ * Uses the by_config_head index for efficient lookup by (previewConfigId, headSha).
+ */
+export const getActiveByConfigPrAndCommit = internalQuery({
+  args: {
+    previewConfigId: v.id("previewConfigs"),
+    prNumber: v.number(),
+    headSha: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Use by_config_head index for efficient commit-specific lookup
+    const run = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_head", (q) =>
+        q.eq("previewConfigId", args.previewConfigId).eq("headSha", args.headSha),
+      )
+      .first();
+
+    // Verify PR number matches and status is active
+    if (run && run.prNumber === args.prNumber && (run.status === "pending" || run.status === "running")) {
+      return run;
+    }
+    return null;
+  },
+});
+
+/**
+ * Get the currently RUNNING preview run for a PR (not pending).
+ * Used to determine if we need to wait before dispatching a new run.
+ */
+export const getRunningByConfigAndPr = internalQuery({
+  args: {
+    previewConfigId: v.id("previewConfigs"),
+    prNumber: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const runs = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", args.previewConfigId).eq("prNumber", args.prNumber),
+      )
+      .order("desc")
+      .take(10);
+
+    // Find the first running one (most recent)
+    return runs.find((r) => r.status === "running") ?? null;
+  },
+});
+
+/**
+ * Mark all pending preview runs for a PR (except the specified one) as superseded.
+ * Called when a new commit arrives to prevent stale preview runs from executing.
+ */
+export const supersedePendingRunsForPr = internalMutation({
+  args: {
+    previewConfigId: v.id("previewConfigs"),
+    prNumber: v.number(),
+    exceptRunId: v.id("previewRuns"),
+  },
+  handler: async (ctx, args) => {
+    const runs = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", args.previewConfigId).eq("prNumber", args.prNumber),
+      )
+      .collect();
+
+    const now = Date.now();
+    let supersededCount = 0;
+
+    for (const run of runs) {
+      // Only supersede pending runs (not running or completed ones)
+      if (run._id !== args.exceptRunId && run.status === "pending") {
+        await ctx.db.patch(run._id, {
+          status: "superseded",
+          stateReason: "Newer commit pushed to PR",
+          completedAt: now,
+          updatedAt: now,
+        });
+        supersededCount++;
+      }
+    }
+
+    if (supersededCount > 0) {
+      console.log("[previewRuns] Superseded pending runs for PR", {
+        previewConfigId: args.previewConfigId,
+        prNumber: args.prNumber,
+        exceptRunId: args.exceptRunId,
+        supersededCount,
+      });
+    }
+
+    return { supersededCount };
   },
 });
 
@@ -551,22 +714,22 @@ export const createManual = authMutation({
       );
     }
 
-    // Check for existing pending/running run for this PR (similar to webhook flow)
-    const existingByPr = await ctx.db
+    // Check for existing pending/running run for this EXACT commit (similar to webhook flow)
+    const existingByCommit = await ctx.db
       .query("previewRuns")
-      .withIndex("by_config_pr", (q) =>
-        q.eq("previewConfigId", config._id).eq("prNumber", args.prNumber),
+      .withIndex("by_config_head", (q) =>
+        q.eq("previewConfigId", config._id).eq("headSha", args.headSha),
       )
-      .order("desc")
       .first();
 
     if (
-      existingByPr &&
-      existingByPr.taskRunId &&
-      (existingByPr.status === "pending" || existingByPr.status === "running")
+      existingByCommit &&
+      existingByCommit.prNumber === args.prNumber &&
+      existingByCommit.taskRunId &&
+      (existingByCommit.status === "pending" || existingByCommit.status === "running")
     ) {
-      // Return existing run only if it has a taskRun linked
-      return { previewRunId: existingByPr._id, reused: true };
+      // Return existing run only if it has a taskRun linked and is for the same commit
+      return { previewRunId: existingByCommit._id, reused: true };
     }
 
     const now = Date.now();
@@ -596,6 +759,25 @@ export const createManual = authMutation({
       createdAt: now,
       updatedAt: now,
     });
+
+    // Supersede any older pending runs for this PR (they have stale commits)
+    const pendingRuns = await ctx.db
+      .query("previewRuns")
+      .withIndex("by_config_pr", (q) =>
+        q.eq("previewConfigId", config._id).eq("prNumber", args.prNumber),
+      )
+      .collect();
+
+    for (const run of pendingRuns) {
+      if (run._id !== runId && run.status === "pending") {
+        await ctx.db.patch(run._id, {
+          status: "superseded",
+          stateReason: "Newer commit pushed to PR",
+          completedAt: now,
+          updatedAt: now,
+        });
+      }
+    }
 
     await ctx.db.patch(config._id, {
       lastRunAt: now,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -637,6 +637,7 @@ const convexSchema = defineSchema({
       v.literal("completed"),
       v.literal("failed"),
       v.literal("skipped"),
+      v.literal("superseded"), // Newer commit arrived; this run was skipped
     ),
     stateReason: v.optional(v.string()),
     dispatchedAt: v.optional(v.number()),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -178,7 +178,8 @@ const convexSchema = defineSchema({
       v.literal("running"),
       v.literal("completed"),
       v.literal("failed"),
-      v.literal("skipped")
+      v.literal("skipped"),
+      v.literal("cancelled") // Cancelled when a newer commit supersedes this run
     ),
     isArchived: v.optional(v.boolean()), // Whether this run is hidden from default views
     isLocalWorkspace: v.optional(v.boolean()),

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -520,6 +520,7 @@ export const updateStatus = internalMutation({
       v.literal("running"),
       v.literal("completed"),
       v.literal("failed"),
+      v.literal("cancelled"),
     ),
     exitCode: v.optional(v.number()),
   },
@@ -540,7 +541,7 @@ export const updateStatus = internalMutation({
       updatedAt: now,
     };
 
-    if (args.status === "completed" || args.status === "failed") {
+    if (args.status === "completed" || args.status === "failed" || args.status === "cancelled") {
       updates.completedAt = now;
       if (args.exitCode !== undefined) {
         updates.exitCode = args.exitCode;
@@ -550,7 +551,7 @@ export const updateStatus = internalMutation({
     await ctx.db.patch(args.id, updates);
 
     // After updating to a terminal status, check if we should update the task status
-    if (args.status === "completed" || args.status === "failed") {
+    if (args.status === "completed" || args.status === "failed" || args.status === "cancelled") {
       await updateTaskStatusFromRuns(ctx, run.taskId, run.teamId, run.userId);
     }
   },


### PR DESCRIPTION
for preview.new we currently check if a preview.new job is currently running for the branch. but what we instead need to do is check to see if the preview.new job is currently running for that branch as well as the COMMIT. we want to run another preview.new job for the same PR if it is a new commit... sometimes newer commits get blocked from running preview.new because a older preview.new job is still running.... come up with a great system to remedy this issue. ultrathink