### PR TITLE
feat(sandboxd): integrate PTY module with OpenAPI support

### DIFF
--- a/packages/sandbox/Cargo.lock
+++ b/packages/sandbox/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "indicatif",
  "libc",
  "open",
+ "parking_lot",
  "portable-pty",
  "predicates",
  "pulldown-cmark 0.12.2",

--- a/packages/sandbox/Cargo.toml
+++ b/packages/sandbox/Cargo.toml
@@ -35,6 +35,7 @@ crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
 ignore = "0.4.25"
 libc = "0.2"
+parking_lot = "0.12"
 portable-pty = "0.8"
 rcgen = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2", "stream"] }

--- a/packages/sandbox/src/api.rs
+++ b/packages/sandbox/src/api.rs
@@ -583,6 +583,15 @@ mod tests {
     // PTY API tests
     // =========================================================================
 
+    /// Create a test PTY request with /bin/sh (available in CI)
+    fn test_pty_request() -> crate::pty::CreatePtyRequest {
+        crate::pty::CreatePtyRequest {
+            shell: "/bin/sh".to_string(),
+            cwd: "/tmp".to_string(),
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
     async fn pty_list_sessions_returns_empty() {
         let app = make_test_router();
@@ -607,7 +616,7 @@ mod tests {
     #[tokio::test]
     async fn pty_create_session_returns_info() {
         let app = make_test_router();
-        let request = crate::pty::CreatePtyRequest::default();
+        let request = test_pty_request();
 
         let response = app
             .oneshot(
@@ -686,7 +695,7 @@ mod tests {
         use tower::Service;
 
         let mut app = make_test_router();
-        let request = crate::pty::CreatePtyRequest::default();
+        let request = test_pty_request();
 
         // Create session
         let response = app
@@ -731,7 +740,7 @@ mod tests {
         use tower::Service;
 
         let mut app = make_test_router();
-        let request = crate::pty::CreatePtyRequest::default();
+        let request = test_pty_request();
 
         // Create session
         let response = app
@@ -784,7 +793,7 @@ mod tests {
         use tower::Service;
 
         let mut app = make_test_router();
-        let request = crate::pty::CreatePtyRequest::default();
+        let request = test_pty_request();
 
         // Create session
         let response = app
@@ -837,7 +846,7 @@ mod tests {
         use tower::Service;
 
         let mut app = make_test_router();
-        let request = crate::pty::CreatePtyRequest::default();
+        let request = test_pty_request();
 
         // Create session
         let response = app
@@ -882,7 +891,7 @@ mod tests {
         use tower::Service;
 
         let mut app = make_test_router();
-        let request = crate::pty::CreatePtyRequest::default();
+        let request = test_pty_request();
 
         // Create session
         let response = app

--- a/packages/sandbox/src/bin/server.rs
+++ b/packages/sandbox/src/bin/server.rs
@@ -661,4 +661,8 @@ impl SandboxService for UnavailableSandboxService {
     async fn delete(&self, _id: String) -> SandboxResult<Option<SandboxSummary>> {
         Err(self.error("delete sandbox"))
     }
+
+    async fn get_sandbox_pid(&self, _id: String) -> Option<u32> {
+        None
+    }
 }

--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -2131,6 +2131,12 @@ impl SandboxService for BubblewrapService {
 
         Ok(None)
     }
+
+    async fn get_sandbox_pid(&self, id_str: String) -> Option<u32> {
+        let id = self.resolve_id(&id_str).await.ok()?;
+        let sandboxes = self.sandboxes.lock().await;
+        sandboxes.get(&id).map(|entry| entry.inner_pid)
+    }
 }
 
 impl SandboxHandle {

--- a/packages/sandbox/src/lib.rs
+++ b/packages/sandbox/src/lib.rs
@@ -8,6 +8,7 @@ pub mod models;
 pub mod mux;
 pub mod notifications;
 pub mod palette;
+pub mod pty;
 pub mod sandbox_handle;
 pub mod service;
 pub mod settings;

--- a/packages/sandbox/src/pty/api.rs
+++ b/packages/sandbox/src/pty/api.rs
@@ -1,0 +1,702 @@
+//! PTY API routes
+//!
+//! REST endpoints for managing PTY sessions within sandboxes.
+
+use super::types::{
+    CapturePtyResponse, CreatePtyRequest, InputPtyRequest, PtyInfo, ResizePtyRequest,
+    UpdatePtyRequest,
+};
+use super::PtyState;
+use crate::errors::{ErrorBody, SandboxError, SandboxResult};
+use crate::service::AppState;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{any, get, post};
+use axum::{Json, Router};
+use futures::{SinkExt, StreamExt};
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+/// Build PTY routes for sandbox-scoped sessions
+pub fn pty_routes() -> Router<AppState> {
+    Router::new()
+        // Sandbox-scoped PTY routes
+        .route(
+            "/sandboxes/{sandbox_id}/sessions",
+            get(list_sandbox_sessions).post(create_sandbox_session),
+        )
+        .route(
+            "/sandboxes/{sandbox_id}/sessions/{session_id}",
+            get(get_session)
+                .delete(delete_session)
+                .patch(update_session),
+        )
+        .route(
+            "/sandboxes/{sandbox_id}/sessions/{session_id}/input",
+            post(send_input),
+        )
+        .route(
+            "/sandboxes/{sandbox_id}/sessions/{session_id}/resize",
+            post(resize_session),
+        )
+        .route(
+            "/sandboxes/{sandbox_id}/sessions/{session_id}/capture",
+            get(capture_session),
+        )
+        .route(
+            "/sandboxes/{sandbox_id}/sessions/{session_id}/ws",
+            any(session_websocket),
+        )
+        // Top-level PTY routes (for host-namespace sessions, e.g., development)
+        .route(
+            "/sessions",
+            get(list_all_sessions).post(create_host_session),
+        )
+        .route(
+            "/sessions/{session_id}",
+            get(get_session_by_id)
+                .delete(delete_session_by_id)
+                .patch(update_session_by_id),
+        )
+        .route("/sessions/{session_id}/input", post(send_input_by_id))
+        .route("/sessions/{session_id}/resize", post(resize_session_by_id))
+        .route("/sessions/{session_id}/capture", get(capture_session_by_id))
+        .route("/sessions/{session_id}/ws", any(session_websocket_by_id))
+        // Event WebSocket (broadcasts all PTY events)
+        .route("/ws", any(events_websocket))
+}
+
+// =============================================================================
+// Sandbox-scoped handlers
+// =============================================================================
+
+/// List PTY sessions for a specific sandbox
+#[utoipa::path(
+    get,
+    path = "/sandboxes/{sandbox_id}/sessions",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID")
+    ),
+    responses(
+        (status = 200, description = "List of PTY sessions in sandbox", body = [PtyInfo])
+    )
+)]
+pub async fn list_sandbox_sessions(
+    State(state): State<AppState>,
+    Path(sandbox_id): Path<String>,
+) -> Json<Vec<PtyInfo>> {
+    Json(state.pty_state.get_ordered_sessions(Some(&sandbox_id)))
+}
+
+/// Create a PTY session in a sandbox
+#[utoipa::path(
+    post,
+    path = "/sandboxes/{sandbox_id}/sessions",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID")
+    ),
+    request_body = CreatePtyRequest,
+    responses(
+        (status = 201, description = "PTY session created in sandbox", body = PtyInfo),
+        (status = 400, description = "Sandbox not found", body = ErrorBody),
+        (status = 500, description = "Internal error", body = ErrorBody)
+    )
+)]
+pub async fn create_sandbox_session(
+    State(state): State<AppState>,
+    Path(sandbox_id): Path<String>,
+    Json(request): Json<CreatePtyRequest>,
+) -> SandboxResult<(StatusCode, Json<PtyInfo>)> {
+    // Get sandbox PID for nsenter
+    let sandbox_pid = state
+        .service
+        .get_sandbox_pid(sandbox_id.clone())
+        .await
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Sandbox not found: {}", sandbox_id))
+        })?;
+
+    let info = state
+        .pty_state
+        .create_session(&request, Some(sandbox_id), Some(sandbox_pid))
+        .map_err(|e| SandboxError::Internal(e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(info)))
+}
+
+/// Get a PTY session
+#[utoipa::path(
+    get,
+    path = "/sandboxes/{sandbox_id}/sessions/{session_id}",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID"),
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    responses(
+        (status = 200, description = "PTY session info", body = PtyInfo),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn get_session(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+) -> SandboxResult<Json<PtyInfo>> {
+    let session = state
+        .pty_state
+        .get_session_for_sandbox(&session_id, Some(&sandbox_id))
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+        })?;
+
+    Ok(Json(session.to_info()))
+}
+
+/// Delete a PTY session
+#[utoipa::path(
+    delete,
+    path = "/sandboxes/{sandbox_id}/sessions/{session_id}",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID"),
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    responses(
+        (status = 200, description = "Deleted PTY session info", body = PtyInfo),
+        (status = 400, description = "Session not found or not in sandbox", body = ErrorBody)
+    )
+)]
+pub async fn delete_session(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+) -> SandboxResult<Json<PtyInfo>> {
+    // Verify session belongs to sandbox
+    let session = state
+        .pty_state
+        .get_session_for_sandbox(&session_id, Some(&sandbox_id))
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+        })?;
+
+    if session.sandbox_id.as_deref() != Some(&sandbox_id) {
+        return Err(SandboxError::InvalidRequest(format!(
+            "Session {} not in sandbox {}",
+            session_id, sandbox_id
+        )));
+    }
+
+    let info = state.pty_state.delete_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    Ok(Json(info))
+}
+
+/// Update a PTY session
+#[utoipa::path(
+    patch,
+    path = "/sandboxes/{sandbox_id}/sessions/{session_id}",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID"),
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    request_body = UpdatePtyRequest,
+    responses(
+        (status = 200, description = "Updated PTY session info", body = PtyInfo),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn update_session(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+    Json(request): Json<UpdatePtyRequest>,
+) -> SandboxResult<Json<PtyInfo>> {
+    let session = state
+        .pty_state
+        .get_session_for_sandbox(&session_id, Some(&sandbox_id))
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+        })?;
+
+    if let Some(name) = request.name {
+        session.set_name(name);
+    }
+    if let Some(index) = request.index {
+        session.set_index(index);
+    }
+    if let Some(metadata) = request.metadata {
+        session.merge_metadata(metadata);
+    }
+
+    Ok(Json(session.to_info()))
+}
+
+/// Send input to a PTY session
+#[utoipa::path(
+    post,
+    path = "/sandboxes/{sandbox_id}/sessions/{session_id}/input",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID"),
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    request_body = InputPtyRequest,
+    responses(
+        (status = 204, description = "Input sent"),
+        (status = 400, description = "Session not found", body = ErrorBody),
+        (status = 500, description = "Failed to write input", body = ErrorBody)
+    )
+)]
+pub async fn send_input(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+    Json(request): Json<InputPtyRequest>,
+) -> SandboxResult<StatusCode> {
+    let session = state
+        .pty_state
+        .get_session_for_sandbox(&session_id, Some(&sandbox_id))
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+        })?;
+
+    session
+        .write_input(&request.data)
+        .map_err(|e| SandboxError::Internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Resize a PTY session
+#[utoipa::path(
+    post,
+    path = "/sandboxes/{sandbox_id}/sessions/{session_id}/resize",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID"),
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    request_body = ResizePtyRequest,
+    responses(
+        (status = 204, description = "PTY resized"),
+        (status = 400, description = "Session not found", body = ErrorBody),
+        (status = 500, description = "Failed to resize", body = ErrorBody)
+    )
+)]
+pub async fn resize_session(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+    Json(request): Json<ResizePtyRequest>,
+) -> SandboxResult<StatusCode> {
+    let session = state
+        .pty_state
+        .get_session_for_sandbox(&session_id, Some(&sandbox_id))
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+        })?;
+
+    session
+        .resize(request.cols, request.rows)
+        .map_err(|e| SandboxError::Internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Capture PTY screen content
+#[utoipa::path(
+    get,
+    path = "/sandboxes/{sandbox_id}/sessions/{session_id}/capture",
+    tag = "pty",
+    params(
+        ("sandbox_id" = String, Path, description = "Sandbox ID"),
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    responses(
+        (status = 200, description = "Screen content captured", body = CapturePtyResponse),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn capture_session(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+) -> SandboxResult<Json<CapturePtyResponse>> {
+    let session = state
+        .pty_state
+        .get_session_for_sandbox(&session_id, Some(&sandbox_id))
+        .ok_or_else(|| {
+            SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+        })?;
+
+    Ok(Json(CapturePtyResponse {
+        content: session.get_scrollback(),
+    }))
+}
+
+/// WebSocket for PTY terminal I/O
+async fn session_websocket(
+    State(state): State<AppState>,
+    Path((sandbox_id, session_id)): Path<(String, String)>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    let pty_state = state.pty_state.clone();
+    ws.on_upgrade(move |socket| {
+        handle_session_websocket(socket, pty_state, session_id, Some(sandbox_id))
+    })
+}
+
+// =============================================================================
+// Top-level (host namespace) handlers
+// =============================================================================
+
+/// List all PTY sessions
+#[utoipa::path(
+    get,
+    path = "/sessions",
+    tag = "pty",
+    responses(
+        (status = 200, description = "List of all PTY sessions", body = [PtyInfo])
+    )
+)]
+pub async fn list_all_sessions(State(state): State<AppState>) -> Json<Vec<PtyInfo>> {
+    Json(state.pty_state.get_ordered_sessions(None))
+}
+
+/// Create a PTY session in host namespace
+#[utoipa::path(
+    post,
+    path = "/sessions",
+    tag = "pty",
+    request_body = CreatePtyRequest,
+    responses(
+        (status = 201, description = "PTY session created", body = PtyInfo),
+        (status = 500, description = "Internal error", body = ErrorBody)
+    )
+)]
+pub async fn create_host_session(
+    State(state): State<AppState>,
+    Json(request): Json<CreatePtyRequest>,
+) -> SandboxResult<(StatusCode, Json<PtyInfo>)> {
+    let info = state
+        .pty_state
+        .create_session(&request, None, None)
+        .map_err(|e| SandboxError::Internal(e.to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(info)))
+}
+
+/// Get a session by ID (any sandbox)
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}",
+    tag = "pty",
+    params(
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    responses(
+        (status = 200, description = "PTY session info", body = PtyInfo),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn get_session_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> SandboxResult<Json<PtyInfo>> {
+    let session = state.pty_state.get_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    Ok(Json(session.to_info()))
+}
+
+/// Delete a session by ID
+#[utoipa::path(
+    delete,
+    path = "/sessions/{session_id}",
+    tag = "pty",
+    params(
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    responses(
+        (status = 200, description = "Deleted PTY session info", body = PtyInfo),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn delete_session_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> SandboxResult<Json<PtyInfo>> {
+    let info = state.pty_state.delete_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    Ok(Json(info))
+}
+
+/// Update a session by ID
+#[utoipa::path(
+    patch,
+    path = "/sessions/{session_id}",
+    tag = "pty",
+    params(
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    request_body = UpdatePtyRequest,
+    responses(
+        (status = 200, description = "Updated PTY session info", body = PtyInfo),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn update_session_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(request): Json<UpdatePtyRequest>,
+) -> SandboxResult<Json<PtyInfo>> {
+    let session = state.pty_state.get_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    if let Some(name) = request.name {
+        session.set_name(name);
+    }
+    if let Some(index) = request.index {
+        session.set_index(index);
+    }
+    if let Some(metadata) = request.metadata {
+        session.merge_metadata(metadata);
+    }
+
+    Ok(Json(session.to_info()))
+}
+
+/// Send input by session ID
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/input",
+    tag = "pty",
+    params(
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    request_body = InputPtyRequest,
+    responses(
+        (status = 204, description = "Input sent"),
+        (status = 400, description = "Session not found", body = ErrorBody),
+        (status = 500, description = "Failed to write input", body = ErrorBody)
+    )
+)]
+pub async fn send_input_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(request): Json<InputPtyRequest>,
+) -> SandboxResult<StatusCode> {
+    let session = state.pty_state.get_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    session
+        .write_input(&request.data)
+        .map_err(|e| SandboxError::Internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Resize by session ID
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/resize",
+    tag = "pty",
+    params(
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    request_body = ResizePtyRequest,
+    responses(
+        (status = 204, description = "PTY resized"),
+        (status = 400, description = "Session not found", body = ErrorBody),
+        (status = 500, description = "Failed to resize", body = ErrorBody)
+    )
+)]
+pub async fn resize_session_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(request): Json<ResizePtyRequest>,
+) -> SandboxResult<StatusCode> {
+    let session = state.pty_state.get_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    session
+        .resize(request.cols, request.rows)
+        .map_err(|e| SandboxError::Internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Capture by session ID
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/capture",
+    tag = "pty",
+    params(
+        ("session_id" = String, Path, description = "PTY session ID")
+    ),
+    responses(
+        (status = 200, description = "Screen content captured", body = CapturePtyResponse),
+        (status = 400, description = "Session not found", body = ErrorBody)
+    )
+)]
+pub async fn capture_session_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> SandboxResult<Json<CapturePtyResponse>> {
+    let session = state.pty_state.get_session(&session_id).ok_or_else(|| {
+        SandboxError::InvalidRequest(format!("Session not found: {}", session_id))
+    })?;
+
+    Ok(Json(CapturePtyResponse {
+        content: session.get_scrollback(),
+    }))
+}
+
+/// WebSocket by session ID
+async fn session_websocket_by_id(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    let pty_state = state.pty_state.clone();
+    ws.on_upgrade(move |socket| handle_session_websocket(socket, pty_state, session_id, None))
+}
+
+/// Events WebSocket - broadcasts all PTY events
+async fn events_websocket(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    let pty_state = state.pty_state.clone();
+    ws.on_upgrade(move |socket| handle_events_websocket(socket, pty_state))
+}
+
+// =============================================================================
+// WebSocket handlers
+// =============================================================================
+
+/// Handle a session WebSocket connection (terminal I/O)
+async fn handle_session_websocket(
+    socket: WebSocket,
+    pty_state: Arc<PtyState>,
+    session_id: String,
+    sandbox_id: Option<String>,
+) {
+    let session = match pty_state.get_session_for_sandbox(&session_id, sandbox_id.as_deref()) {
+        Some(s) => s,
+        None => {
+            warn!("WebSocket connection for unknown session: {}", session_id);
+            return;
+        }
+    };
+
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+    let mut output_rx = session.output_tx.subscribe();
+
+    info!("[ws:{}] Session WebSocket connected", session_id);
+
+    // Send current scrollback
+    let scrollback = session.get_scrollback();
+    if !scrollback.is_empty() {
+        if let Err(e) = ws_sender.send(Message::Text(scrollback.into())).await {
+            error!("[ws:{}] Failed to send scrollback: {}", session_id, e);
+            return;
+        }
+    }
+
+    // Spawn task to forward PTY output to WebSocket
+    let session_id_clone = session_id.clone();
+    let output_task = tokio::spawn(async move {
+        while let Ok(data) = output_rx.recv().await {
+            if ws_sender.send(Message::Text(data.into())).await.is_err() {
+                break;
+            }
+        }
+        info!("[ws:{}] Output task finished", session_id_clone);
+    });
+
+    // Handle incoming WebSocket messages (input)
+    let session_clone = session.clone();
+    let session_id_clone = session_id.clone();
+    while let Some(msg) = ws_receiver.next().await {
+        match msg {
+            Ok(Message::Text(text)) => {
+                if let Err(e) = session_clone.write_input(&text) {
+                    error!("[ws:{}] Failed to write input: {}", session_id_clone, e);
+                    break;
+                }
+            }
+            Ok(Message::Binary(data)) => {
+                let text = String::from_utf8_lossy(&data);
+                if let Err(e) = session_clone.write_input(&text) {
+                    error!("[ws:{}] Failed to write input: {}", session_id_clone, e);
+                    break;
+                }
+            }
+            Ok(Message::Close(_)) => {
+                info!("[ws:{}] Client closed connection", session_id_clone);
+                break;
+            }
+            Err(e) => {
+                error!("[ws:{}] WebSocket error: {}", session_id_clone, e);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    output_task.abort();
+    info!("[ws:{}] Session WebSocket disconnected", session_id);
+}
+
+/// Handle events WebSocket (broadcasts all PTY events)
+async fn handle_events_websocket(socket: WebSocket, pty_state: Arc<PtyState>) {
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+    let mut event_rx = pty_state.subscribe();
+
+    info!("[ws:events] Events WebSocket connected");
+
+    // Send initial state
+    let state_sync = pty_state.get_full_state(None);
+    if let Ok(json) = serde_json::to_string(&state_sync) {
+        if let Err(e) = ws_sender.send(Message::Text(json.into())).await {
+            error!("[ws:events] Failed to send initial state: {}", e);
+            return;
+        }
+    }
+
+    // Spawn task to forward events to WebSocket
+    let event_task = tokio::spawn(async move {
+        while let Ok(event) = event_rx.recv().await {
+            if let Ok(json) = serde_json::to_string(&event) {
+                if ws_sender.send(Message::Text(json.into())).await.is_err() {
+                    break;
+                }
+            }
+        }
+        info!("[ws:events] Event task finished");
+    });
+
+    // Keep connection alive by reading (ignore messages)
+    while let Some(msg) = ws_receiver.next().await {
+        match msg {
+            Ok(Message::Close(_)) => break,
+            Err(e) => {
+                error!("[ws:events] WebSocket error: {}", e);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    event_task.abort();
+    info!("[ws:events] Events WebSocket disconnected");
+}

--- a/packages/sandbox/src/pty/mod.rs
+++ b/packages/sandbox/src/pty/mod.rs
@@ -1,0 +1,15 @@
+//! PTY Session Management
+//!
+//! This module provides PTY session management with support for:
+//! - Host-namespace PTYs (for development)
+//! - Sandbox-scoped PTYs (using nsenter to enter bwrap namespaces)
+
+pub mod api;
+mod session;
+mod state;
+mod types;
+
+pub use api::pty_routes;
+pub use session::PtySession;
+pub use state::PtyState;
+pub use types::*;

--- a/packages/sandbox/src/pty/session.rs
+++ b/packages/sandbox/src/pty/session.rs
@@ -1,0 +1,391 @@
+//! PTY Session implementation
+//!
+//! Handles individual PTY sessions including:
+//! - Process spawning (with nsenter for sandbox sessions)
+//! - Input/output handling
+//! - Scrollback buffer management
+
+use super::types::PtyInfo;
+use anyhow::{Context, Result};
+use parking_lot::{Mutex, RwLock};
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use std::io::{Read, Write as IoWrite};
+use std::sync::mpsc::SyncSender;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::broadcast;
+use tracing::{error, info, warn};
+
+const MAX_SCROLLBACK: usize = 100_000;
+const PTY_WRITE_CHUNK_SIZE: usize = 512;
+pub const PTY_INPUT_CHANNEL_SIZE: usize = 1024;
+pub const PTY_READ_BUFFER_SIZE: usize = 4096;
+
+/// Inner PTY state that requires mutex protection
+struct PtySessionInner {
+    master: Box<dyn MasterPty + Send>,
+    child: Box<dyn portable_pty::Child + Send>,
+}
+
+/// A PTY session with its associated process and I/O channels
+pub struct PtySession {
+    /// Unique session ID
+    pub id: String,
+    /// PTY master and child process
+    inner: Mutex<PtySessionInner>,
+    /// Shell command
+    pub shell: String,
+    /// Working directory
+    pub cwd: String,
+    /// Display name
+    name: RwLock<String>,
+    /// Display index
+    index: RwLock<usize>,
+    /// Creation timestamp
+    pub created_at: f64,
+    /// Terminal columns
+    cols: RwLock<u16>,
+    /// Terminal rows
+    rows: RwLock<u16>,
+    /// Scrollback buffer
+    scrollback: RwLock<String>,
+    /// Broadcast channel for output
+    pub output_tx: broadcast::Sender<String>,
+    /// Input channel (bounded for backpressure)
+    input_tx: SyncSender<Vec<u8>>,
+    /// Process ID
+    pub pid: u32,
+    /// Sandbox ID (if running inside a sandbox)
+    pub sandbox_id: Option<String>,
+    /// Custom metadata
+    metadata: RwLock<Option<serde_json::Value>>,
+}
+
+impl PtySession {
+    /// Create a new PTY session
+    ///
+    /// If `sandbox_pid` is provided, the shell will be spawned inside the sandbox
+    /// using nsenter to enter its namespaces.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        name: String,
+        index: usize,
+        shell: &str,
+        cwd: &str,
+        cols: u16,
+        rows: u16,
+        env: Option<&std::collections::HashMap<String, String>>,
+        sandbox_id: Option<String>,
+        sandbox_pid: Option<u32>,
+        metadata: Option<serde_json::Value>,
+    ) -> Result<(Self, Box<dyn Read + Send>)> {
+        let pty_system = native_pty_system();
+
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("Failed to open PTY")?;
+
+        // Build the command - use nsenter if we have a sandbox PID
+        let mut cmd = if let Some(target_pid) = sandbox_pid {
+            // Use nsenter to enter the sandbox's namespaces
+            let mut cmd = CommandBuilder::new("nsenter");
+            cmd.args([
+                "--target",
+                &target_pid.to_string(),
+                "--mount",  // Enter mount namespace (filesystem isolation)
+                "--net",    // Enter network namespace (unique IP)
+                "--pid",    // Enter PID namespace
+                "--cgroup", // Enter cgroup namespace
+                "--",
+                shell,
+            ]);
+            cmd
+        } else {
+            // Run directly in host namespace
+            CommandBuilder::new(shell)
+        };
+
+        cmd.cwd(cwd);
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
+        cmd.env("SHELL", shell);
+
+        if let Some(env_vars) = env {
+            for (key, value) in env_vars {
+                cmd.env(key, value);
+            }
+        }
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .context("Failed to spawn command")?;
+        let pid = child.process_id().unwrap_or(0);
+
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .context("Failed to clone PTY reader")?;
+        let writer = pair
+            .master
+            .take_writer()
+            .context("Failed to take PTY writer")?;
+
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0);
+
+        let (output_tx, _) = broadcast::channel(1024);
+        let (input_tx, input_rx) = std::sync::mpsc::sync_channel(PTY_INPUT_CHANNEL_SIZE);
+
+        // Spawn dedicated writer thread
+        spawn_pty_writer_thread(id.clone(), writer, input_rx);
+
+        let session = Self {
+            id,
+            inner: Mutex::new(PtySessionInner {
+                master: pair.master,
+                child,
+            }),
+            shell: shell.to_string(),
+            cwd: cwd.to_string(),
+            name: RwLock::new(name),
+            index: RwLock::new(index),
+            created_at,
+            cols: RwLock::new(cols),
+            rows: RwLock::new(rows),
+            scrollback: RwLock::new(String::new()),
+            output_tx,
+            input_tx,
+            pid,
+            sandbox_id,
+            metadata: RwLock::new(metadata),
+        };
+
+        Ok((session, reader))
+    }
+
+    /// Get session info for API responses
+    pub fn to_info(&self) -> PtyInfo {
+        let alive = {
+            let mut inner = self.inner.lock();
+            inner.child.try_wait().ok().flatten().is_none()
+        };
+
+        PtyInfo {
+            id: self.id.clone(),
+            name: self.name.read().clone(),
+            index: *self.index.read(),
+            shell: self.shell.clone(),
+            cwd: self.cwd.clone(),
+            cols: *self.cols.read(),
+            rows: *self.rows.read(),
+            created_at: self.created_at,
+            alive,
+            pid: self.pid,
+            sandbox_id: self.sandbox_id.clone(),
+            metadata: self.metadata.read().clone(),
+        }
+    }
+
+    /// Check if the PTY process is still running
+    pub fn is_alive(&self) -> bool {
+        let mut inner = self.inner.lock();
+        inner.child.try_wait().ok().flatten().is_none()
+    }
+
+    /// Send input to the PTY
+    pub fn write_input(&self, data: &str) -> Result<()> {
+        let len = data.len();
+        if len > 100 {
+            info!("[session:{}] Queueing large input: {} bytes", self.id, len);
+        }
+        self.input_tx.send(data.as_bytes().to_vec()).map_err(|e| {
+            error!("[session:{}] Input channel send failed: {}", self.id, e);
+            anyhow::anyhow!("PTY input channel closed")
+        })?;
+        Ok(())
+    }
+
+    /// Resize the PTY
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<()> {
+        *self.cols.write() = cols;
+        *self.rows.write() = rows;
+        let inner = self.inner.lock();
+        inner
+            .master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("Failed to resize PTY")?;
+        Ok(())
+    }
+
+    /// Kill the PTY process
+    pub fn kill(&self) {
+        let mut inner = self.inner.lock();
+        if let Err(e) = inner.child.kill() {
+            warn!("Failed to kill PTY process: {}", e);
+        }
+    }
+
+    /// Append data to the scrollback buffer
+    pub fn append_scrollback(&self, data: &str) {
+        let mut scrollback = self.scrollback.write();
+        scrollback.push_str(data);
+        if scrollback.len() > MAX_SCROLLBACK {
+            let mut start = scrollback.len() - MAX_SCROLLBACK;
+            // Find valid UTF-8 boundary
+            while start < scrollback.len() && !scrollback.is_char_boundary(start) {
+                start += 1;
+            }
+            *scrollback = scrollback[start..].to_string();
+        }
+    }
+
+    /// Get the scrollback buffer content
+    pub fn get_scrollback(&self) -> String {
+        self.scrollback.read().clone()
+    }
+
+    /// Set the session name
+    pub fn set_name(&self, name: String) {
+        *self.name.write() = name;
+    }
+
+    /// Get the session name
+    pub fn get_name(&self) -> String {
+        self.name.read().clone()
+    }
+
+    /// Set the display index
+    pub fn set_index(&self, index: usize) {
+        *self.index.write() = index;
+    }
+
+    /// Get the display index
+    pub fn get_index(&self) -> usize {
+        *self.index.read()
+    }
+
+    /// Set metadata
+    pub fn set_metadata(&self, metadata: Option<serde_json::Value>) {
+        *self.metadata.write() = metadata;
+    }
+
+    /// Get metadata
+    pub fn get_metadata(&self) -> Option<serde_json::Value> {
+        self.metadata.read().clone()
+    }
+
+    /// Merge metadata with existing
+    pub fn merge_metadata(&self, new_metadata: serde_json::Value) {
+        let mut metadata = self.metadata.write();
+        match (&mut *metadata, new_metadata) {
+            (Some(serde_json::Value::Object(existing)), serde_json::Value::Object(new)) => {
+                for (key, value) in new {
+                    if value.is_null() {
+                        existing.remove(&key);
+                    } else {
+                        existing.insert(key, value);
+                    }
+                }
+            }
+            (_, new) => {
+                *metadata = Some(new);
+            }
+        }
+    }
+}
+
+/// Spawns a dedicated thread for PTY writes
+fn spawn_pty_writer_thread(
+    session_id: String,
+    mut writer: Box<dyn IoWrite + Send>,
+    input_rx: std::sync::mpsc::Receiver<Vec<u8>>,
+) {
+    std::thread::spawn(move || {
+        info!("[writer:{}] Writer thread started", session_id);
+
+        let mut total_bytes_written: usize = 0;
+        let mut message_count: usize = 0;
+
+        while let Ok(data) = input_rx.recv() {
+            message_count += 1;
+            let data_len = data.len();
+
+            // Write in small chunks to prevent blocking
+            for chunk in data.chunks(PTY_WRITE_CHUNK_SIZE) {
+                if let Err(e) = writer.write_all(chunk) {
+                    error!(
+                        "[writer:{}] Write error: {} (errno: {:?})",
+                        session_id,
+                        e,
+                        e.raw_os_error()
+                    );
+                    return;
+                }
+                if let Err(e) = writer.flush() {
+                    error!(
+                        "[writer:{}] Flush error: {} (errno: {:?})",
+                        session_id,
+                        e,
+                        e.raw_os_error()
+                    );
+                    return;
+                }
+                std::thread::yield_now();
+            }
+
+            total_bytes_written += data_len;
+            if data_len > 100 {
+                info!(
+                    "[writer:{}] Large input processed: {} bytes (total: {} bytes)",
+                    session_id, data_len, total_bytes_written
+                );
+            }
+        }
+
+        info!(
+            "[writer:{}] Writer thread finished. Total: {} messages, {} bytes",
+            session_id, message_count, total_bytes_written
+        );
+    });
+}
+
+/// Find the last valid UTF-8 boundary in a byte slice
+pub fn find_utf8_boundary(bytes: &[u8]) -> usize {
+    if bytes.is_empty() {
+        return 0;
+    }
+
+    if std::str::from_utf8(bytes).is_ok() {
+        return bytes.len();
+    }
+
+    // Look back up to 4 bytes to find a complete sequence
+    for i in 1..=4.min(bytes.len()) {
+        let check_pos = bytes.len() - i;
+        if std::str::from_utf8(&bytes[..check_pos]).is_ok() {
+            return check_pos;
+        }
+    }
+
+    // Fallback: find last non-continuation byte
+    for i in (0..bytes.len()).rev() {
+        if bytes[i] & 0b1100_0000 != 0b1000_0000 && std::str::from_utf8(&bytes[..i]).is_ok() {
+            return i;
+        }
+    }
+
+    0
+}

--- a/packages/sandbox/src/pty/state.rs
+++ b/packages/sandbox/src/pty/state.rs
@@ -1,0 +1,311 @@
+//! PTY State Management
+//!
+//! Manages the collection of PTY sessions and handles session lifecycle.
+
+use super::session::{find_utf8_boundary, PtySession, PTY_READ_BUFFER_SIZE};
+use super::types::{CreatePtyRequest, PtyEvent, PtyInfo};
+use anyhow::Result;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::io::Read;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::{error, info};
+use uuid::Uuid;
+
+/// Shared PTY state
+pub struct PtyState {
+    /// All sessions indexed by ID
+    sessions: RwLock<HashMap<String, Arc<PtySession>>>,
+    /// Counter for generating terminal names
+    terminal_counter: RwLock<u32>,
+    /// Broadcast channel for PTY events
+    event_tx: broadcast::Sender<PtyEvent>,
+}
+
+impl PtyState {
+    /// Create a new PTY state
+    pub fn new() -> Self {
+        let (event_tx, _) = broadcast::channel(1024);
+        Self {
+            sessions: RwLock::new(HashMap::new()),
+            terminal_counter: RwLock::new(0),
+            event_tx,
+        }
+    }
+
+    /// Subscribe to PTY events
+    pub fn subscribe(&self) -> broadcast::Receiver<PtyEvent> {
+        self.event_tx.subscribe()
+    }
+
+    /// Generate a unique terminal name
+    fn get_next_terminal_name(&self, shell: &str) -> String {
+        let mut counter = self.terminal_counter.write();
+        *counter += 1;
+        let shell_name = std::path::Path::new(shell)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("shell");
+        format!("{} {}", shell_name, *counter)
+    }
+
+    /// Get all sessions ordered by index
+    pub fn get_ordered_sessions(&self, sandbox_id: Option<&str>) -> Vec<PtyInfo> {
+        let sessions = self.sessions.read();
+        let mut infos: Vec<_> = sessions
+            .values()
+            .filter(|s| {
+                s.is_alive()
+                    && match sandbox_id {
+                        Some(id) => s.sandbox_id.as_deref() == Some(id),
+                        None => true,
+                    }
+            })
+            .map(|s| s.to_info())
+            .collect();
+        infos.sort_by_key(|s| s.index);
+        infos
+    }
+
+    /// Get a session by ID
+    pub fn get_session(&self, session_id: &str) -> Option<Arc<PtySession>> {
+        self.sessions.read().get(session_id).cloned()
+    }
+
+    /// Get a session by ID, optionally validating sandbox ownership
+    pub fn get_session_for_sandbox(
+        &self,
+        session_id: &str,
+        sandbox_id: Option<&str>,
+    ) -> Option<Arc<PtySession>> {
+        let session = self.sessions.read().get(session_id).cloned()?;
+
+        // If a sandbox_id filter is provided, verify the session belongs to it
+        if let Some(id) = sandbox_id {
+            if session.sandbox_id.as_deref() != Some(id) {
+                return None;
+            }
+        }
+
+        Some(session)
+    }
+
+    /// Create a new PTY session
+    ///
+    /// If `sandbox_pid` is provided, the PTY will be spawned inside the sandbox.
+    pub fn create_session(
+        self: &Arc<Self>,
+        request: &CreatePtyRequest,
+        sandbox_id: Option<String>,
+        sandbox_pid: Option<u32>,
+    ) -> Result<PtyInfo> {
+        let session_id = Uuid::new_v4().to_string();
+        let name = request
+            .name
+            .clone()
+            .unwrap_or_else(|| self.get_next_terminal_name(&request.shell));
+
+        let index = self.sessions.read().len();
+
+        let (session, reader) = PtySession::new(
+            session_id.clone(),
+            name,
+            index,
+            &request.shell,
+            &request.cwd,
+            request.cols,
+            request.rows,
+            request.env.as_ref(),
+            sandbox_id,
+            sandbox_pid,
+            request.metadata.clone(),
+        )?;
+
+        let info = session.to_info();
+        let session = Arc::new(session);
+
+        // Insert session
+        {
+            let mut sessions = self.sessions.write();
+            sessions.insert(session_id.clone(), session.clone());
+        }
+
+        info!(
+            "[pty] Session created: {} (pid: {}, sandbox: {:?})",
+            session_id, info.pid, info.sandbox_id
+        );
+
+        // Spawn reader task
+        let state = Arc::clone(self);
+        tokio::spawn(spawn_pty_reader(session, reader, state));
+
+        // Broadcast event
+        self.broadcast_event(PtyEvent::PtyCreated {
+            terminal: info.clone(),
+            creator_client_id: request.client_id.clone(),
+        });
+
+        Ok(info)
+    }
+
+    /// Delete a PTY session
+    pub fn delete_session(&self, session_id: &str) -> Option<PtyInfo> {
+        let session = {
+            let mut sessions = self.sessions.write();
+            sessions.remove(session_id)
+        }?;
+
+        session.kill();
+        let info = session.to_info();
+
+        // Reindex remaining sessions
+        self.reindex_sessions();
+
+        // Broadcast event
+        self.broadcast_event(PtyEvent::PtyDeleted {
+            pty_id: session_id.to_string(),
+        });
+
+        info!("[pty] Session deleted: {}", session_id);
+        Some(info)
+    }
+
+    /// Reindex sessions to ensure contiguous indices
+    fn reindex_sessions(&self) {
+        let sessions = self.sessions.read();
+        let mut infos: Vec<_> = sessions
+            .values()
+            .filter(|s| s.is_alive())
+            .map(|s| (s.id.clone(), s.get_index()))
+            .collect();
+        infos.sort_by_key(|(_, idx)| *idx);
+
+        for (i, (id, _)) in infos.iter().enumerate() {
+            if let Some(session) = sessions.get(id) {
+                session.set_index(i);
+            }
+        }
+    }
+
+    /// Broadcast an event to all subscribers
+    pub fn broadcast_event(&self, event: PtyEvent) {
+        let _ = self.event_tx.send(event);
+    }
+
+    /// Get full state sync event
+    pub fn get_full_state(&self, sandbox_id: Option<&str>) -> PtyEvent {
+        PtyEvent::StateSync {
+            terminals: self.get_ordered_sessions(sandbox_id),
+        }
+    }
+
+    /// Broadcast state sync to all subscribers
+    pub fn broadcast_state_sync(&self) {
+        self.broadcast_event(self.get_full_state(None));
+    }
+
+    /// Count sessions
+    pub fn session_count(&self) -> usize {
+        self.sessions.read().len()
+    }
+
+    /// Count sessions for a specific sandbox
+    pub fn sandbox_session_count(&self, sandbox_id: &str) -> usize {
+        self.sessions
+            .read()
+            .values()
+            .filter(|s| s.sandbox_id.as_deref() == Some(sandbox_id) && s.is_alive())
+            .count()
+    }
+}
+
+impl Default for PtyState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Spawn a task to read PTY output
+async fn spawn_pty_reader(
+    session: Arc<PtySession>,
+    mut reader: Box<dyn Read + Send>,
+    state: Arc<PtyState>,
+) {
+    let session_id = session.id.clone();
+    let mut buf = [0u8; PTY_READ_BUFFER_SIZE];
+    let mut utf8_buffer: Vec<u8> = Vec::new();
+
+    info!("[reader:{}] Reader task started", session_id);
+
+    let mut total_bytes_read: usize = 0;
+
+    loop {
+        let read_result = tokio::task::spawn_blocking({
+            move || {
+                let result = reader.read(&mut buf);
+                (reader, buf, result)
+            }
+        })
+        .await;
+
+        let (returned_reader, returned_buf, result) = match read_result {
+            Ok(r) => r,
+            Err(e) => {
+                error!("[reader:{}] spawn_blocking panicked: {}", session_id, e);
+                break;
+            }
+        };
+
+        reader = returned_reader;
+        buf = returned_buf;
+
+        match result {
+            Ok(0) => {
+                // EOF - flush remaining buffer
+                if !utf8_buffer.is_empty() {
+                    let data = String::from_utf8_lossy(&utf8_buffer).to_string();
+                    session.append_scrollback(&data);
+                    let _ = session.output_tx.send(data);
+                }
+                info!(
+                    "[reader:{}] EOF received. Total: {} bytes",
+                    session_id, total_bytes_read
+                );
+                break;
+            }
+            Ok(n) => {
+                total_bytes_read += n;
+                utf8_buffer.extend_from_slice(&buf[..n]);
+
+                let valid_up_to = find_utf8_boundary(&utf8_buffer);
+                if valid_up_to > 0 {
+                    let data = String::from_utf8_lossy(&utf8_buffer[..valid_up_to]).to_string();
+                    session.append_scrollback(&data);
+                    let _ = session.output_tx.send(data);
+
+                    // Keep incomplete bytes for next read
+                    utf8_buffer = utf8_buffer[valid_up_to..].to_vec();
+                }
+            }
+            Err(e) => {
+                error!("[reader:{}] Read error: {}", session_id, e);
+                break;
+            }
+        }
+    }
+
+    // Clean up dead session
+    {
+        let mut sessions = state.sessions.write();
+        if let Some(s) = sessions.get(&session_id) {
+            if !s.is_alive() {
+                sessions.remove(&session_id);
+                info!("[reader:{}] Session removed (dead)", session_id);
+            }
+        }
+    }
+
+    state.reindex_sessions();
+    state.broadcast_state_sync();
+}

--- a/packages/sandbox/src/pty/types.rs
+++ b/packages/sandbox/src/pty/types.rs
@@ -1,0 +1,194 @@
+//! PTY types and models
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+/// Request to create a new PTY session
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CreatePtyRequest {
+    /// Shell to use (default: /bin/zsh)
+    #[serde(default = "default_shell")]
+    pub shell: String,
+    /// Working directory (default: /workspace)
+    #[serde(default = "default_cwd")]
+    pub cwd: String,
+    /// Terminal columns (default: 80)
+    #[serde(default = "default_cols")]
+    pub cols: u16,
+    /// Terminal rows (default: 24)
+    #[serde(default = "default_rows")]
+    pub rows: u16,
+    /// Additional environment variables
+    pub env: Option<HashMap<String, String>>,
+    /// Session name (auto-generated if not provided)
+    pub name: Option<String>,
+    /// Client ID for tracking who created the session
+    pub client_id: Option<String>,
+    /// Flexible metadata for client use
+    pub metadata: Option<serde_json::Value>,
+}
+
+fn default_shell() -> String {
+    "/bin/zsh".to_string()
+}
+
+fn default_cwd() -> String {
+    "/workspace".to_string()
+}
+
+fn default_cols() -> u16 {
+    80
+}
+
+fn default_rows() -> u16 {
+    24
+}
+
+impl Default for CreatePtyRequest {
+    fn default() -> Self {
+        Self {
+            shell: default_shell(),
+            cwd: default_cwd(),
+            cols: default_cols(),
+            rows: default_rows(),
+            env: None,
+            name: None,
+            client_id: None,
+            metadata: None,
+        }
+    }
+}
+
+/// Request to update a PTY session
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
+pub struct UpdatePtyRequest {
+    /// New session name
+    pub name: Option<String>,
+    /// New index (for reordering)
+    pub index: Option<usize>,
+    /// Metadata to merge with existing
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// PTY session information
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PtyInfo {
+    /// Unique session ID (UUID)
+    pub id: String,
+    /// Human-readable session name
+    pub name: String,
+    /// Display index (for ordering)
+    pub index: usize,
+    /// Shell command
+    pub shell: String,
+    /// Working directory
+    pub cwd: String,
+    /// Terminal columns
+    pub cols: u16,
+    /// Terminal rows
+    pub rows: u16,
+    /// Creation timestamp (Unix epoch seconds)
+    pub created_at: f64,
+    /// Whether the PTY process is still running
+    pub alive: bool,
+    /// Process ID
+    pub pid: u32,
+    /// Sandbox ID (if running inside a sandbox)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_id: Option<String>,
+    /// Custom metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Events broadcast by the PTY server
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PtyEvent {
+    /// Full state sync (list of all sessions)
+    #[serde(rename = "state_sync")]
+    StateSync { terminals: Vec<PtyInfo> },
+
+    /// A new PTY was created
+    #[serde(rename = "pty_created")]
+    PtyCreated {
+        terminal: PtyInfo,
+        creator_client_id: Option<String>,
+    },
+
+    /// A PTY was updated (name, index, metadata)
+    #[serde(rename = "pty_updated")]
+    PtyUpdated {
+        terminal: PtyInfo,
+        changes: HashMap<String, serde_json::Value>,
+    },
+
+    /// A PTY was deleted
+    #[serde(rename = "pty_deleted")]
+    PtyDeleted { pty_id: String },
+
+    /// Terminal output data
+    #[serde(rename = "output")]
+    Output { data: String },
+
+    /// PTY process exited
+    #[serde(rename = "exit")]
+    Exit { exit_code: Option<i32> },
+
+    /// Error message
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
+/// Messages from WebSocket clients
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum PtyClientMessage {
+    /// Request full state sync
+    #[serde(rename = "get_state")]
+    GetState,
+
+    /// Create a new PTY
+    #[serde(rename = "create_pty")]
+    CreatePty {
+        shell: Option<String>,
+        cwd: Option<String>,
+        cols: Option<u16>,
+        rows: Option<u16>,
+        name: Option<String>,
+        client_id: Option<String>,
+        metadata: Option<serde_json::Value>,
+    },
+
+    /// Rename a PTY
+    #[serde(rename = "rename_pty")]
+    RenamePty { pty_id: String, name: String },
+
+    /// Reorder a PTY
+    #[serde(rename = "reorder_pty")]
+    ReorderPty { pty_id: String, index: usize },
+
+    /// Delete a PTY
+    #[serde(rename = "delete_pty")]
+    DeletePty { pty_id: String },
+}
+
+/// Request to resize a PTY
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ResizePtyRequest {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+/// Request to send input to a PTY
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct InputPtyRequest {
+    pub data: String,
+}
+
+/// PTY capture response
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CapturePtyResponse {
+    pub content: String,
+}

--- a/packages/sandbox/tests/cli_e2e.rs
+++ b/packages/sandbox/tests/cli_e2e.rs
@@ -161,6 +161,10 @@ impl SandboxService for MockService {
         }
         Ok(None)
     }
+
+    async fn get_sandbox_pid(&self, _id: String) -> Option<u32> {
+        Some(12345) // Mock PID for testing
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Integrates PTY session management into sandboxd with full REST API and OpenAPI documentation
- Sessions can be created in host namespace (for development) or inside sandbox namespaces using nsenter
- Adds comprehensive HTTP tests for all PTY endpoints

## Changes

### PTY Module (`src/pty/`)
- `session.rs` - PTY session with nsenter support for spawning shells in sandbox namespaces
- `state.rs` - Session registry with broadcast events
- `types.rs` - Request/response types with OpenAPI `ToSchema` derives
- `api.rs` - REST API handlers with `utoipa::path` annotations

### API Endpoints
| Endpoint | Description |
|----------|-------------|
| `GET /sessions` | List all PTY sessions |
| `POST /sessions` | Create host-namespace session |
| `GET /sessions/{id}` | Get session info |
| `PATCH /sessions/{id}` | Update session (name, index, metadata) |
| `DELETE /sessions/{id}` | Delete session |
| `POST /sessions/{id}/input` | Send input to session |
| `POST /sessions/{id}/resize` | Resize terminal |
| `GET /sessions/{id}/capture` | Capture scrollback buffer |
| `GET /sandboxes/{id}/sessions` | List sessions in sandbox |
| `POST /sandboxes/{id}/sessions` | Create session in sandbox (uses nsenter) |

### CLI Commands
- `cmux pty ls` - List sessions
- `cmux pty new` - Create session
- `cmux pty attach` - Attach to session
- `cmux pty kill` - Kill session(s)
- `cmux pty send-keys` - Send keys to session
- `cmux pty capture-pane` - Capture screen content

## Test plan

- [x] Run `cargo test --lib` - 219 tests pass
- [x] Run `cargo clippy` - no warnings
- [x] Verify OpenAPI spec includes PTY routes at `/openapi.json`
- [x] Run tests in Docker with `--privileged --tmpfs /tmp:exec` for full coverage