### PR TITLE
Fix empty space and sticky headers in diff viewer

### DIFF
--- a/apps/client/src/components/file-diff-header.tsx
+++ b/apps/client/src/components/file-diff-header.tsx
@@ -66,7 +66,7 @@ export function FileDiffHeader({
     <button
       onClick={onToggle}
       className={cn(
-        "w-full pl-3 pr-2.5 py-1.5 flex items-center hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-y border-neutral-200 dark:border-neutral-800 sticky top-0 z-[var(--z-sticky-low)]",
+        "w-full pl-3 pr-2.5 py-1.5 flex items-center hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left group pt-1 bg-white dark:bg-neutral-900 border-y border-neutral-200 dark:border-neutral-800 sticky top-[var(--cmux-diff-header-offset,0px)] z-[var(--z-sticky-low)]",
         className
       )}
     >

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -14,6 +14,7 @@ import type { ReviewHeatmapLine } from "@/lib/heatmap";
 import { stackClientApp } from "@/lib/stack";
 import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 import { normalizeGitRef } from "@/lib/refWithOrigin";
+import { cn } from "@/lib/utils";
 import { gitDiffQueryOptions } from "@/queries/git-diff";
 import { api } from "@cmux/convex/api";
 import type { CreateLocalWorkspaceResponse, ReplaceDiffEntry } from "@cmux/shared";
@@ -1090,14 +1091,14 @@ function RunDiffPage() {
               <div className="border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50/60 dark:bg-neutral-950/40 px-3.5 py-3 text-sm text-neutral-500 dark:text-neutral-400">
                 Loading screenshots...
               </div>
-            ) : (
+            ) : screenshotSets.length > 0 ? (
               <RunScreenshotGallery
                 screenshotSets={screenshotSets}
                 highlightedSetId={selectedRun?.latestScreenshotSetId ?? null}
               />
-            )}
+            ) : null}
             <div
-              className="flex-1 min-h-0 mt-6"
+              className={cn("flex-1 min-h-0", screenshotSets.length > 0 && "mt-6")}
               style={{ "--cmux-diff-header-offset": "56px" } as React.CSSProperties}
             >
               <Suspense


### PR DESCRIPTION
image.png  there seems to b eunnecessary space here for some reason when there is no screenshot preview gallery also we need to make the file headers sticky attach to the top right under the task detail header when we scroll down, similar to the cmux heatmap, we need to do the same thing here as well... in the og git diff viewer