### PR TITLE
Revert PR 1392: remove taskruns entry in web

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -285,20 +285,18 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
             ))}
           </ul>
 
-          {isElectron && (
-            <div className="mt-4 flex flex-col">
-              <SidebarSectionLink
-                to="/$teamSlugOrId/prs"
-                params={{ teamSlugOrId }}
-                exact
-              >
-                Pull requests
-              </SidebarSectionLink>
-              <div className="ml-2 pt-px">
-                <SidebarPullRequestList teamSlugOrId={teamSlugOrId} />
-              </div>
+          <div className="mt-4 flex flex-col">
+            <SidebarSectionLink
+              to="/$teamSlugOrId/prs"
+              params={{ teamSlugOrId }}
+              exact
+            >
+              Pull requests
+            </SidebarSectionLink>
+            <div className="ml-2 pt-px">
+              <SidebarPullRequestList teamSlugOrId={teamSlugOrId} />
             </div>
-          )}
+          </div>
 
           <div className="mt-2 flex flex-col gap-0.5">
             <SidebarWorkspacesSection teamSlugOrId={teamSlugOrId} />

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -2155,7 +2155,7 @@ function TaskRunDetails({
         />
       ) : null}
 
-      {shouldRenderPullRequestLink ? (
+      {shouldRenderPullRequestLink && isElectron ? (
         <TaskRunDetailLink
           to="/$teamSlugOrId/task/$taskId/run/$runId/pr"
           params={{ teamSlugOrId, taskId, runId: run._id }}


### PR DESCRIPTION
undo this pr: https://github.com/manaflow-ai/cmux/pull/1392 what we really want to do is remove the pull request entry in sidebar taskruns iff we're in web mode.dont forget to revert it!