### PR TITLE
Stabilize CI to prevent flaky build failures

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -278,7 +278,24 @@ jobs:
       - name: Build native Rust addon
         working-directory: apps/server/native/core
         shell: bash
-        run: bunx --bun @napi-rs/cli build --platform --release
+        env:
+          # Limit parallel rustc jobs to reduce peak memory usage on self-hosted runners
+          CARGO_BUILD_JOBS: "2"
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "Building native addon (attempt $attempt/3)..."
+            if bunx --bun @napi-rs/cli build --platform --release; then
+              echo "Build succeeded"
+              break
+            fi
+            if [[ $attempt -eq 3 ]]; then
+              echo "Build failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "Build failed, retrying in 10 seconds..."
+            sleep 10
+          done
       - name: Build, sign, and notarize (arm64) via publish script
         env:
           MAC_CERT_BASE64: ${{ secrets.MAC_CERT_BASE64 }}
@@ -409,14 +426,46 @@ jobs:
           rm -f cmux_native_core.darwin-*.node
 
       # Prebuild the Rust N-API addon for both slices so electron-builder can pick them up.
+      # Build sequentially with limited parallelism to avoid OOM on self-hosted runners.
       - name: Build native Rust addon (arm64 + x64)
         working-directory: apps/server/native/core
         shell: bash
+        env:
+          # Limit parallel rustc jobs to reduce peak memory usage
+          CARGO_BUILD_JOBS: "2"
         run: |
           set -euo pipefail
           rustup target add x86_64-apple-darwin aarch64-apple-darwin || true
-          bunx --bun @napi-rs/cli build --platform --release --target x86_64-apple-darwin
-          bunx --bun @napi-rs/cli build --platform --release --target aarch64-apple-darwin
+
+          # Build x86_64 first with retry logic for transient OOM failures
+          for attempt in 1 2 3; do
+            echo "Building x86_64-apple-darwin (attempt $attempt/3)..."
+            if bunx --bun @napi-rs/cli build --platform --release --target x86_64-apple-darwin; then
+              echo "x86_64-apple-darwin build succeeded"
+              break
+            fi
+            if [[ $attempt -eq 3 ]]; then
+              echo "x86_64-apple-darwin build failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "Build failed, retrying in 10 seconds..."
+            sleep 10
+          done
+
+          # Build aarch64 with retry logic
+          for attempt in 1 2 3; do
+            echo "Building aarch64-apple-darwin (attempt $attempt/3)..."
+            if bunx --bun @napi-rs/cli build --platform --release --target aarch64-apple-darwin; then
+              echo "aarch64-apple-darwin build succeeded"
+              break
+            fi
+            if [[ $attempt -eq 3 ]]; then
+              echo "aarch64-apple-darwin build failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "Build failed, retrying in 10 seconds..."
+            sleep 10
+          done
 
       - name: Verify macOS native addon slices
         working-directory: apps/server/native/core

--- a/apps/server/native/core/Cargo.toml
+++ b/apps/server/native/core/Cargo.toml
@@ -24,3 +24,12 @@ similar = "2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[profile.release]
+# Reduce memory pressure during compilation on CI (especially for universal macOS builds).
+# Higher codegen-units = less parallelism per crate = lower peak memory usage.
+codegen-units = 8
+# Disable LTO to significantly reduce memory usage during linking.
+lto = false
+# Keep optimizations high for runtime performance.
+opt-level = 3


### PR DESCRIPTION
error: failed to run custom build command for `rustversion v1.0.22`Caused by:  process didn't exit successfully: `/Users/cmux/actions-runner-2/_work/_temp/cargo-target-20545228657-mac-universal/release/build/rustversion-0420a36ec774df70/build-script-build` (signal: 9, SIGKILL: kill)warning: build failed, waiting for other jobs to finish...Internal Error: Build failed with exit code 101    at <anonymous> (/private/tmp/bunx-501-@napi-rs/cli@latest/node_modules/@napi-rs/cli/dist/cli.js:1300:40)    at emit (node:events:98:22)    at #handleOnExit (node:child_process:520:14)    at processTicksAndRejections (native:7:39)Error: Process completed with exit code 1. we seem to have a problem because its very flaky in the github actions workflow for some reason. one of them seems to fail in this way, but rerunning makes it work. ultrathink find a way to make this much more reliable so builds dont fail the first time