### PR TITLE
fix(cmux-pty): handle terminal size read timeout gracefully

### DIFF
--- a/crates/cmux-pty/src/cli.rs
+++ b/crates/cmux-pty/src/cli.rs
@@ -257,8 +257,8 @@ impl PtyClient {
         let mut stdout = std::io::stdout();
         stdout.execute(EnterAlternateScreen)?;
 
-        // Get terminal size and send resize
-        let (cols, rows) = terminal::size()?;
+        // Get terminal size and send resize (use fallback if terminal size can't be read)
+        let (cols, rows) = terminal::size().unwrap_or((80, 24));
         let resize_msg = serde_json::json!({
             "type": "resize",
             "cols": cols,


### PR DESCRIPTION
## Summary
- Fix "The cursor position could not be read within a normal duration" error when attaching to PTY sessions
- Use fallback dimensions (80x24) when `terminal::size()` fails

## Problem
The `crossterm` crate's `terminal::size()` function can fail with a timeout error when:
- stdout is piped/redirected
- Running inside certain terminal emulators (like Warp)
- Running without a proper TTY

This caused the `attach` command to fail completely.

## Solution
Changed error propagation (`?`) to use fallback with `unwrap_or((80, 24))`, matching the existing pattern used in `cmd_new`.

## Test plan
- [ ] Run `cmux-pty attach <session>` in a terminal
- [ ] Run with piped stdout to verify it doesn't crash