### PR TITLE
Remove PR entry from taskruns in web mode

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/client-env";
 import { Dropdown } from "@/components/ui/dropdown";
 import {
   Tooltip,
@@ -1546,10 +1547,12 @@ function TaskRunTreeInner({
     });
   }, [refreshGitHubAuth, run._id, teamSlugOrId]);
 
-  const shouldRenderPullRequestLink = Boolean(
-    (run.pullRequestUrl && run.pullRequestUrl !== "pending") ||
-      run.pullRequests?.some((pr) => pr.url)
-  );
+  const shouldRenderPullRequestLink =
+    !env.NEXT_PUBLIC_WEB_MODE &&
+    Boolean(
+      (run.pullRequestUrl && run.pullRequestUrl !== "pending") ||
+        run.pullRequests?.some((pr) => pr.url)
+    );
   const hasOpenWithActions = openWithActions.length > 0;
   const hasPortActions = portActions.length > 0;
   const canCopyBranch = Boolean(copyRunBranch);


### PR DESCRIPTION
undo this pr: https://github.com/manaflow-ai/cmux/pull/1392what we really want to do is remove the pull request entry in sidebar taskruns iff we're in web mode.