### PR TITLE
Fix codex agent timeout and cursor read issue

### DIFF
--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -1797,9 +1797,15 @@ impl SandboxService for BubblewrapService {
             // Reader tasks (Stdout/Stderr -> WebSocket)
             let (tx_out, mut rx_out) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
             let tx_err = tx_out.clone();
+            let tx_in_for_dsr = tx_in.clone();
+            let tx_in_for_dsr_err = tx_in.clone();
 
             tokio::spawn(async move {
                 let mut buf = [0u8; 1024];
+                // DSR cursor position query: ESC [ 6 n
+                const DSR_QUERY: &[u8] = b"\x1b[6n";
+                // DSR status query: ESC [ 5 n
+                const DSR_STATUS_QUERY: &[u8] = b"\x1b[5n";
                 loop {
                     match stdout.read(&mut buf).await {
                         Ok(0) => {
@@ -1807,8 +1813,25 @@ impl SandboxService for BubblewrapService {
                             break;
                         }
                         Ok(n) => {
-                            info!("Read from stdout: {:?}", String::from_utf8_lossy(&buf[..n]));
-                            if tx_out.send(buf[..n].to_vec()).await.is_err() {
+                            let data = &buf[..n];
+                            info!("Read from stdout: {:?}", String::from_utf8_lossy(data));
+
+                            // Respond to DSR queries even without a PTY to avoid CLI timeouts.
+                            if data.windows(DSR_QUERY.len()).any(|w| w == DSR_QUERY) {
+                                let response = b"\x1b[1;1R".to_vec();
+                                info!("Detected DSR query, injecting cursor position response");
+                                let _ = tx_in_for_dsr.send(response).await;
+                            }
+                            if data
+                                .windows(DSR_STATUS_QUERY.len())
+                                .any(|w| w == DSR_STATUS_QUERY)
+                            {
+                                let response = b"\x1b[0n".to_vec();
+                                info!("Detected DSR status query, injecting OK response");
+                                let _ = tx_in_for_dsr.send(response).await;
+                            }
+
+                            if tx_out.send(data.to_vec()).await.is_err() {
                                 break;
                             }
                         }
@@ -1822,6 +1845,10 @@ impl SandboxService for BubblewrapService {
 
             tokio::spawn(async move {
                 let mut buf = [0u8; 1024];
+                // DSR cursor position query: ESC [ 6 n
+                const DSR_QUERY: &[u8] = b"\x1b[6n";
+                // DSR status query: ESC [ 5 n
+                const DSR_STATUS_QUERY: &[u8] = b"\x1b[5n";
                 loop {
                     match stderr.read(&mut buf).await {
                         Ok(0) => {
@@ -1829,8 +1856,25 @@ impl SandboxService for BubblewrapService {
                             break;
                         }
                         Ok(n) => {
-                            info!("Read from stderr: {:?}", String::from_utf8_lossy(&buf[..n]));
-                            if tx_err.send(buf[..n].to_vec()).await.is_err() {
+                            let data = &buf[..n];
+                            info!("Read from stderr: {:?}", String::from_utf8_lossy(data));
+
+                            // Respond to DSR queries even without a PTY to avoid CLI timeouts.
+                            if data.windows(DSR_QUERY.len()).any(|w| w == DSR_QUERY) {
+                                let response = b"\x1b[1;1R".to_vec();
+                                info!("Detected DSR query on stderr, injecting cursor position response");
+                                let _ = tx_in_for_dsr_err.send(response).await;
+                            }
+                            if data
+                                .windows(DSR_STATUS_QUERY.len())
+                                .any(|w| w == DSR_STATUS_QUERY)
+                            {
+                                let response = b"\x1b[0n".to_vec();
+                                info!("Detected DSR status query on stderr, injecting OK response");
+                                let _ = tx_in_for_dsr_err.send(response).await;
+                            }
+
+                            if tx_err.send(data.to_vec()).await.is_err() {
                                 break;
                             }
                         }


### PR DESCRIPTION
mkdir -p /root/lifecycle
rm -f /root/workspace/.cmux/tmp/codex-turns.jsonl /root/workspace/codex-turns.jsonl /root/workspace/logs/codex-turns.jsonl /tmp/codex-turns.jsonl /tmp/cmux/codex-turns.jsonl /root/lifecycle/codex-turns.jsonl || true
'bunx' '@openai/codex@latest' '--model' 'gpt-5.2-codex' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '-c' 'model_reasoning_effort="xhigh"' '/root/prompt//root/prompt/image.png.pngthe cursor position could not be read within a normal duration Error when we run codex agent sometimes... why is it taking longer than normal?'
root@morphvm:~/workspace# mkdir -p ~/.codex
root@morphvm:~/workspace# mkdir -p /root/lifecycle
root@morphvm:~/workspace# rm -f /root/workspace/.cmux/tmp/codex-turns.jsonl /root/workspace/codex-turns.jsonl /root/workspace/logs/codex-turns.jsonl /tmp/codex-turns.jsonl /tmp/cmux/codex-turns.jsonl /root/lifecycle/codex-turns.jsonl || true
root@morphvm:~/workspace# 'bunx' '@openai/codex@latest' '--model' 'gpt-5.2-codex' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '-c' 'model_reasoning_effort="xhigh"' '/root/prompt//root/prompt/image.png.pngthe cursor position could not be read within a normal duration Error when we run codex agent sometimes... why is it taking longer than normal?'
Error: The cursor position could not be read within a normal durationwe need to fix this issue with codex agent...