### PR TITLE
feat: add shell history sync for zsh-autosuggestions in VMs

### DIFF
--- a/apps/client/src/components/ShellHistorySettings.tsx
+++ b/apps/client/src/components/ShellHistorySettings.tsx
@@ -1,0 +1,217 @@
+import { api } from "@cmux/convex/api";
+import { convexQuery } from "@convex-dev/react-query";
+import { Switch } from "@heroui/react";
+import { useClipboard } from "@mantine/hooks";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useConvex } from "convex/react";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+interface ShellHistorySettingsProps {
+  teamSlugOrId: string;
+  onDataChange?: (data: { enabled: boolean; sanitizedHistory: string }) => void;
+}
+
+// Detect OS for clipboard command
+function getOsType(): "mac" | "windows" | "linux" {
+  const platform = navigator.platform.toLowerCase();
+  if (platform.includes("mac")) return "mac";
+  if (platform.includes("win")) return "windows";
+  return "linux";
+}
+
+function getClipboardCommand(): string {
+  const filter = `grep -v -E '(password|passwd|pwd=|token|api_key|apikey|secret|credential|Bearer|curl.*-u|curl.*-H.*[Aa]uthorization|mysql.*-p|psql.*password|\\b[A-Z_]{5,}\\b)'`;
+
+  const os = getOsType();
+  if (os === "mac") {
+    return `cat ~/.zsh_history | ${filter} | pbcopy`;
+  }
+  if (os === "windows") {
+    return `cat ~/.zsh_history | ${filter} | clip`;
+  }
+  return `cat ~/.zsh_history | ${filter} | xclip -selection clipboard`;
+}
+
+export function ShellHistorySettings({
+  teamSlugOrId,
+  onDataChange,
+}: ShellHistorySettingsProps) {
+  const convex = useConvex();
+  const clipboard = useClipboard({ timeout: 2000 });
+  const [enabled, setEnabled] = useState(false);
+  const [originalEnabled, setOriginalEnabled] = useState(false);
+  const [sanitizedHistory, setSanitizedHistory] = useState("");
+  const [originalSanitizedHistory, setOriginalSanitizedHistory] = useState("");
+
+  // Query existing settings
+  const { data: settings } = useQuery(
+    convexQuery(api.shellHistorySettings.get, { teamSlugOrId }),
+  );
+
+  // Mutation for saving settings
+  const updateMutation = useMutation({
+    mutationFn: async (data: {
+      enabled: boolean;
+      sanitizedHistory?: string;
+    }) => {
+      return await convex.mutation(api.shellHistorySettings.update, {
+        teamSlugOrId,
+        ...data,
+      });
+    },
+    onSuccess: () => {
+      setOriginalEnabled(enabled);
+      setOriginalSanitizedHistory(sanitizedHistory);
+      toast.success("Shell history settings saved");
+    },
+    onError: (error) => {
+      toast.error("Failed to save shell history settings");
+      console.error("Error saving shell history settings:", error);
+    },
+  });
+
+  // Initialize form values when data loads
+  useEffect(() => {
+    if (settings !== undefined) {
+      setEnabled(settings.enabled ?? false);
+      setOriginalEnabled(settings.enabled ?? false);
+      setSanitizedHistory(settings.sanitizedHistory ?? "");
+      setOriginalSanitizedHistory(settings.sanitizedHistory ?? "");
+    }
+  }, [settings]);
+
+  // Notify parent of changes
+  useEffect(() => {
+    onDataChange?.({ enabled, sanitizedHistory });
+  }, [enabled, sanitizedHistory, onDataChange]);
+
+  const hasChanges = () => {
+    return (
+      enabled !== originalEnabled ||
+      sanitizedHistory !== originalSanitizedHistory
+    );
+  };
+
+  const saveSettings = () => {
+    updateMutation.mutate({
+      enabled,
+      sanitizedHistory: sanitizedHistory || undefined,
+    });
+  };
+
+  const lineCount = sanitizedHistory
+    ? sanitizedHistory.split("\n").filter((line) => line.trim()).length
+    : 0;
+
+  return (
+    <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
+      <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
+        <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          Shell History
+        </h2>
+      </div>
+      <div className="p-4 space-y-4">
+        {/* Toggle */}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <label className="block text-sm font-medium text-neutral-900 dark:text-neutral-100">
+              Seed Default Shell History
+            </label>
+            <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+              Pre-populate VMs with your shell history for zsh-autosuggestions.
+            </p>
+          </div>
+          <Switch
+            aria-label="Seed Default Shell History"
+            size="sm"
+            color="primary"
+            isSelected={enabled}
+            onValueChange={setEnabled}
+          />
+        </div>
+
+        {/* Explanation */}
+        <div className="p-3 bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg">
+          <h4 className="text-xs font-medium text-neutral-900 dark:text-neutral-100 mb-2">
+            What is zsh-autosuggestions?
+          </h4>
+          <p className="text-xs text-neutral-600 dark:text-neutral-400 mb-2">
+            Zsh-autosuggestions suggests commands as you type based on your
+            command history. Enable this to seed VMs with a sanitized version of
+            your local shell history, giving you familiar command suggestions.
+          </p>
+          <h4 className="text-xs font-medium text-neutral-900 dark:text-neutral-100 mb-1 mt-3">
+            What gets filtered out?
+          </h4>
+          <ul className="text-xs text-neutral-600 dark:text-neutral-400 list-disc ml-4 space-y-0.5">
+            <li>Environment variables (uppercase words like API_KEY, SECRET_TOKEN)</li>
+            <li>Passwords and credentials</li>
+            <li>Auth tokens and Bearer headers</li>
+            <li>Database connection strings with passwords</li>
+          </ul>
+        </div>
+
+        {/* Command to copy */}
+        {enabled && (
+          <>
+            <div>
+              <label className="block text-xs font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                Step 1: Run this command in your terminal to copy sanitized history
+              </label>
+              <div className="flex items-start gap-2">
+                <div className="flex-1 p-2 bg-neutral-100 dark:bg-neutral-800 rounded-lg font-mono text-xs text-neutral-800 dark:text-neutral-200 break-all">
+                  {getClipboardCommand()}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => clipboard.copy(getClipboardCommand())}
+                  className="p-2 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 hover:bg-neutral-200 dark:hover:bg-neutral-700 rounded-lg transition-colors flex-shrink-0"
+                  title={clipboard.copied ? "Copied!" : "Copy command"}
+                >
+                  {clipboard.copied ? (
+                    <Check className="w-4 h-4 text-green-500" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* Textarea for pasting */}
+            <div>
+              <label className="block text-xs font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                Step 2: Paste your sanitized history here
+              </label>
+              <textarea
+                value={sanitizedHistory}
+                onChange={(e) => setSanitizedHistory(e.target.value)}
+                placeholder="Paste your sanitized history here..."
+                className="w-full h-40 px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y"
+              />
+              <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+                {lineCount > 0 ? `${lineCount.toLocaleString()} lines` : "No history pasted yet"}
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Footer with save button */}
+      <div className="px-4 py-3 border-t border-neutral-200 dark:border-neutral-800 flex items-center justify-end">
+        <button
+          onClick={saveSettings}
+          disabled={!hasChanges() || updateMutation.isPending}
+          className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
+            !hasChanges() || updateMutation.isPending
+              ? "bg-neutral-200 dark:bg-neutral-800 text-neutral-400 dark:text-neutral-500 cursor-not-allowed"
+              : "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900 hover:bg-neutral-800 dark:hover:bg-neutral-200"
+          }`}
+        >
+          {updateMutation.isPending ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -2,6 +2,7 @@ import { env } from "@/client-env";
 import { ContainerSettings } from "@/components/ContainerSettings";
 import { FloatingPane } from "@/components/floating-pane";
 import { ProviderStatusSettings } from "@/components/provider-status-settings";
+import { ShellHistorySettings } from "@/components/ShellHistorySettings";
 import { useTheme } from "@/components/theme/use-theme";
 import { TitleBar } from "@/components/TitleBar";
 import { api } from "@cmux/convex/api";
@@ -1005,6 +1006,11 @@ function SettingsComponent() {
                   />
                 </div>
               </div>
+            )}
+
+            {/* Shell History Settings - hidden in web mode */}
+            {!env.NEXT_PUBLIC_WEB_MODE && (
+              <ShellHistorySettings teamSlugOrId={teamSlugOrId} />
             )}
 
             {/* Notifications */}

--- a/apps/server/src/vscode/DockerVSCodeInstance.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.ts
@@ -787,13 +787,89 @@ export class DockerVSCodeInstance extends VSCodeInstance {
     return logs;
   }
 
-  // Bootstrap container environment including GitHub auth and devcontainer
+  // Bootstrap container environment including GitHub auth, shell history, and devcontainer
   private async bootstrapContainerEnvironment(): Promise<void> {
     // First, set up GitHub authentication
     await this.bootstrapGitHubAuth();
 
+    // Write shell history for zsh-autosuggestions (non-blocking)
+    await this.bootstrapShellHistory();
+
     // Then, bootstrap devcontainer if present
     await this.bootstrapDevcontainerIfPresent();
+  }
+
+  // Write sanitized shell history to container for zsh-autosuggestions
+  private async bootstrapShellHistory(): Promise<void> {
+    try {
+      if (!this.container) {
+        dockerLogger.debug(
+          `bootstrapShellHistory: container not available for ${this.containerName}`
+        );
+        return;
+      }
+
+      // Fetch shell history settings from Convex
+      const shellHistorySettings = await getConvex().query(
+        api.shellHistorySettings.get,
+        { teamSlugOrId: this.teamSlugOrId }
+      );
+
+      if (
+        !shellHistorySettings?.enabled ||
+        !shellHistorySettings?.sanitizedHistory
+      ) {
+        dockerLogger.debug(
+          `bootstrapShellHistory: shell history sync not enabled for ${this.containerName}`
+        );
+        return;
+      }
+
+      const lineCount = shellHistorySettings.sanitizedHistory.split("\n").length;
+      dockerLogger.info(
+        `Writing shell history (${lineCount} lines) to container ${this.containerName}...`
+      );
+
+      // Write history using heredoc
+      const historyCmd = [
+        "bash",
+        "-c",
+        `cat >> ~/.zsh_history << 'SHELL_HISTORY_EOF'
+${shellHistorySettings.sanitizedHistory}
+SHELL_HISTORY_EOF
+chmod 600 ~/.zsh_history`,
+      ];
+
+      const exec = await this.container.exec({
+        Cmd: historyCmd,
+        AttachStdout: true,
+        AttachStderr: true,
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        exec.start({}, (err: Error | null, stream?: NodeJS.ReadableStream) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          if (stream) {
+            stream.on("end", () => resolve());
+            stream.resume();
+          } else {
+            resolve();
+          }
+        });
+      });
+
+      dockerLogger.info(
+        `Shell history written successfully to container ${this.containerName}`
+      );
+    } catch (error) {
+      dockerLogger.warn(
+        `Shell history bootstrap error for ${this.containerName}:`,
+        error
+      );
+    }
   }
 
   // Authenticate GitHub CLI using token from host

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -21,7 +21,7 @@ import {
   fetchGitIdentityInputs,
 } from "./sandboxes/git";
 import type { HydrateRepoConfig } from "./sandboxes/hydration";
-import { hydrateWorkspace } from "./sandboxes/hydration";
+import { hydrateWorkspace, writeShellHistory } from "./sandboxes/hydration";
 import { resolveTeamAndSnapshot } from "./sandboxes/snapshot";
 import {
   allocateScriptIdentifiers,
@@ -510,6 +510,30 @@ sandboxesRouter.openapi(
         await instance.stop().catch(() => { });
         return c.text("Failed to hydrate sandbox", 500);
       }
+
+      // Write shell history if enabled (non-blocking, best-effort)
+      (async () => {
+        try {
+          const shellHistorySettings = await convex.query(
+            api.shellHistorySettings.get,
+            { teamSlugOrId: body.teamSlugOrId },
+          );
+          if (
+            shellHistorySettings?.enabled &&
+            shellHistorySettings?.sanitizedHistory
+          ) {
+            await writeShellHistory({
+              instance,
+              sanitizedHistory: shellHistorySettings.sanitizedHistory,
+            });
+          }
+        } catch (error) {
+          console.error(
+            "[sandboxes.start] Failed to write shell history (non-fatal):",
+            error,
+          );
+        }
+      })();
 
       // Update status to "running" after hydration completes
       if (body.taskRunId && vscodePersisted) {

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -50,6 +50,7 @@ import type * as preview_jobs_worker from "../preview_jobs_worker.js";
 import type * as preview_screenshots_http from "../preview_screenshots_http.js";
 import type * as screenshots_http from "../screenshots_http.js";
 import type * as seed from "../seed.js";
+import type * as shellHistorySettings from "../shellHistorySettings.js";
 import type * as stack from "../stack.js";
 import type * as stack_webhook from "../stack_webhook.js";
 import type * as stack_webhook_actions from "../stack_webhook_actions.js";
@@ -116,6 +117,7 @@ declare const fullApi: ApiFromModules<{
   preview_screenshots_http: typeof preview_screenshots_http;
   screenshots_http: typeof screenshots_http;
   seed: typeof seed;
+  shellHistorySettings: typeof shellHistorySettings;
   stack: typeof stack;
   stack_webhook: typeof stack_webhook;
   stack_webhook_actions: typeof stack_webhook_actions;

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -668,6 +668,16 @@ const convexSchema = defineSchema({
     teamId: v.string(),
   }).index("by_team_user", ["teamId", "userId"]),
 
+  // Shell history settings for zsh-autosuggestions in VMs
+  shellHistorySettings: defineTable({
+    enabled: v.boolean(), // Whether to sync shell history to VMs
+    sanitizedHistory: v.optional(v.string()), // Sanitized shell history content
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    userId: v.string(),
+    teamId: v.string(),
+  }).index("by_team_user", ["teamId", "userId"]),
+
   // System and user comments attached to a task
   taskComments: defineTable({
     taskId: v.id("tasks"),

--- a/packages/convex/convex/shellHistorySettings.ts
+++ b/packages/convex/convex/shellHistorySettings.ts
@@ -1,0 +1,90 @@
+import { v } from "convex/values";
+import { resolveTeamIdLoose } from "../_shared/team";
+import { internalQuery } from "./_generated/server";
+import { authMutation, authQuery } from "./users/utils";
+
+// Default settings
+const DEFAULT_SETTINGS = {
+  enabled: false,
+  sanitizedHistory: null as string | null,
+};
+
+// Get shell history settings
+export const get = authQuery({
+  args: { teamSlugOrId: v.string() },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const settings = await ctx.db
+      .query("shellHistorySettings")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", teamId).eq("userId", userId),
+      )
+      .first();
+    if (!settings) {
+      return {
+        ...DEFAULT_SETTINGS,
+        _id: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+    }
+    return settings;
+  },
+});
+
+// Update shell history settings
+export const update = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    enabled: v.boolean(),
+    sanitizedHistory: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const existing = await ctx.db
+      .query("shellHistorySettings")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", teamId).eq("userId", userId),
+      )
+      .first();
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        enabled: args.enabled,
+        sanitizedHistory: args.sanitizedHistory,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("shellHistorySettings", {
+        enabled: args.enabled,
+        sanitizedHistory: args.sanitizedHistory,
+        userId,
+        teamId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  },
+});
+
+// Internal query for fetching shell history during VM provisioning
+export const getShellHistoryInternal = internalQuery({
+  args: { teamId: v.string(), userId: v.string() },
+  handler: async (ctx, args) => {
+    const settings = await ctx.db
+      .query("shellHistorySettings")
+      .withIndex("by_team_user", (q) =>
+        q.eq("teamId", args.teamId).eq("userId", args.userId),
+      )
+      .first();
+
+    if (!settings || !settings.enabled) {
+      return null;
+    }
+
+    return settings.sanitizedHistory || null;
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a new Shell History settings section (Electron only) that allows users to sync sanitized shell history to VMs
- History is written to `~/.zsh_history` on VM start, enabling zsh-autosuggestions with familiar commands
- Includes OS-detected clipboard command generation (pbcopy/clip/xclip) and security filtering

## Test plan
- [ ] Open Settings in Electron app and verify "Shell History" section appears
- [ ] Toggle "Enable Shell History Sync" and verify command/textarea UI appears
- [ ] Copy command, run in terminal, paste result into textarea
- [ ] Save and verify toast notification appears
- [ ] Start a VM and verify shell history is written to `~/.zsh_history`
- [ ] Verify feature is hidden in web mode