### PR TITLE
chore: update morph snapshots to v42

### DIFF
--- a/configs/ide-deps.json
+++ b/configs/ide-deps.json
@@ -31,8 +31,8 @@
     "@anthropic-ai/claude-code": "2.0.76",
     "@google/gemini-cli": "0.22.2",
     "opencode-ai": "1.0.193",
-    "codebuff": "1.0.559",
+    "codebuff": "1.0.561",
     "@devcontainers/cli": "0.80.3",
-    "@sourcegraph/amp": "0.0.1766534507-g06e602"
+    "@sourcegraph/amp": "0.0.1766549470-g10018e"
   }
 }

--- a/packages/shared/src/morph-snapshots.json
+++ b/packages/shared/src/morph-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2025-12-24T02:38:05Z",
+  "updatedAt": "2025-12-24T04:35:32Z",
   "presets": [
     {
       "presetId": "4vcpu_16gb_48gb",
@@ -213,6 +213,11 @@
           "version": 41,
           "snapshotId": "snapshot_urlxhopc",
           "capturedAt": "2025-12-24T02:38:55Z"
+        },
+        {
+          "version": 42,
+          "snapshotId": "snapshot_ztk8hh65",
+          "capturedAt": "2025-12-24T04:35:30Z"
         }
       ],
       "description": "Great default for day-to-day work. Balanced CPU, memory, and storage."
@@ -428,6 +433,11 @@
           "version": 41,
           "snapshotId": "snapshot_mtl73ecs",
           "capturedAt": "2025-12-24T02:38:05Z"
+        },
+        {
+          "version": 42,
+          "snapshotId": "snapshot_3yms1udr",
+          "capturedAt": "2025-12-24T04:35:32Z"
         }
       ],
       "description": "Extra headroom for larger codebases or heavier workloads."


### PR DESCRIPTION
## Summary
- **Fix cursor position timeout error**: Auto-respond to CSI 6n (cursor position queries) immediately with ESC[1;1R
- Update Morph snapshots to version 42
- Bumped IDE deps: codebuff 1.0.561, @sourcegraph/amp 0.0.1766549470-g10018e

## The Problem
Apps like Codex CLI use crossterm which sends `ESC[6n` to query cursor position. When no terminal emulator responds in time (due to no client connected or WebSocket latency), crossterm times out with:
```
Error: The cursor position could not be read within a normal duration
```

## The Fix
Detect CSI 6n in PTY output and immediately respond with `ESC[1;1R` (row 1, col 1). This matches behavior of terminal multiplexers like tmux/screen. A double response (ours + real terminal) is harmless.

## New Snapshot IDs
| Preset | Snapshot ID |
|--------|-------------|
| 4vcpu_16gb_48gb | `snapshot_ztk8hh65` |
| 8vcpu_32gb_48gb | `snapshot_3yms1udr` |

## Test plan
- [ ] Run Codex CLI in a cmux sandbox without web client attached
- [ ] Verify no cursor position timeout errors