### PR TITLE
Fix preview routes and wrong redirects

### DIFF
--- a/apps/www/components/preview/preview-test-dashboard.tsx
+++ b/apps/www/components/preview/preview-test-dashboard.tsx
@@ -132,10 +132,10 @@ function PreviewTestDashboardInner({
 
   // Client app base URL for workspace/browser links
   // In development, the client app runs on port 5173
-  // In production, both apps share the same domain (www.cmux.sh)
+  // In production, workspace/browser are on www.cmux.sh (not preview.new)
   const clientBaseUrl = typeof window !== "undefined" && window.location.hostname === "localhost"
     ? "http://localhost:5173"
-    : "";
+    : "https://www.cmux.sh";
 
   // Fetch test jobs
   const { data: jobsData, isLoading: isLoadingJobs } = useQuery({

--- a/apps/www/proxy.ts
+++ b/apps/www/proxy.ts
@@ -33,8 +33,31 @@ export function proxy(request: NextRequest) {
     return NextResponse.rewrite(new URL("/heatmap", request.url));
   }
 
-  if (hostname === "preview.new" && pathname === "/") {
-    return NextResponse.rewrite(new URL("/preview", request.url));
+  // Handle preview.new domain routing
+  if (hostname === "preview.new") {
+    // Redirect /preview/* to /* to avoid duplicate URLs
+    // (e.g., preview.new/preview → preview.new/)
+    if (pathname === "/preview") {
+      const url = request.nextUrl.clone();
+      url.pathname = "/";
+      return NextResponse.redirect(url, 301);
+    }
+    if (pathname.startsWith("/preview/")) {
+      const url = request.nextUrl.clone();
+      url.pathname = pathname.replace(/^\/preview/, "");
+      return NextResponse.redirect(url, 301);
+    }
+
+    // Rewrite clean URLs to actual routes
+    if (pathname === "/") {
+      return NextResponse.rewrite(new URL("/preview", request.url));
+    }
+    if (pathname === "/test") {
+      return NextResponse.rewrite(new URL("/preview/test", request.url));
+    }
+    if (pathname === "/configure") {
+      return NextResponse.rewrite(new URL("/preview/configure", request.url));
+    }
   }
 
   if (hostname === "manaflow.com" && pathname === "/") {


### PR DESCRIPTION
currently there is a bug in /preview/test... also why do we have (preview)/preview... and (preview)/preview/test... we should only be having (preview)/page.tsx and (preview)/test/page.tsx like that format otherwise we get preview.new and preview.new/preview to be the same thing. also the bug is that when we click on workspace or browser button it goes to preview.new/a79... [id] etc etc instead of cmux.sh/a79 etc etc... ultrathink