### PR TITLE
feat(sandbox): add cmux prune command with orphaned filesystem cleanup

### DIFF
--- a/packages/sandbox/src/api.rs
+++ b/packages/sandbox/src/api.rs
@@ -1,7 +1,8 @@
 use crate::errors::{ErrorBody, SandboxError, SandboxResult};
 use crate::models::{
     CreateSandboxRequest, ExecRequest, ExecResponse, HealthResponse, HostEvent, NotificationLevel,
-    NotificationLogEntry, NotificationRequest, OpenUrlRequest, SandboxSummary,
+    NotificationLogEntry, NotificationRequest, OpenUrlRequest, PruneRequest, PruneResponse,
+    PrunedItem, SandboxSummary,
 };
 use crate::notifications::NotificationStore;
 use crate::service::{AppState, GhResponseRegistry, HostEventSender, SandboxService};
@@ -49,6 +50,7 @@ fn default_tty() -> bool {
         open_url_post,
         list_notifications,
         send_notification,
+        prune_orphaned,
     ),
     components(schemas(
         CreateSandboxRequest,
@@ -62,7 +64,10 @@ fn default_tty() -> bool {
         NotificationRequest,
         NotificationLogEntry,
         NotificationLevel,
-        OpenUrlRequest
+        OpenUrlRequest,
+        PruneRequest,
+        PruneResponse,
+        PrunedItem
     )),
     tags((name = "sandboxes", description = "Manage bubblewrap-based sandboxes"))
 )]
@@ -106,6 +111,8 @@ pub fn build_router(
             "/notifications",
             get(list_notifications).post(send_notification),
         )
+        // Prune orphaned sandbox filesystem directories
+        .route("/prune", post(prune_orphaned))
         .merge(swagger_routes)
         .with_state(state)
 }
