### PR TITLE
Hide local workspaces in web cmux sidebar

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/client-env";
 import { TaskTree } from "@/components/TaskTree";
 import { TaskTreeSkeleton } from "@/components/TaskTreeSkeleton";
 import { useExpandTasks } from "@/contexts/expand-tasks/ExpandTasksContext";
@@ -105,8 +106,9 @@ export function Sidebar({ tasks, teamSlugOrId }: SidebarProps) {
 
   const { expandTaskIds } = useExpandTasks();
 
-  // Fetch pinned items
-  const pinnedData = useQuery(api.tasks.getPinned, { teamSlugOrId });
+  // Fetch pinned items (exclude local workspaces in web mode)
+  const excludeLocalWorkspaces = env.NEXT_PUBLIC_WEB_MODE || undefined;
+  const pinnedData = useQuery(api.tasks.getPinned, { teamSlugOrId, excludeLocalWorkspaces });
 
   // Fetch unread notification count
   const unreadCount = useQuery(api.taskNotifications.getUnreadCount, {


### PR DESCRIPTION
on web mode, cmux.sh ... the sidebar is still showing local workspaces when it should not be showing local workspaces at all.. ONLY cloud workspaces.