### PR TITLE
Hide environments from repo picker in local mode

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -738,7 +738,8 @@ function DashboardComponent() {
     }));
 
     const options: SelectOption[] = [];
-    if (envOptions.length > 0) {
+    // Only show environments in cloud mode
+    if (isCloudMode && envOptions.length > 0) {
       options.push({
         label: "Environments",
         value: "__heading-env",
@@ -756,7 +757,7 @@ function DashboardComponent() {
     }
 
     return options;
-  }, [reposByOrg, environmentsQuery.data]);
+  }, [reposByOrg, environmentsQuery.data, isCloudMode]);
 
   const selectedRepoFullName = useMemo(() => {
     if (!selectedProject[0] || isEnvSelected) return null;


### PR DESCRIPTION
for local mode, we should not be displaying any environments in the repo picker and only show repos, we should filter them out...