### PR TITLE
Filter local workspaces from cmux web tasks

### DIFF
--- a/apps/client/src/components/dashboard/TaskList.tsx
+++ b/apps/client/src/components/dashboard/TaskList.tsx
@@ -7,6 +7,7 @@ import { memo, useCallback, useMemo, useState } from "react";
 import { TaskItem } from "./TaskItem";
 import { PreviewItem } from "./PreviewItem";
 import { ChevronRight } from "lucide-react";
+import { env } from "../../client-env";
 
 type TaskCategoryKey =
   | "pinned"
@@ -183,12 +184,16 @@ export const TaskList = memo(function TaskList({
 }: {
   teamSlugOrId: string;
 }) {
-  const allTasks = useQuery(api.tasks.get, { teamSlugOrId });
+  // In web mode, exclude local workspaces from the task list
+  const excludeLocalWorkspaces = env.NEXT_PUBLIC_WEB_MODE || undefined;
+
+  const allTasks = useQuery(api.tasks.get, { teamSlugOrId, excludeLocalWorkspaces });
   const archivedTasks = useQuery(api.tasks.get, {
     teamSlugOrId,
     archived: true,
+    excludeLocalWorkspaces,
   });
-  const pinnedData = useQuery(api.tasks.getPinned, { teamSlugOrId });
+  const pinnedData = useQuery(api.tasks.getPinned, { teamSlugOrId, excludeLocalWorkspaces });
   const previewRuns = useQuery(api.previewRuns.listByTeam, { teamSlugOrId });
   const [tab, setTab] = useState<"all" | "archived" | "previews">("all");
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.workspaces.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.workspaces.tsx
@@ -10,21 +10,26 @@ import { convexQuery } from "@convex-dev/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQueries, useQuery } from "convex/react";
 import { useMemo } from "react";
+import { env } from "@/client-env";
 
 export const Route = createFileRoute("/_layout/$teamSlugOrId/workspaces")({
   component: WorkspacesRoute,
   loader: async ({ params }) => {
     const { teamSlugOrId } = params;
+    // In web mode, exclude local workspaces
+    const excludeLocalWorkspaces = env.NEXT_PUBLIC_WEB_MODE || undefined;
     void convexQueryClient.queryClient.ensureQueryData(
-      convexQuery(api.tasks.getWithNotificationOrder, { teamSlugOrId })
+      convexQuery(api.tasks.getWithNotificationOrder, { teamSlugOrId, excludeLocalWorkspaces })
     );
   },
 });
 
 function WorkspacesRoute() {
   const { teamSlugOrId } = Route.useParams();
+  // In web mode, exclude local workspaces
+  const excludeLocalWorkspaces = env.NEXT_PUBLIC_WEB_MODE || undefined;
   // Use notification-aware ordering: unread notifications first, then by createdAt
-  const tasks = useQuery(api.tasks.getWithNotificationOrder, { teamSlugOrId });
+  const tasks = useQuery(api.tasks.getWithNotificationOrder, { teamSlugOrId, excludeLocalWorkspaces });
   const tasksWithUnread = useQuery(api.taskNotifications.getTasksWithUnread, {
     teamSlugOrId,
   });

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",


### PR DESCRIPTION
we need to gate local workspaces in cmux.sh web mode. it should not show up in the tasks page with workspaces... OR pinned... just make sure to filter them out completely. ultrathink