### PR TITLE
Fix token expiry and refresh flow for Electron

### DIFF
--- a/apps/client/src/lib/cachedGetUser.ts
+++ b/apps/client/src/lib/cachedGetUser.ts
@@ -9,6 +9,41 @@ declare global {
   }
 }
 
+/**
+ * Fetches a fresh user from Stack Auth, bypassing the cache.
+ * This triggers Stack Auth's internal token refresh mechanism.
+ */
+async function fetchFreshUser(
+  stackClientApp: StackClientApp
+): Promise<User | null> {
+  try {
+    // stackClientApp.getUser() will automatically refresh tokens if needed
+    // via Stack Auth's internal refresh mechanism
+    const user = await stackClientApp.getUser();
+
+    if (!user) {
+      window.cachedUser = null;
+      window.userPromise = null;
+      return null;
+    }
+
+    const tokens = await user.currentSession.getTokens();
+
+    if (!tokens.accessToken) {
+      window.cachedUser = null;
+      window.userPromise = null;
+      return null;
+    }
+    window.cachedUser = user;
+    return user;
+  } catch (error) {
+    console.error("Error fetching fresh user:", error);
+    window.cachedUser = null;
+    window.userPromise = null;
+    return null;
+  }
+}
+
 export async function cachedGetUser(
   stackClientApp: StackClientApp
 ): Promise<User | null> {
@@ -17,21 +52,27 @@ export async function cachedGetUser(
     try {
       const tokens = await window.cachedUser.currentSession.getTokens();
       if (!tokens.accessToken) {
+        // No access token - need to fetch fresh user
         window.cachedUser = null;
         window.userPromise = null;
-        return null;
+        return fetchFreshUser(stackClientApp);
       }
       const jwt = decodeJwt(tokens.accessToken);
-      if (jwt.exp && jwt.exp < Date.now() / 1000) {
+      // Add a 30-second buffer before expiration to proactively refresh
+      const bufferSeconds = 30;
+      if (jwt.exp && jwt.exp < Date.now() / 1000 + bufferSeconds) {
+        // Token is expired or about to expire - fetch fresh user which triggers refresh
         window.cachedUser = null;
         window.userPromise = null;
-        return null;
+        return fetchFreshUser(stackClientApp);
       }
       return window.cachedUser;
     } catch (error) {
       console.warn("Error checking cached user validity:", error);
       window.cachedUser = null;
       window.userPromise = null;
+      // Try to fetch fresh user on error
+      return fetchFreshUser(stackClientApp);
     }
   }
 

--- a/apps/client/src/lib/cachedGetUser.ts
+++ b/apps/client/src/lib/cachedGetUser.ts
@@ -23,7 +23,6 @@ async function fetchFreshUser(
 
     if (!user) {
       window.cachedUser = null;
-      window.userPromise = null;
       return null;
     }
 
@@ -31,7 +30,6 @@ async function fetchFreshUser(
 
     if (!tokens.accessToken) {
       window.cachedUser = null;
-      window.userPromise = null;
       return null;
     }
     window.cachedUser = user;
@@ -39,8 +37,10 @@ async function fetchFreshUser(
   } catch (error) {
     console.error("Error fetching fresh user:", error);
     window.cachedUser = null;
-    window.userPromise = null;
     return null;
+  } finally {
+    // Always clear the promise to allow future fetches
+    window.userPromise = null;
   }
 }
 

--- a/apps/client/src/lib/stack.ts
+++ b/apps/client/src/lib/stack.ts
@@ -28,24 +28,94 @@ convexQueryClient.convexClient.setAuth(
   },
 );
 
+/**
+ * Checks if a response indicates an expired/invalid auth token.
+ */
+function isTokenExpiredResponse(status: number, bodyText: string): boolean {
+  if (status !== 401) return false;
+  const lowerBody = bodyText.toLowerCase();
+  return (
+    lowerBody.includes("token expired") ||
+    lowerBody.includes("invalid auth header") ||
+    lowerBody.includes("jwt expired") ||
+    lowerBody.includes("unauthorized")
+  );
+}
+
+/**
+ * Clears the cached user to force a fresh fetch with token refresh on next call.
+ */
+function clearCachedUser(): void {
+  if (typeof window !== "undefined") {
+    window.cachedUser = null;
+    window.userPromise = null;
+  }
+}
+
 const fetchWithAuth = (async (request: Request) => {
-  const user = await cachedGetUser(stackClientApp);
-  if (!user) {
-    throw new Error("User not found");
+  const makeRequest = async (isRetry: boolean): Promise<Response> => {
+    const user = await cachedGetUser(stackClientApp);
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    // getAuthHeaders() should return fresh headers - Stack Auth handles refresh internally
+    const authHeaders = await user.getAuthHeaders();
+    const mergedHeaders = new Headers();
+    for (const [key, value] of Object.entries(authHeaders)) {
+      mergedHeaders.set(key, value);
+    }
+    for (const [key, value] of request instanceof Request
+      ? request.headers.entries()
+      : []) {
+      mergedHeaders.set(key, value);
+    }
+
+    // Clone the request for potential retry (request body can only be consumed once)
+    const requestForFetch = isRetry ? request.clone() : request;
+
+    const response = await fetch(requestForFetch, {
+      headers: mergedHeaders,
+    });
+
+    return response;
+  };
+
+  // First attempt
+  let response = await makeRequest(false);
+
+  // Check if it's an auth error that warrants a retry
+  if (response.status === 401) {
+    const clone = response.clone();
+    let bodyText = "";
+    try {
+      bodyText = await clone.text();
+    } catch (e) {
+      console.error("[APIError] Failed to read error body for retry check", e);
+    }
+
+    if (isTokenExpiredResponse(response.status, bodyText)) {
+      console.warn(
+        "[Auth] Token expired, clearing cache and retrying with fresh token..."
+      );
+
+      // Clear the cached user to force Stack Auth to refresh the token
+      clearCachedUser();
+
+      // Retry the request with fresh auth headers
+      try {
+        response = await makeRequest(true);
+        if (response.ok) {
+          console.log("[Auth] Retry succeeded with refreshed token");
+        }
+      } catch (retryError) {
+        console.error("[Auth] Retry failed after token refresh:", retryError);
+        // Return the original 401 response if retry fails
+      }
+    }
   }
-  const authHeaders = await user.getAuthHeaders();
-  const mergedHeaders = new Headers();
-  for (const [key, value] of Object.entries(authHeaders)) {
-    mergedHeaders.set(key, value);
-  }
-  for (const [key, value] of request instanceof Request
-    ? request.headers.entries()
-    : []) {
-    mergedHeaders.set(key, value);
-  }
-  const response = await fetch(request, {
-    headers: mergedHeaders,
-  });
+
+  // Log non-OK responses for debugging
   if (!response.ok) {
     try {
       const clone = response.clone();
@@ -60,6 +130,7 @@ const fetchWithAuth = (async (request: Request) => {
       console.error("[APIError] Failed to read error body", e);
     }
   }
+
   return response;
 }) as typeof fetch; // TODO: remove when bun types dont conflict with node types
 


### PR DESCRIPTION
invalid auth header expired. token expired... i need to fix this problem. why does this error occur with token expiring. it blocks all my functions on electron desktop app and it requires me to quit and restart the app. why can't we fetch another access token using the refresh token. what is going wrong? please figure out the root issue and fix it completely ultrathink