### PR TITLE
Add applicationID to Convex custom JWT auth config

### DIFF
--- a/packages/convex/convex/auth.config.ts
+++ b/packages/convex/convex/auth.config.ts
@@ -4,12 +4,14 @@ export default {
   providers: [
     {
       type: "customJwt",
+      applicationID: env.NEXT_PUBLIC_STACK_PROJECT_ID,
       issuer: `https://api.stack-auth.com/api/v1/projects/${env.NEXT_PUBLIC_STACK_PROJECT_ID}`,
       jwks: `https://api.stack-auth.com/api/v1/projects/${env.NEXT_PUBLIC_STACK_PROJECT_ID}/.well-known/jwks.json?include_anonymous=true`,
       algorithm: "ES256",
     },
     {
       type: "customJwt",
+      applicationID: `${env.NEXT_PUBLIC_STACK_PROJECT_ID}:anon`,
       issuer: `https://api.stack-auth.com/api/v1/projects-anonymous-users/${env.NEXT_PUBLIC_STACK_PROJECT_ID}`,
       jwks: `https://api.stack-auth.com/api/v1/projects/${env.NEXT_PUBLIC_STACK_PROJECT_ID}/.well-known/jwks.json?include_anonymous=true`,
       algorithm: "ES256",


### PR DESCRIPTION
## Summary
- Adds `applicationID` field to custom JWT providers in `auth.config.ts`
- Required for proper JWT `aud` claim validation with Stack Auth
- Fixes Convex auth for iOS and other non-web clients

## Test plan
- [x] Tested with iOS app - Convex auth now works correctly
- [ ] Verify web app still works (should be unaffected)