@@ -391,6 +398,23 @@ async fn delete_sandbox(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/prune",
+    request_body = PruneRequest,
+    responses(
+        (status = 200, description = "Prune completed", body = PruneResponse),
+        (status = 500, description = "Prune failed", body = ErrorBody)
+    )
+)]
+async fn prune_orphaned(
+    state: axum::extract::State<AppState>,
+    Json(request): Json<PruneRequest>,
+) -> SandboxResult<Json<PruneResponse>> {
+    let response = state.service.prune_orphaned(request).await?;
+    Ok(Json(response))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -465,6 +489,15 @@ mod tests {
 
         async fn delete(&self, _id: String) -> SandboxResult<Option<SandboxSummary>> {
             Ok(Some(fake_summary("mock-delete".into())))
+        }
+
+        async fn prune_orphaned(&self, request: PruneRequest) -> SandboxResult<PruneResponse> {
+            Ok(PruneResponse {
+                deleted_count: 0,
+                failed_count: 0,
+                items: vec![],
+                dry_run: request.dry_run,
+            })
         }
     }
 

--- a/packages/sandbox/src/bin/cli.rs
+++ b/packages/sandbox/src/bin/cli.rs
@@ -1661,7 +1661,16 @@ async fn prune_docker(args: &PruneArgs) -> anyhow::Result<()> {
         None
     } else {
         let duration = args.until.unwrap_or(Duration::from_secs(24 * 3600));
-        Some(format!("{}h", duration.as_secs() / 3600))
+        let secs = duration.as_secs();
+        // Use minutes for sub-hour durations to avoid truncation to 0h
+        // Docker supports both "Xh" and "Xm" formats
+        if secs < 3600 {
+            // Use minutes, with minimum of 1 minute
+            let mins = (secs / 60).max(1);
+            Some(format!("{mins}m"))
+        } else {
+            Some(format!("{}h", secs / 3600))
+        }
     };
 
     // Prune containers

--- a/packages/sandbox/src/bin/cli.rs
+++ b/packages/sandbox/src/bin/cli.rs
@@ -162,6 +162,9 @@ enum Command {
 
     /// Open sandbox in Zed via SSH Remote
     Zed(IdeArgs),
+
+    /// Remove old sandboxes and optionally prune Docker resources
+    Prune(PruneArgs),
 }
 
 #[derive(Args, Debug)]
@@ -174,6 +177,29 @@ struct IdeArgs {
     /// Path to open in the IDE (defaults to /workspace for local, /root/workspace for cloud)
     #[arg(long, short = 'p')]
     path: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct PruneArgs {
+    /// Only prune sandboxes older than this duration (e.g., "24h", "7d", "1w")
+    #[arg(long, value_parser = parse_duration)]
+    until: Option<Duration>,
+
+    /// Skip confirmation prompt
+    #[arg(long, short = 'f')]
+    force: bool,
+
+    /// Show what would be deleted without actually deleting
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Also prune Docker resources (containers, images, volumes) older than the specified duration
+    #[arg(long)]
+    docker: bool,
+
+    /// Prune all sandboxes (ignore --until filter)
+    #[arg(long, short = 'a')]
+    all: bool,
 }
 
 #[derive(Args, Debug)]
@@ -480,6 +506,48 @@ fn parse_env(raw: &str) -> Result<EnvVar, String> {
         key: parts[0].to_string(),
         value: parts[1].to_string(),
     })
+}
+
+/// Parse a duration string like "24h", "7d", "1w" into a Duration
+fn parse_duration(raw: &str) -> Result<Duration, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("duration cannot be empty".to_string());
+    }
+
+    // Find where the number ends and the unit begins
+    let num_end = raw
+        .chars()
+        .position(|c| !c.is_ascii_digit())
+        .unwrap_or(raw.len());
+
+    if num_end == 0 {
+        return Err("duration must start with a number (e.g., \"24h\", \"7d\")".to_string());
+    }
+
+    let num: u64 = raw[..num_end]
+        .parse()
+        .map_err(|_| "invalid number in duration".to_string())?;
+
+    let unit = &raw[num_end..];
+    let seconds = match unit {
+        "s" | "sec" | "secs" | "second" | "seconds" => num,
+        "m" | "min" | "mins" | "minute" | "minutes" => num * 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => num * 3600,
+        "d" | "day" | "days" => num * 86400,
+        "w" | "wk" | "wks" | "week" | "weeks" => num * 604800,
+        "" => {
+            // Default to hours if no unit specified
+            num * 3600
+        }
+        _ => {
+            return Err(format!(
+                "unknown duration unit: \"{unit}\". Use s, m, h, d, or w"
+            ))
+        }
+    };
+
+    Ok(Duration::from_secs(seconds))
 }
 
 fn get_config_dir() -> PathBuf {
@@ -1048,6 +1116,9 @@ async fn run() -> anyhow::Result<()> {
             let api_url = get_cmux_api_url();
             handle_ide(&client, &cli.base_url, &api_url, "zed", &args).await?;
         }
+        Command::Prune(args) => {
+            handle_prune(&client, &cli.base_url, args).await?;
+        }
         Command::Sandboxes(cmd) => {
             match cmd {
                 SandboxCommand::List => {
@@ -1324,6 +1395,284 @@ where
     }
 
     Ok(response.json::<T>().await?)
+}
+
+/// Handle the prune command - delete old sandboxes and optionally Docker resources
+async fn handle_prune(client: &Client, base_url: &str, args: PruneArgs) -> anyhow::Result<()> {
+    use chrono::Utc;
+
+    // Fetch all sandboxes
+    let url = format!("{}/sandboxes", base_url.trim_end_matches('/'));
+    let response = client.get(&url).send().await?;
+    let sandboxes: Vec<SandboxSummary> = parse_response(response).await?;
+
+    if sandboxes.is_empty() {
+        eprintln!("No sandboxes found.");
+        if args.docker {
+            prune_docker(&args).await?;
+        }
+        return Ok(());
+    }
+
+    // Filter sandboxes by age
+    let now = Utc::now();
+    let cutoff_duration = if args.all {
+        None
+    } else {
+        Some(args.until.unwrap_or(Duration::from_secs(24 * 3600))) // Default: 24h
+    };
+
+    let mut to_prune: Vec<&SandboxSummary> = sandboxes
+        .iter()
+        .filter(|s| {
+            if let Some(duration) = cutoff_duration {
+                let age = now.signed_duration_since(s.created_at);
+                age.num_seconds() > duration.as_secs() as i64
+            } else {
+                true // --all: prune everything
+            }
+        })
+        .collect();
+
+    // Sort by age (oldest first)
+    to_prune.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+
+    if to_prune.is_empty() {
+        let filter_desc = if args.all {
+            "all".to_string()
+        } else {
+            format!(
+                "older than {}",
+                format_duration(cutoff_duration.unwrap_or_default())
+            )
+        };
+        eprintln!("No sandboxes match the filter ({filter_desc}).");
+        if args.docker {
+            prune_docker(&args).await?;
+        }
+        return Ok(());
+    }
+
+    // Display what will be pruned
+    eprintln!(
+        "Found {} sandbox{} to prune:\n",
+        to_prune.len(),
+        if to_prune.len() == 1 { "" } else { "es" }
+    );
+
+    for sandbox in &to_prune {
+        let age = now.signed_duration_since(sandbox.created_at);
+        let age_str = format_chrono_duration(age);
+        eprintln!("  {} {} ({})", sandbox.id, sandbox.name, age_str);
+    }
+    eprintln!();
+
+    if args.dry_run {
+        eprintln!("(dry run - no sandboxes deleted)");
+        if args.docker {
+            prune_docker(&args).await?;
+        }
+        return Ok(());
+    }
+
+    // Confirm unless --force
+    if !args.force {
+        eprint!(
+            "Delete {} sandbox{}? [y/N] ",
+            to_prune.len(),
+            if to_prune.len() == 1 { "" } else { "es" }
+        );
+        std::io::Write::flush(&mut std::io::stderr())?;
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        if input != "y" && input != "yes" {
+            eprintln!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Delete sandboxes
+    let mut deleted = 0;
+    let mut failed = 0;
+
+    for sandbox in &to_prune {
+        let delete_url = format!(
+            "{}/sandboxes/{}",
+            base_url.trim_end_matches('/'),
+            sandbox.id
+        );
+        match client.delete(&delete_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                eprintln!("  \x1b[32m✓\x1b[0m Deleted {}", sandbox.id);
+                deleted += 1;
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                eprintln!(
+                    "  \x1b[31m✗\x1b[0m Failed to delete {}: {} {}",
+                    sandbox.id, status, body
+                );
+                failed += 1;
+            }
+            Err(e) => {
+                eprintln!("  \x1b[31m✗\x1b[0m Failed to delete {}: {}", sandbox.id, e);
+                failed += 1;
+            }
+        }
+    }
+
+    eprintln!();
+    eprintln!(
+        "Pruned {} sandbox{}, {} failed.",
+        deleted,
+        if deleted == 1 { "" } else { "es" },
+        failed
+    );
+
+    if args.docker {
+        prune_docker(&args).await?;
+    }
+
+    Ok(())
+}
+
+/// Prune Docker resources
+async fn prune_docker(args: &PruneArgs) -> anyhow::Result<()> {
+    eprintln!("\nPruning Docker resources...");
+
+    let filter = if args.all {
+        None
+    } else {
+        let duration = args.until.unwrap_or(Duration::from_secs(24 * 3600));
+        Some(format!("{}h", duration.as_secs() / 3600))
+    };
+
+    // Prune containers
+    let mut cmd = ProcessCommand::new("docker");
+    cmd.arg("container").arg("prune").arg("-f");
+    if let Some(ref f) = filter {
+        cmd.arg("--filter").arg(format!("until={f}"));
+    }
+
+    if args.dry_run {
+        eprintln!(
+            "  (dry run) would run: docker container prune -f{}",
+            filter
+                .as_ref()
+                .map(|f| format!(" --filter until={f}"))
+                .unwrap_or_default()
+        );
+    } else {
+        match cmd.output() {
+            Ok(output) => {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    if !stdout.trim().is_empty() {
+                        eprintln!(
+                            "  \x1b[32m✓\x1b[0m Containers: {}",
+                            stdout.trim().replace('\n', ", ")
+                        );
+                    }
+                }
+            }
+            Err(e) => eprintln!("  \x1b[33m!\x1b[0m Failed to prune containers: {e}"),
+        }
+    }
+
+    // Prune images
+    let mut cmd = ProcessCommand::new("docker");
+    cmd.arg("image").arg("prune").arg("-f");
+    if let Some(ref f) = filter {
+        cmd.arg("--filter").arg(format!("until={f}"));
+    }
+
+    if args.dry_run {
+        eprintln!(
+            "  (dry run) would run: docker image prune -f{}",
+            filter
+                .as_ref()
+                .map(|f| format!(" --filter until={f}"))
+                .unwrap_or_default()
+        );
+    } else {
+        match cmd.output() {
+            Ok(output) => {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    if !stdout.trim().is_empty() {
+                        eprintln!(
+                            "  \x1b[32m✓\x1b[0m Images: {}",
+                            stdout.trim().replace('\n', ", ")
+                        );
+                    }
+                }
+            }
+            Err(e) => eprintln!("  \x1b[33m!\x1b[0m Failed to prune images: {e}"),
+        }
+    }
+
+    // Prune volumes (no until filter support)
+    if args.all {
+        let mut cmd = ProcessCommand::new("docker");
+        cmd.arg("volume").arg("prune").arg("-f");
+
+        if args.dry_run {
+            eprintln!("  (dry run) would run: docker volume prune -f");
+        } else {
+            match cmd.output() {
+                Ok(output) => {
+                    if output.status.success() {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        if !stdout.trim().is_empty() {
+                            eprintln!(
+                                "  \x1b[32m✓\x1b[0m Volumes: {}",
+                                stdout.trim().replace('\n', ", ")
+                            );
+                        }
+                    }
+                }
+                Err(e) => eprintln!("  \x1b[33m!\x1b[0m Failed to prune volumes: {e}"),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Format a Duration as a human-readable string
+fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h", secs / 3600)
+    } else if secs < 604800 {
+        format!("{}d", secs / 86400)
+    } else {
+        format!("{}w", secs / 604800)
+    }
+}
+
+/// Format a chrono Duration as a human-readable string
+fn format_chrono_duration(d: chrono::Duration) -> String {
+    let secs = d.num_seconds();
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else if secs < 604800 {
+        format!("{}d ago", secs / 86400)
+    } else {
+        format!("{}w ago", secs / 604800)
+    }
 }
 
 struct ChunkedWriter {

--- a/packages/sandbox/src/bin/cli.rs
+++ b/packages/sandbox/src/bin/cli.rs
@@ -1408,6 +1408,8 @@ async fn handle_prune(client: &Client, base_url: &str, args: PruneArgs) -> anyho
 
     if sandboxes.is_empty() {
         eprintln!("No sandboxes found.");
+        // Still check for orphaned filesystem directories
+        prune_orphaned_fs(client, base_url, &args).await?;
         if args.docker {
             prune_docker(&args).await?;
         }
@@ -1447,6 +1449,8 @@ async fn handle_prune(client: &Client, base_url: &str, args: PruneArgs) -> anyho
             )
         };
         eprintln!("No sandboxes match the filter ({filter_desc}).");
+        // Still check for orphaned filesystem directories
+        prune_orphaned_fs(client, base_url, &args).await?;
         if args.docker {
             prune_docker(&args).await?;
         }

--- a/packages/sandbox/src/bin/server.rs
+++ b/packages/sandbox/src/bin/server.rs
@@ -661,4 +661,11 @@ impl SandboxService for UnavailableSandboxService {
     async fn delete(&self, _id: String) -> SandboxResult<Option<SandboxSummary>> {
         Err(self.error("delete sandbox"))
     }
+
+    async fn prune_orphaned(
+        &self,
+        _request: cmux_sandbox::models::PruneRequest,
+    ) -> SandboxResult<cmux_sandbox::models::PruneResponse> {
+        Err(self.error("prune orphaned"))
+    }
 }

--- a/packages/sandbox/src/models.rs
+++ b/packages/sandbox/src/models.rs
@@ -168,6 +168,45 @@ pub struct GhResponse {
     pub stderr: String,
 }
 
+/// Request to prune orphaned sandbox filesystem directories.
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct PruneRequest {
+    /// Only prune directories older than this many seconds.
+    /// If not specified, defaults to 86400 (24 hours).
+    #[serde(default)]
+    pub max_age_secs: Option<u64>,
+    /// If true, prune all orphaned directories regardless of age.
+    #[serde(default)]
+    pub all: bool,
+    /// If true, only report what would be deleted without actually deleting.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+/// Information about a pruned orphaned directory.
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct PrunedItem {
+    /// The UUID of the orphaned sandbox directory.
+    pub id: String,
+    /// Path to the directory that was (or would be) deleted.
+    pub path: String,
+    /// Age of the directory in seconds.
+    pub age_secs: u64,
+}
+
+/// Response from pruning orphaned sandbox directories.
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct PruneResponse {
+    /// Number of orphaned directories that were deleted (or would be in dry_run mode).
+    pub deleted_count: usize,
+    /// Number of directories that failed to delete.
+    pub failed_count: usize,
+    /// Details about each pruned item.
+    pub items: Vec<PrunedItem>,
+    /// Whether this was a dry run.
+    pub dry_run: bool,
+}
+
 // ============================================================================
 // Unified Bridge Socket Protocol
 // ============================================================================

--- a/packages/sandbox/src/service.rs
+++ b/packages/sandbox/src/service.rs
@@ -1,6 +1,7 @@
 use crate::errors::SandboxResult;
 use crate::models::{
-    CreateSandboxRequest, ExecRequest, ExecResponse, GhResponse, HostEvent, SandboxSummary,
+    CreateSandboxRequest, ExecRequest, ExecResponse, GhResponse, HostEvent, PruneRequest,
+    PruneResponse, SandboxSummary,
 };
 use crate::notifications::NotificationStore;
 use async_trait::async_trait;
@@ -55,6 +56,8 @@ pub trait SandboxService: Send + Sync + 'static {
     async fn proxy(&self, id: String, port: u16, socket: WebSocket) -> SandboxResult<()>;
     async fn upload_archive(&self, id: String, archive: Body) -> SandboxResult<()>;
     async fn delete(&self, id: String) -> SandboxResult<Option<SandboxSummary>>;
+    /// Prune orphaned sandbox filesystem directories that don't correspond to running sandboxes.
+    async fn prune_orphaned(&self, request: PruneRequest) -> SandboxResult<PruneResponse>;
 }
 
 #[derive(Clone)]

--- a/packages/sandbox/tests/cli_e2e.rs
+++ b/packages/sandbox/tests/cli_e2e.rs
@@ -161,6 +161,19 @@ impl SandboxService for MockService {
         }
         Ok(None)
     }
+
+    async fn prune_orphaned(
+        &self,
+        request: cmux_sandbox::models::PruneRequest,
+    ) -> cmux_sandbox::errors::SandboxResult<cmux_sandbox::models::PruneResponse> {
+        self.record("prune_orphaned").await;
+        Ok(cmux_sandbox::models::PruneResponse {
+            deleted_count: 0,
+            failed_count: 0,
+            items: vec![],
+            dry_run: request.dry_run,
+        })
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `cmux prune` command to clean up old sandboxes and orphaned filesystem directories
- Implements server-side `/prune` endpoint to scan workspace_root for orphaned UUID directories
- CLI calls the prune endpoint after deleting old sandboxes to clean up stale filesystem data

## Changes
- Add `PruneRequest`/`PruneResponse`/`PrunedItem` models
- Add `prune_orphaned` method to `SandboxService` trait
- Implement orphaned directory scanning in `BubblewrapService`
- Add `POST /prune` endpoint to the API
- Update CLI prune command to call server endpoint

## Test plan
- [x] Run `cargo clippy` - passes
- [x] Run `cargo test` - all tests pass
- [x] Run `cargo fmt` - formatted
- [ ] Test `cmux prune --dry-run` shows orphaned directories
- [ ] Test `cmux prune -a` cleans up all orphaned directories

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated cleanup for stale sandboxes and filesystems.
> 
> - Adds `cmux prune` CLI subcommand with `--until`, `--all`, `--dry-run`, `--force`, and optional Docker pruning; lists/deletes old sandboxes and then calls server cleanup
> - New server `POST /prune` endpoint with `PruneRequest`/`PruneResponse`/`PrunedItem` models; documented in OpenAPI and wired into the router
> - Extends `SandboxService` with `prune_orphaned` and implements in Bubblewrap to scan `workspace_root` for UUID dirs, skip symlinks, handle dry-run, and safely remove overlays
> - Updates mocks/tests and server stubs to support the new pruning flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2e2d91ef470086fb9ea91d12939f9c58fde9faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->