### PR TITLE
Support multi-line env var pastes across systems

### DIFF
--- a/apps/client/src/components/EnvironmentConfiguration.tsx
+++ b/apps/client/src/components/EnvironmentConfiguration.tsx
@@ -1009,12 +1009,15 @@ export function EnvironmentConfiguration({
             <div
               className="pb-2"
               onPasteCapture={(e) => {
-                // Allow normal paste behavior when pasting into a value input
                 const target = e.target as HTMLElement;
-                if (target.getAttribute?.("data-env-input") === "value") {
+                const inputType = target.getAttribute?.("data-env-input");
+                const text = e.clipboardData?.getData("text") ?? "";
+
+                // Always allow normal paste into value fields (values can contain =, :, URLs, etc.)
+                if (inputType === "value") {
                   return;
                 }
-                const text = e.clipboardData?.getData("text") ?? "";
+
                 if (text && (/\n/.test(text) || /(=|:)\s*\S/.test(text))) {
                   e.preventDefault();
                   const items = parseEnvBlock(text);
@@ -1119,6 +1122,7 @@ export function EnvironmentConfiguration({
                           });
                         }}
                         placeholder="EXAMPLE_NAME"
+                        data-env-input="key"
                         className="w-full min-w-0 self-start rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 py-2 text-sm font-mono text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700"
                       />
                       <TextareaAutosize

--- a/apps/client/src/components/EnvironmentConfiguration.tsx
+++ b/apps/client/src/components/EnvironmentConfiguration.tsx
@@ -1009,6 +1009,11 @@ export function EnvironmentConfiguration({
             <div
               className="pb-2"
               onPasteCapture={(e) => {
+                // Allow normal paste behavior when pasting into a value input
+                const target = e.target as HTMLElement;
+                if (target.getAttribute?.("data-env-input") === "value") {
+                  return;
+                }
                 const text = e.clipboardData?.getData("text") ?? "";
                 if (text && (/\n/.test(text) || /(=|:)\s*\S/.test(text))) {
                   e.preventDefault();
@@ -1135,6 +1140,7 @@ export function EnvironmentConfiguration({
                         placeholder="I9JU23NF394R6HH"
                         minRows={1}
                         maxRows={10}
+                        data-env-input="value"
                         className="w-full min-w-0 rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 py-2 text-sm font-mono text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700 resize-none"
                       />
                       <div className="self-start flex items-center justify-end w-[44px]">

--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -193,12 +193,15 @@ export function WorkspaceSetupPanel({
 
   const handleEnvPaste = useCallback(
     (event: ClipboardEvent<HTMLDivElement>) => {
-      // Allow normal paste behavior when pasting into a value input
       const target = event.target as HTMLElement;
-      if (target.getAttribute?.("data-env-input") === "value") {
+      const inputType = target.getAttribute?.("data-env-input");
+      const text = event.clipboardData?.getData("text") ?? "";
+
+      // Always allow normal paste into value fields (values can contain =, :, URLs, etc.)
+      if (inputType === "value") {
         return;
       }
-      const text = event.clipboardData?.getData("text") ?? "";
+
       if (!text || !/\n|=/.test(text)) {
         return;
       }
@@ -415,6 +418,7 @@ export function WorkspaceSetupPanel({
                                 });
                               }}
                               placeholder="EXAMPLE_KEY"
+                              data-env-input="key"
                               className="w-full rounded-md border border-neutral-200 bg-white px-2 py-1.5 text-[11px] font-mono text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:border-neutral-400 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-600 dark:focus:border-neutral-600"
                             />
                             <input

--- a/apps/client/src/components/WorkspaceSetupPanel.tsx
+++ b/apps/client/src/components/WorkspaceSetupPanel.tsx
@@ -193,6 +193,11 @@ export function WorkspaceSetupPanel({
 
   const handleEnvPaste = useCallback(
     (event: ClipboardEvent<HTMLDivElement>) => {
+      // Allow normal paste behavior when pasting into a value input
+      const target = event.target as HTMLElement;
+      if (target.getAttribute?.("data-env-input") === "value") {
+        return;
+      }
       const text = event.clipboardData?.getData("text") ?? "";
       if (!text || !/\n|=/.test(text)) {
         return;
@@ -441,6 +446,7 @@ export function WorkspaceSetupPanel({
                                   current === idx ? null : current,
                                 );
                               }}
+                              data-env-input="value"
                               className="w-full rounded-md border border-neutral-200 bg-white px-2 py-1.5 text-[11px] font-mono text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:border-neutral-400 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-600 dark:focus:border-neutral-600 transition"
                             />
                             <button

--- a/apps/client/src/components/environment/EnvironmentInitialSetup.tsx
+++ b/apps/client/src/components/environment/EnvironmentInitialSetup.tsx
@@ -79,12 +79,15 @@ export function EnvironmentInitialSetup({
 
   const handleEnvVarsPaste = useCallback(
     (e: React.ClipboardEvent<HTMLDivElement>) => {
-      // Allow normal paste behavior when pasting into a value input
       const target = e.target as HTMLElement;
-      if (target.getAttribute?.("data-env-input") === "value") {
+      const inputType = target.getAttribute?.("data-env-input");
+      const text = e.clipboardData?.getData("text") ?? "";
+
+      // Always allow normal paste into value fields (values can contain =, :, URLs, etc.)
+      if (inputType === "value") {
         return;
       }
-      const text = e.clipboardData?.getData("text") ?? "";
+
       if (text && (/\n/.test(text) || /(=|:)\s*\S/.test(text))) {
         e.preventDefault();
         const items = parseEnvBlock(text);
@@ -358,6 +361,7 @@ function EnvVarsSection({
                   });
                 }}
                 placeholder="EXAMPLE_NAME"
+                data-env-input="key"
                 className="w-full min-w-0 h-9 rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 text-sm font-mono text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700"
               />
               <input

--- a/apps/client/src/components/environment/EnvironmentInitialSetup.tsx
+++ b/apps/client/src/components/environment/EnvironmentInitialSetup.tsx
@@ -79,6 +79,11 @@ export function EnvironmentInitialSetup({
 
   const handleEnvVarsPaste = useCallback(
     (e: React.ClipboardEvent<HTMLDivElement>) => {
+      // Allow normal paste behavior when pasting into a value input
+      const target = e.target as HTMLElement;
+      if (target.getAttribute?.("data-env-input") === "value") {
+        return;
+      }
       const text = e.clipboardData?.getData("text") ?? "";
       if (text && (/\n/.test(text) || /(=|:)\s*\S/.test(text))) {
         e.preventDefault();
@@ -377,6 +382,7 @@ function EnvVarsSection({
                 }
                 readOnly={shouldMaskValue}
                 placeholder="I9JU23NF394R6HH"
+                data-env-input="value"
                 className="w-full min-w-0 h-9 rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 text-sm font-mono text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700"
               />
               <button

--- a/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
+++ b/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
@@ -282,12 +282,15 @@ export function EnvironmentWorkspaceConfig({
 
   const handleEnvVarsPaste = useCallback(
     (e: React.ClipboardEvent<HTMLDivElement>) => {
-      // Allow normal paste behavior when pasting into a value input
       const target = e.target as HTMLElement;
-      if (target.getAttribute?.("data-env-input") === "value") {
+      const inputType = target.getAttribute?.("data-env-input");
+      const text = e.clipboardData?.getData("text") ?? "";
+
+      // Always allow normal paste into value fields (values can contain =, :, URLs, etc.)
+      if (inputType === "value") {
         return;
       }
-      const text = e.clipboardData?.getData("text") ?? "";
+
       if (text && (/\n/.test(text) || /(=|:)\s*\S/.test(text))) {
         e.preventDefault();
         const items = parseEnvBlock(text);
@@ -496,6 +499,7 @@ export function EnvironmentWorkspaceConfig({
                     });
                   }}
                   placeholder="EXAMPLE_NAME"
+                  data-env-input="key"
                   className="w-full min-w-0 h-9 rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 text-sm font-mono text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700"
                 />
                 <input

--- a/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
+++ b/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
@@ -282,6 +282,11 @@ export function EnvironmentWorkspaceConfig({
 
   const handleEnvVarsPaste = useCallback(
     (e: React.ClipboardEvent<HTMLDivElement>) => {
+      // Allow normal paste behavior when pasting into a value input
+      const target = e.target as HTMLElement;
+      if (target.getAttribute?.("data-env-input") === "value") {
+        return;
+      }
       const text = e.clipboardData?.getData("text") ?? "";
       if (text && (/\n/.test(text) || /(=|:)\s*\S/.test(text))) {
         e.preventDefault();
@@ -515,6 +520,7 @@ export function EnvironmentWorkspaceConfig({
                   }
                   readOnly={shouldMaskValue}
                   placeholder="I9JU23NF394R6HH"
+                  data-env-input="value"
                   className="w-full min-w-0 h-9 rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 text-sm font-mono text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700"
                 />
                 <button


### PR DESCRIPTION
currently in the environment variables, i can only paste it if its in the ENVIRONMENT_VAR=secret format... i cannot paste it one at a time, suppose I just want to do the standard copy and paste, it doesn't let me do it... ultrathink we need to fix this bug (everywhere that we have this implmented, there should be multiple places)...