### PR TITLE
Show loading indicator during update restart

### DIFF
--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -60,6 +60,15 @@ function useAutoUpdateNotifications() {
     const showToast = (version: string | null) => {
       const versionLabel = version ? ` (${version})` : "";
 
+      const showRestartingToast = () => {
+        toast.loading("Restarting cmux...", {
+          id: AUTO_UPDATE_TOAST_ID,
+          duration: Infinity,
+          description: "Please wait while the update is being applied.",
+          className: "select-none",
+        });
+      };
+
       toast("New version available", {
         id: AUTO_UPDATE_TOAST_ID,
         duration: 30000,
@@ -69,6 +78,7 @@ function useAutoUpdateNotifications() {
           ? {
               label: "Restart now",
               onClick: () => {
+                showRestartingToast();
                 void cmux.autoUpdate
                   .install()
                   .then((result) => {
@@ -77,7 +87,7 @@ function useAutoUpdateNotifications() {
                         result.reason === "not-packaged"
                           ? "Updates can only be applied from the packaged app."
                           : "Failed to restart. Try again from the menu.";
-                      toast.error(reason);
+                      toast.error(reason, { id: AUTO_UPDATE_TOAST_ID });
                     }
                   })
                   .catch((error) => {
@@ -85,7 +95,9 @@ function useAutoUpdateNotifications() {
                       "Failed to trigger auto-update install",
                       error
                     );
-                    toast.error("Couldn't restart. Try again from the menu.");
+                    toast.error("Couldn't restart. Try again from the menu.", {
+                      id: AUTO_UPDATE_TOAST_ID,
+                    });
                   });
               },
             }

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cmux",


### PR DESCRIPTION
after clicking restart to update in the toast, toast disappears, and there's like 5 seconds where nothing's happening (just seeing normal ui) and then the app restarts. make it so that it's much clearer that there's something happening