### PR TITLE
Add loading state for team access on signup

### DIFF
--- a/apps/client/src/contexts/convex/authJsonQueryOptions.ts
+++ b/apps/client/src/contexts/convex/authJsonQueryOptions.ts
@@ -10,6 +10,7 @@ export interface StackUserLike {
 
 // Refresh every 9 minutes to beat the ~10 minute Stack access token expiry window
 export const defaultAuthJsonRefreshInterval = 9 * 60 * 1000;
+const missingAuthJsonRefreshInterval = 2 * 1000;
 
 export function authJsonQueryOptions() {
   return queryOptions<AuthJson>({
@@ -20,7 +21,12 @@ export function authJsonQueryOptions() {
       const authJson = await user.getAuthJson();
       return authJson ?? null;
     },
-    refetchInterval: defaultAuthJsonRefreshInterval,
+    refetchInterval: (query) => {
+      const accessToken = query.state.data?.accessToken;
+      return accessToken
+        ? defaultAuthJsonRefreshInterval
+        : missingAuthJsonRefreshInterval;
+    },
     refetchIntervalInBackground: true,
   });
 }


### PR DESCRIPTION
there is a problem when user first creates an account and tries to click on their team, which loads right away, it doesn't load and says no auth token yet; delaying connect because the sync hasn't been completed via the webhook yet. this is a problem. how do we have a loading state after user press it and show like loading cmux dashboard... or something like that.. or just put it in the cmux loading state that we have.. i think second option is better. but we need to make sure its not a bug. it looks like buggy behavior right now