### PR TITLE
Add Notification hook to Claude Code environment for Morph sandboxes

### DIFF
--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -199,6 +199,17 @@ exit 0`;
       ? { anthropicApiKey: ctx.apiKeys?.ANTHROPIC_API_KEY }
       : {}),
     hooks: {
+      Notification: [
+        {
+          matcher: ".*",
+          hooks: [
+            {
+              type: "command",
+              command: `jq -r '.message // "Awaiting input"' | xargs -I{} cmux-bridge notify "Claude Code: {}" 2>>/tmp/claude-hook-error.log`,
+            },
+          ],
+        },
+      ],
       Stop: [
         {
           hooks: [


### PR DESCRIPTION
## Summary
- Add missing Notification hook to `getClaudeEnvironment()` for Morph sandbox path
- This hook sends real-time "awaiting input" notifications to the cmux UI via `cmux-bridge notify`
- Previously only the sandboxd (bubblewrap) path had this hook via `agent-config/claude/settings.json`

## Test plan
- [ ] Deploy to staging and run a Claude Code task in cloud mode (Morph)
- [ ] Verify notifications appear in the UI when Claude is awaiting input