### PR TITLE
Fix cmux.dev latest release display

### DIFF
--- a/apps/www/lib/fetch-latest-release.ts
+++ b/apps/www/lib/fetch-latest-release.ts
@@ -14,6 +14,8 @@ export type ReleaseInfo = {
 
 type GithubRelease = {
   tag_name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
   assets?: Array<{
     name?: string;
     browser_download_url?: string;
@@ -99,10 +101,14 @@ export async function fetchLatestRelease(): Promise<ReleaseInfo> {
 
     const releases = (await response.json()) as GithubRelease[];
 
-    // Find the first release that matches the cmux CLI pattern (v1.0.xxx)
+    // Find the first stable release that matches the cmux CLI pattern (v1.0.xxx)
+    // Exclude drafts and prereleases to match the behavior of /releases/latest
     const cmuxRelease = releases.find(
       (release) =>
-        typeof release.tag_name === "string" && isCmuxCliRelease(release.tag_name)
+        typeof release.tag_name === "string" &&
+        !release.draft &&
+        !release.prerelease &&
+        isCmuxCliRelease(release.tag_name)
     );
 
     return deriveReleaseInfo(cmuxRelease ?? null);

--- a/apps/www/lib/releases.ts
+++ b/apps/www/lib/releases.ts
@@ -1,8 +1,8 @@
 export const RELEASE_PAGE_URL =
   "https://github.com/manaflow-ai/cmux/releases/latest";
 
-export const GITHUB_RELEASE_URL =
-  "https://api.github.com/repos/manaflow-ai/cmux/releases/latest";
+export const GITHUB_RELEASES_URL =
+  "https://api.github.com/repos/manaflow-ai/cmux/releases?per_page=20";
 
 export const DMG_SUFFIXES = {
   universal: "-universal.dmg",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
-        "@next/eslint-plugin-next": "^16.0.0",
+        "@next/eslint-plugin-next": "^16.1.1",
         "@t3-oss/env-core": "^0.13.8",
         "@types/node-forge": "^1.3.14",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
@@ -39,7 +39,7 @@
     },
     "apps/client": {
       "name": "@cmux/client",
-      "version": "1.0.206",
+      "version": "1.0.209",
       "dependencies": {
         "@base-ui-components/react": "1.0.0-beta.2",
         "@cmux/convex": "workspace:*",


### PR DESCRIPTION
late release on cmux.dev page is wrong:
Latest release: cmux host-screenshot-collector-v0.1.0-20251224095740-0570dab. Need another build? Visit the GitHub release page for all downloads.