### PR TITLE
Surface docker pull errors for first-time users

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -477,19 +477,44 @@ function DashboardComponent() {
       if (!isEnvSelected && !isCloudMode) {
         // Always check Docker status when in local mode, regardless of current state
         if (socket) {
-          const ready = await new Promise<boolean>((resolve) => {
+          const dockerCheck = await new Promise<{
+            isRunning: boolean;
+            workerImage?: {
+              name: string;
+              isAvailable: boolean;
+              isPulling?: boolean;
+            };
+          }>((resolve) => {
             socket.emit("check-provider-status", (response) => {
               const isRunning = !!response?.dockerStatus?.isRunning;
               if (typeof isRunning === "boolean") {
                 setDockerReady(isRunning);
               }
-              resolve(isRunning);
+              resolve({
+                isRunning,
+                workerImage: response?.dockerStatus?.workerImage,
+              });
             });
           });
 
           // Only show the alert if Docker is actually not running after checking
-          if (!ready) {
+          if (!dockerCheck.isRunning) {
             toast.error("Docker is not running. Start Docker Desktop.");
+            return;
+          }
+
+          // Check if Docker worker image is available
+          if (dockerCheck.workerImage && !dockerCheck.workerImage.isAvailable) {
+            const imageName = dockerCheck.workerImage.name;
+            if (dockerCheck.workerImage.isPulling) {
+              toast.error(
+                `Docker image "${imageName}" is currently being pulled. Please wait for it to complete.`
+              );
+            } else {
+              toast.error(
+                `Docker image "${imageName}" is not available. Please pull it first: docker pull ${imageName}`
+              );
+            }
             return;
           }
         } else {

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -89,7 +89,13 @@ function VSCodeComponent() {
   // Extract stable values from taskRun to avoid re-renders when unrelated fields change
   const rawWorkspaceUrl = taskRun?.vscode?.workspaceUrl;
   const vsCodeProvider = taskRun?.vscode?.provider;
+  const vsCodeStatusMessage = taskRun?.vscode?.statusMessage;
+  const taskRunStatus = taskRun?.status;
+  const taskRunErrorMessage = taskRun?.errorMessage;
   const localServeWebBaseUrl = localServeWeb.data?.baseUrl;
+
+  // Check if the task run failed (e.g., Docker pull failed)
+  const hasTaskRunFailed = taskRunStatus === "failed";
 
   // Memoize the workspace URL to prevent unnecessary recalculations
   const workspaceUrl = useMemo(
@@ -151,9 +157,13 @@ function VSCodeComponent() {
   const loadingFallback = useMemo(
     () =>
       isLocalWorkspace ? null : (
-        <WorkspaceLoadingIndicator variant="vscode" status="loading" />
+        <WorkspaceLoadingIndicator
+          variant="vscode"
+          status="loading"
+          loadingDescription={vsCodeStatusMessage}
+        />
       ),
-    [isLocalWorkspace]
+    [isLocalWorkspace, vsCodeStatusMessage]
   );
   const errorFallback = useMemo(
     () => <WorkspaceLoadingIndicator variant="vscode" status="error" />,
@@ -216,7 +226,12 @@ function VSCodeComponent() {
           )}
           {!hasWorkspace && !isLocalWorkspace ? (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-              <WorkspaceLoadingIndicator variant="vscode" status="loading" />
+              <WorkspaceLoadingIndicator
+                variant="vscode"
+                status={hasTaskRunFailed ? "error" : "loading"}
+                loadingDescription={vsCodeStatusMessage}
+                errorDescription={taskRunErrorMessage ?? undefined}
+              />
             </div>
           ) : null}
           {taskRun ? (

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -259,6 +259,7 @@ const convexSchema = defineSchema({
           v.literal("running"),
           v.literal("stopped")
         ),
+        statusMessage: v.optional(v.string()), // Human-readable status (e.g., "Pulling Docker image...")
         ports: v.optional(
           v.object({
             vscode: v.string(),

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -389,6 +389,13 @@ export const DockerStatusSchema = z.object({
     .optional(),
 });
 
+// Docker pull image schemas
+export const DockerPullImageResponseSchema = z.object({
+  success: z.boolean(),
+  imageName: z.string().optional(),
+  error: z.string().optional(),
+});
+
 export const GitStatusSchema = z.object({
   isAvailable: z.boolean(),
   version: z.string().optional(),
@@ -470,6 +477,9 @@ export type ArchiveTask = z.infer<typeof ArchiveTaskSchema>;
 export type SpawnFromComment = z.infer<typeof SpawnFromCommentSchema>;
 export type ProviderStatus = z.infer<typeof ProviderStatusSchema>;
 export type DockerStatus = z.infer<typeof DockerStatusSchema>;
+export type DockerPullImageResponse = z.infer<
+  typeof DockerPullImageResponseSchema
+>;
 export type GitStatus = z.infer<typeof GitStatusSchema>;
 export type GitHubStatus = z.infer<typeof GitHubStatusSchema>;
 export type GitHubFetchRepos = z.infer<typeof GitHubFetchReposSchema>;
@@ -562,6 +572,9 @@ export interface ClientToServerEvents {
   ) => void;
   "check-provider-status": (
     callback: (response: ProviderStatusResponse) => void
+  ) => void;
+  "docker-pull-image": (
+    callback: (response: DockerPullImageResponse) => void
   ) => void;
   "get-local-vscode-serve-web-origin": (
     callback: (response: { baseUrl: string | null; port: number | null }) => void


### PR DESCRIPTION
for docker local tasks, we need to surface when we are doing a docker pull for users in their first time. we also need to surfaxe any errors with the docker pull if there are any... currently what happens is that if the docker pull fails, we actually just have the local task hang forever... with no error message... local tasks should not start if the docker thing is not detected... there should be better error message surfacing for this... ultrathink