### PR TITLE
feat: use CmuxIcon for header logo

### DIFF
--- a/apps/www/components/site-header.tsx
+++ b/apps/www/components/site-header.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import CmuxLogo from "@/components/logo/cmux-logo";
 import { MacDownloadLink } from "@/components/mac-download-link";
 import type { MacDownloadUrls } from "@/lib/releases";
 import clsx from "clsx";
@@ -98,8 +97,11 @@ export function SiteHeader({
         )}
       >
         <Link aria-label="cmux" href="/">
-          <div className="flex items-center gap-3">
-            <CmuxLogo height={36} label="cmux" showWordmark />
+          <div className="flex items-center gap-2">
+            <CmuxIcon className="h-7 w-7" aria-hidden />
+            <span className="text-xl font-bold tracking-wide text-white font-mono">
+              cmux
+            </span>
           </div>
         </Link>
         <nav className="hidden items-center gap-8 text-sm font-medium md:flex">


### PR DESCRIPTION
## Summary
- Replace CmuxLogo SVG component with the simpler CmuxIcon for the site header
- Uses the same gradient icon (cyan to purple) for consistent branding

## Test plan
- [ ] Verify header logo displays correctly on landing page
- [ ] Check gradient colors match brand guidelines