### PR TITLE
feat: add cron to stop old Morph instances after 2 weeks

### DIFF
--- a/apps/client/src/components/resume-workspace-overlay.tsx
+++ b/apps/client/src/components/resume-workspace-overlay.tsx
@@ -29,8 +29,7 @@ export function ResumeWorkspaceOverlay({
   });
 
   const isPaused = pauseStatusQuery.data?.paused === true;
-  // Type assertion needed until openapi client is regenerated
-  const isStopped = (pauseStatusQuery.data as { stopped?: boolean } | undefined)?.stopped === true;
+  const isStopped = pauseStatusQuery.data?.stopped === true;
 
   const resumeWorkspace = useResumeMorphWorkspace({
     taskRunId,

--- a/apps/client/src/components/resume-workspace-overlay.tsx
+++ b/apps/client/src/components/resume-workspace-overlay.tsx
@@ -6,6 +6,7 @@ import {
   useMorphInstancePauseQuery,
   useResumeMorphWorkspace,
 } from "@/hooks/useMorphWorkspace";
+import { AlertTriangle } from "lucide-react";
 
 interface ResumeWorkspaceOverlayProps {
   taskRun: Doc<"taskRuns">;
@@ -28,6 +29,8 @@ export function ResumeWorkspaceOverlay({
   });
 
   const isPaused = pauseStatusQuery.data?.paused === true;
+  // Type assertion needed until openapi client is regenerated
+  const isStopped = (pauseStatusQuery.data as { stopped?: boolean } | undefined)?.stopped === true;
 
   const resumeWorkspace = useResumeMorphWorkspace({
     taskRunId,
@@ -36,7 +39,7 @@ export function ResumeWorkspaceOverlay({
   });
 
   const handleResume = useCallback(async () => {
-    if (!taskRun || !isPaused) {
+    if (!taskRun || !isPaused || isStopped) {
       return;
     }
 
@@ -44,10 +47,39 @@ export function ResumeWorkspaceOverlay({
       path: { taskRunId },
       body: { teamSlugOrId },
     });
-  }, [resumeWorkspace, isPaused, taskRun, taskRunId, teamSlugOrId]);
+  }, [resumeWorkspace, isPaused, isStopped, taskRun, taskRunId, teamSlugOrId]);
 
   if (!isPaused) {
     return null;
+  }
+
+  // Show different UI for permanently stopped instances
+  if (isStopped) {
+    return (
+      <div
+        className={clsx(
+          "absolute inset-0 flex items-center justify-center bg-neutral-50/90 backdrop-blur-sm dark:bg-black/80",
+          className
+        )}
+      >
+        <div className="rounded-lg border border-neutral-200/80 bg-white/90 p-4 text-center shadow-sm dark:border-neutral-800 dark:bg-neutral-900/80 max-w-sm">
+          <div className="flex justify-center mb-2">
+            <AlertTriangle className="h-8 w-8 text-amber-500" />
+          </div>
+          <p className="text-sm font-medium text-neutral-900 dark:text-neutral-50">
+            Workspace expired
+          </p>
+          <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+            This workspace was automatically cleaned up after being inactive for
+            2 weeks. Your code changes are preserved in any commits or pull
+            requests you created.
+          </p>
+          <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-500">
+            To continue working, create a new task with the same repository.
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/apps/www/lib/routes/morph.route.ts
+++ b/apps/www/lib/routes/morph.route.ts
@@ -164,6 +164,11 @@ morphRouter.openapi(
 
       await instance.resume();
 
+      // Record the resume for activity tracking (used by cleanup cron)
+      await convex.mutation(api.morphInstances.recordResume, {
+        instanceId,
+      });
+
       await convex.mutation(api.taskRuns.updateVSCodeStatus, {
         teamSlugOrId,
         id: taskRunId as Id<"taskRuns">,

--- a/apps/www/lib/routes/morph.route.ts
+++ b/apps/www/lib/routes/morph.route.ts
@@ -167,6 +167,7 @@ morphRouter.openapi(
       // Record the resume for activity tracking (used by cleanup cron)
       await convex.mutation(api.morphInstances.recordResume, {
         instanceId,
+        teamSlugOrId,
       });
 
       await convex.mutation(api.taskRuns.updateVSCodeStatus, {

--- a/apps/www/lib/routes/morph.route.ts
+++ b/apps/www/lib/routes/morph.route.ts
@@ -73,6 +73,8 @@ const ResumeTaskRunResponse = z
 const CheckTaskRunPausedResponse = z
   .object({
     paused: z.boolean(),
+    stopped: z.boolean().optional(), // True if instance was permanently stopped by cleanup cron
+    stoppedAt: z.number().optional(), // When the instance was stopped
   })
   .openapi("CheckTaskRunPausedResponse");
 
@@ -241,7 +243,22 @@ morphRouter.openapi(
 
     try {
       const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
-      const instance = await client.instances.get({ instanceId });
+
+      let instance: Instance;
+      try {
+        instance = await client.instances.get({ instanceId });
+      } catch (instanceError) {
+        // If instance not found, it was likely stopped/deleted
+        const errorMessage = instanceError instanceof Error ? instanceError.message : String(instanceError);
+        if (errorMessage.includes("404") || errorMessage.includes("not found")) {
+          return c.json({
+            paused: true,
+            stopped: true,
+            stoppedAt: undefined, // We don't know exactly when it was stopped
+          });
+        }
+        throw instanceError;
+      }
 
       const metadataTeamId = (
         instance as unknown as {
@@ -253,7 +270,7 @@ morphRouter.openapi(
         return c.text("Forbidden", 403);
       }
 
-      return c.json({ paused: instance.status === "paused" });
+      return c.json({ paused: instance.status === "paused", stopped: false });
     } catch (error) {
       console.error(
         "[morph.check-task-run-paused] Failed to check instance status",

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -1355,6 +1355,23 @@ sandboxesRouter.openapi(
       }
 
       await instance.resume();
+
+      // Record the resume for activity tracking (used by cleanup cron)
+      // Get teamSlugOrId from request or fall back to instance metadata
+      const instanceMetadata = instance.metadata as Record<string, unknown> | undefined;
+      const effectiveTeamSlugOrId = teamSlugOrId ?? (instanceMetadata?.teamId as string | undefined);
+      if (effectiveTeamSlugOrId && morphInstanceId) {
+        try {
+          await convex.mutation(api.morphInstances.recordResume, {
+            instanceId: morphInstanceId,
+            teamSlugOrId: effectiveTeamSlugOrId,
+          });
+        } catch (recordError) {
+          // Don't fail the resume if recording fails
+          console.error("[sandboxes.resume] Failed to record resume activity:", recordError);
+        }
+      }
+
       return c.json({ resumed: true });
     } catch (error) {
       if (error instanceof HTTPException) {

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
-        "@next/eslint-plugin-next": "^16.0.0",
+        "@next/eslint-plugin-next": "^16.1.1",
         "@t3-oss/env-core": "^0.13.8",
         "@types/node-forge": "^1.3.14",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
@@ -39,7 +39,7 @@
     },
     "apps/client": {
       "name": "@cmux/client",
-      "version": "1.0.206",
+      "version": "1.0.209",
       "dependencies": {
         "@base-ui-components/react": "1.0.0-beta.2",
         "@cmux/convex": "workspace:*",

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -41,6 +41,7 @@ import type * as http from "../http.js";
 import type * as localWorkspaces from "../localWorkspaces.js";
 import type * as migrations from "../migrations.js";
 import type * as morphInstanceMaintenance from "../morphInstanceMaintenance.js";
+import type * as morphInstances from "../morphInstances.js";
 import type * as notifications_http from "../notifications_http.js";
 import type * as previewConfigs from "../previewConfigs.js";
 import type * as previewRuns from "../previewRuns.js";
@@ -109,6 +110,7 @@ declare const fullApi: ApiFromModules<{
   localWorkspaces: typeof localWorkspaces;
   migrations: typeof migrations;
   morphInstanceMaintenance: typeof morphInstanceMaintenance;
+  morphInstances: typeof morphInstances;
   notifications_http: typeof notifications_http;
   previewConfigs: typeof previewConfigs;
   previewRuns: typeof previewRuns;

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -15,7 +15,7 @@ crons.daily(
 );
 
 // Stop (delete) Morph instances that have been paused for more than 2 weeks
-// Runs daily at 5 AM Pacific Time (13:00 UTC)
+// Runs daily at 13:00 UTC (~5-6 AM Pacific depending on DST)
 crons.daily(
   "stop old morph instances",
   { hourUTC: 13, minuteUTC: 0 },

--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -14,4 +14,12 @@ crons.daily(
   internal.morphInstanceMaintenance.pauseOldMorphInstances
 );
 
+// Stop (delete) Morph instances that have been paused for more than 2 weeks
+// Runs daily at 5 AM Pacific Time (13:00 UTC)
+crons.daily(
+  "stop old morph instances",
+  { hourUTC: 13, minuteUTC: 0 },
+  internal.morphInstanceMaintenance.stopOldMorphInstances
+);
+
 export default crons;

--- a/packages/convex/convex/morphInstanceMaintenance.ts
+++ b/packages/convex/convex/morphInstanceMaintenance.ts
@@ -60,8 +60,9 @@ export const pauseOldMorphInstances = internalAction({
     const thresholdMs = PAUSE_HOURS_THRESHOLD * MILLISECONDS_PER_HOUR;
 
     // Filter for cmux ready instances older than the threshold
+    // Note: app can be "cmux", "cmux-dev", "cmux-preview", "cmux-automated-code-review", etc.
     const staleActiveInstances = instances
-      .filter((instance) => instance.metadata?.app === "cmux-dev")
+      .filter((instance) => instance.metadata?.app?.startsWith("cmux"))
       .filter((instance) => instance.status === "ready")
       .filter((instance) => {
         const createdMs = instance.created * 1000;
@@ -189,8 +190,9 @@ export const stopOldMorphInstances = internalAction({
     const thresholdMs = STOP_DAYS_THRESHOLD * 24 * MILLISECONDS_PER_HOUR;
 
     // Filter for cmux paused instances only (we don't stop running instances or non-cmux instances)
+    // Note: app can be "cmux", "cmux-dev", "cmux-preview", "cmux-automated-code-review", etc.
     const pausedInstances = instances
-      .filter((instance) => instance.metadata?.app === "cmux-dev")
+      .filter((instance) => instance.metadata?.app?.startsWith("cmux"))
       .filter((instance) => instance.status === "paused");
 
     if (pausedInstances.length === 0) {

--- a/packages/convex/convex/morphInstanceMaintenance.ts
+++ b/packages/convex/convex/morphInstanceMaintenance.ts
@@ -1,15 +1,18 @@
 "use node";
 
-import { internalAction } from "./_generated/server";
+import { internalAction, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { env } from "../_shared/convex-env";
 import {
   createMorphCloudClient,
   listInstancesInstanceGet,
   pauseInstanceInstanceInstanceIdPausePost,
+  stopInstanceInstanceInstanceIdDelete,
   type InstanceModel,
 } from "@cmux/morphcloud-openapi-client";
+import { v } from "convex/values";
 
-const HOURS_THRESHOLD = 20;
+const PAUSE_HOURS_THRESHOLD = 20;
 const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
 const BATCH_SIZE = 5;
 
@@ -56,7 +59,7 @@ export const pauseOldMorphInstances = internalAction({
     }
 
     const now = Date.now();
-    const thresholdMs = HOURS_THRESHOLD * MILLISECONDS_PER_HOUR;
+    const thresholdMs = PAUSE_HOURS_THRESHOLD * MILLISECONDS_PER_HOUR;
 
     // Filter for ready instances older than the threshold
     const staleActiveInstances = instances
@@ -69,13 +72,13 @@ export const pauseOldMorphInstances = internalAction({
 
     if (staleActiveInstances.length === 0) {
       console.log(
-        `[morphInstanceMaintenance] No active instances older than ${HOURS_THRESHOLD} hours`
+        `[morphInstanceMaintenance] No active instances older than ${PAUSE_HOURS_THRESHOLD} hours`
       );
       return;
     }
 
     console.log(
-      `[morphInstanceMaintenance] Found ${staleActiveInstances.length} active instance(s) older than ${HOURS_THRESHOLD} hours`
+      `[morphInstanceMaintenance] Found ${staleActiveInstances.length} active instance(s) older than ${PAUSE_HOURS_THRESHOLD} hours`
     );
 
     let successCount = 0;
@@ -128,6 +131,188 @@ export const pauseOldMorphInstances = internalAction({
 
     console.log(
       `[morphInstanceMaintenance] Finished: ${successCount} paused, ${failureCount} failed`
+    );
+  },
+});
+
+const STOP_DAYS_THRESHOLD = 14; // 2 weeks
+const STOP_BATCH_SIZE = 5;
+
+/**
+ * Records that a Morph instance was stopped.
+ */
+export const recordInstanceStop = internalMutation({
+  args: {
+    instanceId: v.string(),
+    ageHoursWhenStopped: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("morphInstanceStops", {
+      instanceId: args.instanceId,
+      stoppedAt: Date.now(),
+      ageHoursWhenStopped: args.ageHoursWhenStopped,
+    });
+  },
+});
+
+/**
+ * Checks if an instance has already been stopped by looking up in the DB.
+ */
+export const isInstanceStopped = internalMutation({
+  args: {
+    instanceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("morphInstanceStops")
+      .withIndex("by_instanceId", (q) => q.eq("instanceId", args.instanceId))
+      .first();
+    return existing !== null;
+  },
+});
+
+/**
+ * Stops (deletes) all Morph instances that have been paused for more than 2 weeks.
+ * Called by the daily cron job at 5 AM Pacific Time.
+ */
+export const stopOldMorphInstances = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    // Only run in production to avoid dev crons affecting prod instances
+    if (!env.CONVEX_IS_PRODUCTION) {
+      console.log("[morphInstanceMaintenance:stop] Skipping: not in production");
+      return;
+    }
+
+    const morphApiKey = env.MORPH_API_KEY;
+    if (!morphApiKey) {
+      console.error("[morphInstanceMaintenance:stop] MORPH_API_KEY not configured");
+      return;
+    }
+
+    const morphClient = createMorphCloudClient({
+      auth: morphApiKey,
+    });
+
+    // List all instances
+    const listResponse = await listInstancesInstanceGet({
+      client: morphClient,
+    });
+
+    if (listResponse.error) {
+      console.error(
+        "[morphInstanceMaintenance:stop] Failed to list instances:",
+        listResponse.error
+      );
+      return;
+    }
+
+    const instances = listResponse.data?.data ?? [];
+    if (instances.length === 0) {
+      console.log("[morphInstanceMaintenance:stop] No instances found");
+      return;
+    }
+
+    const now = Date.now();
+    const thresholdMs = STOP_DAYS_THRESHOLD * 24 * MILLISECONDS_PER_HOUR;
+
+    // Filter for paused instances older than 2 weeks
+    const stalePausedInstances = instances
+      .filter((instance: InstanceModel) => instance.status === "paused")
+      .filter((instance: InstanceModel) => {
+        const createdMs = instance.created * 1000;
+        return now - createdMs > thresholdMs;
+      })
+      .sort((a: InstanceModel, b: InstanceModel) => a.created - b.created);
+
+    if (stalePausedInstances.length === 0) {
+      console.log(
+        `[morphInstanceMaintenance:stop] No paused instances older than ${STOP_DAYS_THRESHOLD} days`
+      );
+      return;
+    }
+
+    console.log(
+      `[morphInstanceMaintenance:stop] Found ${stalePausedInstances.length} paused instance(s) older than ${STOP_DAYS_THRESHOLD} days`
+    );
+
+    let successCount = 0;
+    let failureCount = 0;
+    let skippedCount = 0;
+
+    // Process instances in batches
+    for (let i = 0; i < stalePausedInstances.length; i += STOP_BATCH_SIZE) {
+      const batch = stalePausedInstances.slice(i, i + STOP_BATCH_SIZE);
+      console.log(
+        `[morphInstanceMaintenance:stop] Processing batch ${Math.floor(i / STOP_BATCH_SIZE) + 1} (${batch.length} instances)`
+      );
+
+      const results = await Promise.allSettled(
+        batch.map(async (instance: InstanceModel) => {
+          // Check if already stopped (recorded in DB)
+          const alreadyStopped = await ctx.runMutation(
+            internal.morphInstanceMaintenance.isInstanceStopped,
+            { instanceId: instance.id }
+          );
+
+          if (alreadyStopped) {
+            console.log(
+              `[morphInstanceMaintenance:stop] Skipping ${instance.id} - already recorded as stopped`
+            );
+            return { skipped: true, instanceId: instance.id };
+          }
+
+          const ageHours = Math.floor(
+            (now - instance.created * 1000) / MILLISECONDS_PER_HOUR
+          );
+          console.log(
+            `[morphInstanceMaintenance:stop] Stopping ${instance.id} (${ageHours}h old)...`
+          );
+
+          const stopResponse = await stopInstanceInstanceInstanceIdDelete({
+            client: morphClient,
+            path: { instance_id: instance.id },
+          });
+
+          if (stopResponse.error) {
+            throw new Error(JSON.stringify(stopResponse.error));
+          }
+
+          // Record the stop in the database
+          await ctx.runMutation(
+            internal.morphInstanceMaintenance.recordInstanceStop,
+            {
+              instanceId: instance.id,
+              ageHoursWhenStopped: ageHours,
+            }
+          );
+
+          console.log(`[morphInstanceMaintenance:stop] Stopped ${instance.id}`);
+          return { skipped: false, instanceId: instance.id };
+        })
+      );
+
+      for (let j = 0; j < results.length; j++) {
+        const result = results[j];
+        const instance = batch[j];
+        if (result.status === "fulfilled") {
+          if (result.value.skipped) {
+            skippedCount++;
+          } else {
+            successCount++;
+          }
+        } else {
+          failureCount++;
+          console.error(
+            `[morphInstanceMaintenance:stop] Failed to stop ${instance.id}:`,
+            result.reason
+          );
+        }
+      }
+    }
+
+    console.log(
+      `[morphInstanceMaintenance:stop] Finished: ${successCount} stopped, ${skippedCount} skipped, ${failureCount} failed`
     );
   },
 });

--- a/packages/convex/convex/morphInstances.ts
+++ b/packages/convex/convex/morphInstances.ts
@@ -49,12 +49,10 @@ export const recordResume = authMutation({
     // Find the taskRun that uses this instance to verify ownership
     const taskRun = await ctx.db
       .query("taskRuns")
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("teamId"), teamId),
-          q.eq(q.field("vscode.containerName"), args.instanceId)
-        )
+      .withIndex("by_vscode_container_name", (q) =>
+        q.eq("vscode.containerName", args.instanceId)
       )
+      .filter((q) => q.eq(q.field("teamId"), teamId))
       .first();
 
     if (!taskRun) {

--- a/packages/convex/convex/morphInstances.ts
+++ b/packages/convex/convex/morphInstances.ts
@@ -1,0 +1,35 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Check if an instance has been stopped by the cleanup cron.
+ * Returns the stop record if found, null otherwise.
+ */
+export const getStopRecord = query({
+  args: {
+    instanceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const record = await ctx.db
+      .query("morphInstanceStops")
+      .withIndex("by_instanceId", (q) => q.eq("instanceId", args.instanceId))
+      .first();
+    return record;
+  },
+});
+
+/**
+ * Check if an instance is stopped (simple boolean check).
+ */
+export const isStopped = query({
+  args: {
+    instanceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const record = await ctx.db
+      .query("morphInstanceStops")
+      .withIndex("by_instanceId", (q) => q.eq("instanceId", args.instanceId))
+      .first();
+    return record !== null;
+  },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1121,11 +1121,12 @@ const convexSchema = defineSchema({
     .index("by_team_user", ["teamId", "userId"]) // Get unread runs for a user in a team
     .index("by_task_user", ["taskId", "userId"]), // Get unread runs for a task
 
-  // Track Morph instances that have been stopped by the cleanup cron
-  morphInstanceStops: defineTable({
+  // Track Morph instance activity for cleanup cron decisions
+  morphInstanceActivity: defineTable({
     instanceId: v.string(), // Morph instance ID (morphvm_xxx)
-    stoppedAt: v.number(), // Timestamp when the instance was stopped
-    ageHoursWhenStopped: v.number(), // Age of instance in hours when stopped
+    lastPausedAt: v.optional(v.number()), // When instance was last paused by cron
+    lastResumedAt: v.optional(v.number()), // When instance was last resumed via UI
+    stoppedAt: v.optional(v.number()), // When instance was permanently stopped
   }).index("by_instanceId", ["instanceId"]),
 });
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1120,6 +1120,13 @@ const convexSchema = defineSchema({
     .index("by_user", ["userId"]) // Get all unread runs for a user
     .index("by_team_user", ["teamId", "userId"]) // Get unread runs for a user in a team
     .index("by_task_user", ["taskId", "userId"]), // Get unread runs for a task
+
+  // Track Morph instances that have been stopped by the cleanup cron
+  morphInstanceStops: defineTable({
+    instanceId: v.string(), // Morph instance ID (morphvm_xxx)
+    stoppedAt: v.number(), // Timestamp when the instance was stopped
+    ageHoursWhenStopped: v.number(), // Age of instance in hours when stopped
+  }).index("by_instanceId", ["instanceId"]),
 });
 
 export default convexSchema;

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -394,6 +394,8 @@ export type ResumeTaskRunBody = {
 
 export type CheckTaskRunPausedResponse = {
     paused: boolean;
+    stopped?: boolean;
+    stoppedAt?: number;
 };
 
 export type CheckTaskRunPausedBody = {
@@ -420,7 +422,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_urlxhopc' | 'snapshot_mtl73ecs' | 'snapshot_pcmfvjra');
+    snapshotId?: string | ('snapshot_ztk8hh65' | 'snapshot_3yms1udr' | 'snapshot_pcmfvjra');
 };
 
 export type InstanceInfo = {


### PR DESCRIPTION
## Summary
- Add daily cron job at 5 AM PT to stop (delete) Morph instances that have been inactive for more than 2 weeks
- Add `morphInstanceActivity` table to track pause/resume/stop events for activity-based cleanup decisions
- Track resume activity across all resume endpoints (web UI, CLI, iframe preflight)
- Update `is-paused` endpoint to detect stopped instances (returns 404 from Morph API)
- Add "Workspace expired" UI overlay when users try to access a stopped instance

## Changes
- `packages/convex/convex/crons.ts`: Add new daily cron `stop old morph instances`
- `packages/convex/convex/morphInstanceMaintenance.ts`: 
  - Update `pauseOldMorphInstances` to record pause events and filter by cmux app prefix
  - Add `stopOldMorphInstances` action that checks activity before stopping
- `packages/convex/convex/schema.ts`: Add `morphInstanceActivity` table with `lastPausedAt`, `lastResumedAt`, `stoppedAt`
- `packages/convex/convex/morphInstances.ts`: Add queries/mutations for activity tracking
- `apps/www/lib/routes/morph.route.ts`: Update `is-paused` to return `stopped: true` if instance not found, record resume activity
- `apps/www/lib/routes/sandboxes.route.ts`: Record resume activity for CLI resumes
- `apps/www/lib/routes/iframe-preflight.route.ts`: Record resume activity for iframe auto-resumes
- `apps/client/src/components/resume-workspace-overlay.tsx`: Show "Workspace expired" message for stopped instances

## Test plan
- [ ] Run `convex dev` to generate types
- [ ] Verify cron job appears in Convex dashboard
- [ ] Test that paused instances older than 2 weeks (with no recent activity) are stopped
- [ ] Test that recently resumed instances are NOT stopped
- [ ] Test that the UI shows "Workspace expired" for stopped instances
- [ ] Verify activity records are created on pause/resume/stop