### PR TITLE
Add spacing between checks, progress, and diff viewer

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -1075,7 +1075,7 @@ function RunDiffPage() {
               />
             )}
             <div
-              className="flex-1 min-h-0"
+              className="flex-1 min-h-0 mt-4"
               style={{ "--cmux-diff-header-offset": "56px" } as React.CSSProperties}
             >
               <Suspense


### PR DESCRIPTION
image.pngwe should add some spacing beween the checks and the review progress and file diff viewer start tab/. in general we need space between this whether it is preview screenshots or whatever..