### PR TITLE
fix: correctly handle VSCode URLs for local Docker containers in sidebar

### DIFF
--- a/apps/client/src/components/OpenWithDropdown.tsx
+++ b/apps/client/src/components/OpenWithDropdown.tsx
@@ -6,6 +6,7 @@ import { EllipsisVertical, ExternalLink, GitBranch, Globe } from "lucide-react";
 
 interface OpenWithDropdownProps {
   vscodeUrl?: string | null;
+  vscodeProvider?: "docker" | "morph" | "daytona" | "other";
   worktreePath?: string | null;
   branch?: string | null;
   networking?: Parameters<typeof useOpenWithActions>[0]["networking"];
@@ -15,6 +16,7 @@ interface OpenWithDropdownProps {
 
 export function OpenWithDropdown({
   vscodeUrl,
+  vscodeProvider,
   worktreePath,
   branch,
   networking,
@@ -29,6 +31,7 @@ export function OpenWithDropdown({
     executePortAction,
   } = useOpenWithActions({
     vscodeUrl,
+    vscodeProvider,
     worktreePath,
     branch,
     networking,

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -1459,6 +1459,7 @@ function TaskRunTreeInner({
     () => (hasActiveVSCode && run.vscode?.url) || null,
     [hasActiveVSCode, run]
   );
+  const vscodeProvider = run.vscode?.provider;
 
   // Collect running preview ports and custom previews
   const previewServices = useMemo(() => {
@@ -1474,6 +1475,7 @@ function TaskRunTreeInner({
     executePortAction,
   } = useOpenWithActions({
     vscodeUrl,
+    vscodeProvider,
     worktreePath: run.worktreePath,
     branch: run.newBranch,
     networking: run.networking,

--- a/apps/client/src/components/dashboard/TaskItem.tsx
+++ b/apps/client/src/components/dashboard/TaskItem.tsx
@@ -162,13 +162,14 @@ export const TaskItem = memo(function TaskItem({
   );
   const hasActiveVSCode = runWithVSCode?.vscode?.status === "running";
 
-  // Generate the VSCode URL if available
+  // Generate the VSCode URL if available (use base URL, not workspaceUrl)
   const vscodeUrl = useMemo(() => {
-    if (hasActiveVSCode && runWithVSCode?.vscode?.workspaceUrl) {
-      return runWithVSCode.vscode.workspaceUrl;
+    if (hasActiveVSCode && runWithVSCode?.vscode?.url) {
+      return runWithVSCode.vscode.url;
     }
     return null;
   }, [hasActiveVSCode, runWithVSCode]);
+  const vscodeProvider = runWithVSCode?.vscode?.provider;
 
   // For local workspaces, find the run with VSCode to navigate to VSCode view directly
   const localWorkspaceRunWithVscode = useMemo(() => {
@@ -500,6 +501,7 @@ export const TaskItem = memo(function TaskItem({
           {/* Open with dropdown - always appears on hover */}
           <OpenWithDropdown
             vscodeUrl={vscodeUrl}
+            vscodeProvider={vscodeProvider}
             worktreePath={runWithVSCode?.worktreePath || task.worktreePath}
             branch={task.baseBranch}
             className="group-hover:opacity-100 aria-expanded:opacity-100 opacity-0"


### PR DESCRIPTION
## Summary

- Fixes the sidebar's "Open with" → "VS Code (web)" action incorrectly rewriting localhost URLs for Docker containers
- Docker container URLs (`http://localhost:PORT`) were being rewritten to use local serve-web origin, which is only appropriate for local workspace mode (provider === "other")
- Now correctly distinguishes between Docker, Morph, and local workspace modes

## Changes

- Added `vscodeProvider` parameter to `useOpenWithActions` hook to distinguish between providers
- Only applies URL rewriting for `provider === "other"` (local workspace mode without containers)
- For Docker and Morph containers, uses their URLs directly without rewriting
- Fixed `TaskItem.tsx` to use base `url` instead of `workspaceUrl` to avoid double folder parameter issues
- Properly handles URLs that already contain the folder parameter

## Test plan

- [ ] Start a task in local Docker mode, right-click in sidebar, select "Open with" → "VS Code (web)"
- [ ] Verify the URL opens directly to `http://localhost:PORT/?folder=/root/workspace`
- [ ] Start a task in Morph cloud mode, verify "VS Code (web)" opens the Morph URL correctly
- [ ] If local serve-web is running, verify local workspace mode still works correctly