### PR TITLE
Investigate missing preview jobs and ensure persistence

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -422,7 +422,7 @@ export type SetupInstanceBody = {
     instanceId?: string;
     selectedRepos?: Array<string>;
     ttlSeconds?: number;
-    snapshotId?: string | ('snapshot_m0lw91ep' | 'snapshot_hnwrt0re' | 'snapshot_pcmfvjra');
+    snapshotId?: string | ('snapshot_phq07yhf' | 'snapshot_qrql1trf' | 'snapshot_pcmfvjra');
 };
 
 export type InstanceInfo = {


### PR DESCRIPTION
a lot of my preview test jobs disappeared for some reason. we need to figure out why they disappeared.. they should still be stored in convex? even if the sandbox is closed now or timed out. we still need to show their screenshots and etc. that information should have been persisted in our convex database