### PR TITLE
Wait for environment variables before running scripts

### DIFF
--- a/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
+++ b/apps/www/lib/routes/sandboxes/startDevAndMaintenanceScript.ts
@@ -91,6 +91,26 @@ set -eu
 # Source system profile for environment variables (RUSTUP_HOME, etc.)
 [[ -f /etc/profile ]] && source /etc/profile
 
+# Load environment variables from envctl daemon (auto-starts daemon if needed)
+# The daemon stores env vars set via 'envctl load' during sandbox startup
+# Retry to handle daemon startup timing
+__load_envctl_vars() {
+  local max_attempts=15
+  local attempt=0
+  while (( attempt < max_attempts )); do
+    local out
+    if out="$(envctl export zsh --pwd "${WORKSPACE_ROOT}" 2>/dev/null)"; then
+      eval "$out"
+      return 0
+    fi
+    sleep 1
+    (( attempt++ ))
+  done
+  echo "Warning: Could not load envctl environment variables after $max_attempts attempts" >&2
+  return 0
+}
+__load_envctl_vars
+
 cd ${WORKSPACE_ROOT}
 
 echo "=== Maintenance Script Started at \\$(date) ==="
@@ -106,6 +126,26 @@ set -u
 
 # Source system profile for environment variables (RUSTUP_HOME, etc.)
 [[ -f /etc/profile ]] && source /etc/profile
+
+# Load environment variables from envctl daemon (auto-starts daemon if needed)
+# The daemon stores env vars set via 'envctl load' during sandbox startup
+# Retry to handle daemon startup timing
+__load_envctl_vars() {
+  local max_attempts=15
+  local attempt=0
+  while (( attempt < max_attempts )); do
+    local out
+    if out="$(envctl export zsh --pwd "${WORKSPACE_ROOT}" 2>/dev/null)"; then
+      eval "$out"
+      return 0
+    fi
+    sleep 1
+    (( attempt++ ))
+  done
+  echo "Warning: Could not load envctl environment variables after $max_attempts attempts" >&2
+  return 0
+}
+__load_envctl_vars
 
 cd ${WORKSPACE_ROOT}
 


### PR DESCRIPTION
there is something wrong where my setup scripts fail when im using repo cloud tasks.... set +x; zsh '/var/tmp/cmux-scripts/maintenance.sh' 2>&1 | tee '/var/tmp/cmux-scripts/maintenance_mjw7liov_rnk3ptan.log'; echo ${pipestatus[1]} > '/var/tmp/cmux-scripts/maintenance_mjw7liov_rnk3ptan.exit-code'; exec zsh
nk3ptan.exit-code'; exec zsh maintenance script failed in 3 seconds.. there seems to be something wrong. we also need to make sure we wait until environment variables are loaded properly before starting any of the maintenance or setup scripts or dev scripts/ ultrathink