### PR TITLE
feat(ios): Add OpenAI Codex OAuth integration

### DIFF
--- a/ios-app/.gitignore
+++ b/ios-app/.gitignore
@@ -43,3 +43,6 @@ fastlane/test_output
 dev-docs/
 
 .sentryclirc
+
+# Local developer config (use LocalConfig.example.plist as template)
+Sources/Config/LocalConfig.plist

--- a/ios-app/Sources/Config/Environment.swift
+++ b/ios-app/Sources/Config/Environment.swift
@@ -12,6 +12,17 @@ enum Environment {
         #endif
     }
 
+    // MARK: - Local Config Override
+
+    /// Reads from LocalConfig.plist (gitignored) for per-developer overrides
+    private static let localConfig: [String: Any]? = {
+        guard let path = Bundle.main.path(forResource: "LocalConfig", ofType: "plist"),
+              let dict = NSDictionary(contentsOfFile: path) as? [String: Any] else {
+            return nil
+        }
+        return dict
+    }()
+
     // MARK: - Stack Auth
 
     var stackAuthProjectId: String {
@@ -35,6 +46,11 @@ enum Environment {
     // MARK: - Convex
 
     var convexURL: String {
+        // Check for local override first (from LocalConfig.plist)
+        if let override = Self.localConfig?["CONVEX_URL"] as? String, !override.isEmpty {
+            return override
+        }
+
         switch self {
         case .development:
             return "https://polite-canary-804.convex.cloud"

--- a/ios-app/Sources/Config/LocalConfig.example.plist
+++ b/ios-app/Sources/Config/LocalConfig.example.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+    Local developer configuration overrides.
+    Copy this file to LocalConfig.plist and customize for your environment.
+    LocalConfig.plist is gitignored.
+-->
+<dict>
+    <!-- Override the Convex URL for local development / preview deployments -->
+    <key>CONVEX_URL</key>
+    <string></string>
+</dict>
+</plist>

--- a/ios-app/Sources/ContentView.swift
+++ b/ios-app/Sources/ContentView.swift
@@ -66,6 +66,12 @@ struct SettingsView: View {
                 }
 
                 #if DEBUG
+                Section("External Accounts") {
+                    NavigationLink("OpenAI Codex") {
+                        CodexOAuthView()
+                    }
+                }
+
                 Section("Debug") {
                     Toggle("Show chat debug overlays", isOn: $showChatOverlays)
                     NavigationLink("Chat Keyboard Approaches") {

--- a/ios-app/Sources/Debug/CodexOAuthView.swift
+++ b/ios-app/Sources/Debug/CodexOAuthView.swift
@@ -1,0 +1,690 @@
+import SwiftUI
+import WebKit
+import CryptoKit
+import ConvexMobile
+import Combine
+
+// MARK: - Codex OAuth View
+
+struct CodexOAuthView: View {
+    @StateObject private var authManager = AuthManager.shared
+    @StateObject private var convex = ConvexClientManager.shared
+    @State private var codexStatus: CodexStatus = .loading
+    @State private var showWebView = false
+    @State private var authURL: URL?
+    @State private var codeVerifier: String?
+    @State private var errorMessage: String?
+    @State private var isExchangingCode = false
+    @State private var currentTeamId: String?
+
+    var body: some View {
+        List {
+            Section {
+                statusRow
+            }
+
+            if let error = errorMessage {
+                Section {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
+            }
+
+            Section {
+                switch codexStatus {
+                case .loading:
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                case .notLinked:
+                    Button("Link OpenAI Codex Account") {
+                        startOAuth()
+                    }
+                    .frame(maxWidth: .infinity)
+                case .linked(let info):
+                    accountInfoRows(info)
+                    Button(role: .destructive) {
+                        Task { await unlinkAccount() }
+                    } label: {
+                        Text("Disconnect Account")
+                            .frame(maxWidth: .infinity)
+                    }
+                case .error:
+                    Button("Retry") {
+                        Task { await loadStatus() }
+                    }
+                }
+            }
+
+            Section("About") {
+                Text("Link your OpenAI account to use Codex CLI features through cmux. Your tokens are encrypted and stored securely on our servers, and refreshed automatically when needed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("cmux is not affiliated with, endorsed by, or sponsored by OpenAI.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .navigationTitle("OpenAI Codex")
+        .task {
+            await loadStatus()
+        }
+        .sheet(isPresented: $showWebView) {
+            if let url = authURL, let verifier = codeVerifier {
+                CodexOAuthWebView(
+                    url: url,
+                    codeVerifier: verifier,
+                    onSuccess: { tokens in
+                        showWebView = false
+                        Task { await saveTokens(tokens) }
+                    },
+                    onError: { error in
+                        showWebView = false
+                        errorMessage = error
+                    }
+                )
+            }
+        }
+        .overlay {
+            if isExchangingCode {
+                ZStack {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.2)
+                            .tint(.primary)
+
+                        Text("Linking Account")
+                            .font(.headline)
+
+                        Text("Saving your credentials securely...")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(24)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+                    .shadow(color: .black.opacity(0.1), radius: 10, y: 5)
+                }
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: isExchangingCode)
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        HStack {
+            Image(systemName: statusIcon)
+                .foregroundColor(statusColor)
+            Text(statusText)
+            Spacer()
+        }
+    }
+
+    private var statusIcon: String {
+        switch codexStatus {
+        case .loading: return "circle.dotted"
+        case .notLinked: return "person.badge.plus"
+        case .linked: return "checkmark.circle.fill"
+        case .error: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var statusColor: Color {
+        switch codexStatus {
+        case .loading: return .secondary
+        case .notLinked: return .secondary
+        case .linked: return .green
+        case .error: return .red
+        }
+    }
+
+    private var statusText: String {
+        switch codexStatus {
+        case .loading: return "Checking status..."
+        case .notLinked: return "Not linked"
+        case .linked: return "Linked"
+        case .error: return "Error loading status"
+        }
+    }
+
+    @ViewBuilder
+    private func accountInfoRows(_ info: CodexAccountInfo) -> some View {
+        if let email = info.email {
+            HStack {
+                Text("Email")
+                Spacer()
+                Text(email)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if let accountId = info.accountId {
+            HStack {
+                Text("Account ID")
+                Spacer()
+                Text(String(accountId.prefix(12)) + "...")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if let planType = info.planType {
+            HStack {
+                Text("Plan")
+                Spacer()
+                Text(planType.capitalized)
+                    .foregroundStyle(planType == "pro" ? .blue : .secondary)
+            }
+        }
+        HStack {
+            Text("Proxy Token")
+            Spacer()
+            Text(info.proxyToken)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - OAuth Configuration
+
+    private let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
+    private let issuer = "https://auth.openai.com"
+    private let redirectUri = "http://localhost:1455/auth/callback"
+
+    // MARK: - Actions
+
+    private func loadStatus() async {
+        // First get the user's team membership
+        guard let teamId = await getFirstTeamId() else {
+            codexStatus = .notLinked
+            errorMessage = "No team found. Please join a team first."
+            return
+        }
+        currentTeamId = teamId
+
+        // Now check for Codex tokens using subscription
+        var cancellable: AnyCancellable?
+        cancellable = convex.client
+            .subscribe(to: "codexTokens:get", with: ["teamSlugOrId": teamId], yielding: CodexTokensResponse?.self)
+            .first()
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case .failure(let error):
+                        print("[CodexOAuth] Error loading status: \(error)")
+                        self.codexStatus = .error
+                    }
+                    cancellable?.cancel()
+                },
+                receiveValue: { tokens in
+                    if let tokens = tokens {
+                        let userId = self.authManager.currentUser?.id ?? "unknown"
+                        let proxyToken = "cmux_\(userId)_\(teamId)"
+                        self.codexStatus = .linked(CodexAccountInfo(
+                            email: tokens.email,
+                            accountId: tokens.accountId,
+                            planType: tokens.planType,
+                            proxyToken: proxyToken
+                        ))
+                    } else {
+                        self.codexStatus = .notLinked
+                    }
+                }
+            )
+    }
+
+    private func getFirstTeamId() async -> String? {
+        return await withCheckedContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = convex.client
+                .subscribe(to: "teams:listTeamMemberships", yielding: [TeamMembershipForCodex].self)
+                .first()
+                .receive(on: DispatchQueue.main)
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure = completion {
+                            continuation.resume(returning: nil)
+                        }
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { memberships in
+                        continuation.resume(returning: memberships.first?.teamId)
+                    }
+                )
+        }
+    }
+
+    private func startOAuth() {
+        errorMessage = nil
+
+        let verifier = generateCodeVerifier()
+        let challenge = generateCodeChallenge(from: verifier)
+        let state = generateState()
+
+        var components = URLComponents(string: "\(issuer)/oauth/authorize")!
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "redirect_uri", value: redirectUri),
+            URLQueryItem(name: "scope", value: "openid profile email offline_access"),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "id_token_add_organizations", value: "true"),
+            URLQueryItem(name: "codex_cli_simplified_flow", value: "true"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "originator", value: "cmux"),
+        ]
+
+        guard let url = components.url else {
+            errorMessage = "Failed to build auth URL"
+            return
+        }
+
+        codeVerifier = verifier
+        authURL = url
+        showWebView = true
+    }
+
+    private func saveTokens(_ tokens: CodexTokenResponse) async {
+        guard let teamId = currentTeamId else {
+            errorMessage = "No team selected"
+            return
+        }
+
+        isExchangingCode = true
+        defer { isExchangingCode = false }
+
+        // Parse JWT to extract claims
+        var accountId: String?
+        var planType: String?
+        var email: String?
+
+        if let claims = parseJWT(tokens.access_token) {
+            if let auth = claims["https://api.openai.com/auth"] as? [String: Any] {
+                accountId = auth["chatgpt_account_id"] as? String
+                planType = auth["chatgpt_plan_type"] as? String
+            }
+            if let profile = claims["https://api.openai.com/profile"] as? [String: Any] {
+                email = profile["email"] as? String
+            }
+        }
+
+        // Call mutation via HTTP action workaround or direct mutation
+        // For now, we'll use a simpler approach - make direct HTTP call to save
+        do {
+            try await saveTokensViaHTTP(
+                teamId: teamId,
+                accessToken: tokens.access_token,
+                refreshToken: tokens.refresh_token ?? "",
+                idToken: tokens.id_token,
+                accountId: accountId,
+                planType: planType,
+                email: email,
+                expiresIn: tokens.expires_in ?? 864000
+            )
+            await loadStatus()
+        } catch {
+            print("[CodexOAuth] Error saving tokens: \(error)")
+            errorMessage = "Failed to save tokens: \(error.localizedDescription)"
+        }
+    }
+
+    private func saveTokensViaHTTP(
+        teamId: String,
+        accessToken: String,
+        refreshToken: String,
+        idToken: String?,
+        accountId: String?,
+        planType: String?,
+        email: String?,
+        expiresIn: Int
+    ) async throws {
+        // Use Convex mutation through the client
+        // Since ConvexMobile doesn't have a direct mutation call in subscript style,
+        // we need to use the action approach or call the Convex HTTP endpoint
+
+        // Use the configured Convex URL from Environment
+        let convexUrl = Environment.current.convexURL
+
+        let token = try await authManager.getAccessToken()
+
+        var request = URLRequest(url: URL(string: "\(convexUrl)/api/mutation")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        var args: [String: Any] = [
+            "teamSlugOrId": teamId,
+            "accessToken": accessToken,
+            "refreshToken": refreshToken,
+            "expiresIn": expiresIn
+        ]
+        if let idToken = idToken { args["idToken"] = idToken }
+        if let accountId = accountId { args["accountId"] = accountId }
+        if let planType = planType { args["planType"] = planType }
+        if let email = email { args["email"] = email }
+
+        let body: [String: Any] = [
+            "path": "codexTokens:save",
+            "args": args
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CodexOAuthError.invalidResponse
+        }
+
+        if httpResponse.statusCode != 200 {
+            let errorText = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw CodexOAuthError.saveFailed(errorText)
+        }
+    }
+
+    private func unlinkAccount() async {
+        guard let teamId = currentTeamId else {
+            return
+        }
+
+        do {
+            let convexUrl = Environment.current.convexURL
+            let token = try await authManager.getAccessToken()
+
+            var request = URLRequest(url: URL(string: "\(convexUrl)/api/mutation")!)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+            let body: [String: Any] = [
+                "path": "codexTokens:remove",
+                "args": ["teamSlugOrId": teamId]
+            ]
+
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                codexStatus = .notLinked
+            }
+        } catch {
+            print("[CodexOAuth] Error unlinking: \(error)")
+            errorMessage = "Failed to unlink: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - PKCE
+
+    private func generateCodeVerifier() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+            .prefix(43)
+            .description
+    }
+
+    private func generateCodeChallenge(from verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hash = SHA256.hash(data: data)
+        return Data(hash).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private func generateState() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - JWT Parsing
+
+    private func parseJWT(_ token: String) -> [String: Any]? {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3 else { return nil }
+
+        var base64 = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        while base64.count % 4 != 0 {
+            base64 += "="
+        }
+
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        return json
+    }
+}
+
+// MARK: - Models
+
+private enum CodexStatus {
+    case loading
+    case notLinked
+    case linked(CodexAccountInfo)
+    case error
+}
+
+private struct CodexAccountInfo {
+    let email: String?
+    let accountId: String?
+    let planType: String?
+    let proxyToken: String
+}
+
+private struct CodexTokensResponse: Decodable {
+    let email: String?
+    let accountId: String?
+    let planType: String?
+}
+
+private struct TeamMembershipForCodex: Decodable {
+    let teamId: String
+}
+
+struct CodexTokenResponse: Codable {
+    let access_token: String
+    let refresh_token: String?
+    let id_token: String?
+    let expires_in: Int?
+}
+
+enum CodexOAuthError: Error {
+    case invalidResponse
+    case saveFailed(String)
+}
+
+// MARK: - OAuth WebView
+
+struct CodexOAuthWebView: View {
+    let url: URL
+    let codeVerifier: String
+    let onSuccess: (CodexTokenResponse) -> Void
+    let onError: (String) -> Void
+
+    @State private var isLoading = true
+
+    var body: some View {
+        ZStack {
+            CodexOAuthWebViewRepresentable(
+                url: url,
+                codeVerifier: codeVerifier,
+                isLoading: $isLoading,
+                onSuccess: onSuccess,
+                onError: onError
+            )
+
+            if isLoading {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                    Text("Loading OpenAI sign-in...")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.regularMaterial)
+            }
+        }
+    }
+}
+
+struct CodexOAuthWebViewRepresentable: UIViewRepresentable {
+    let url: URL
+    let codeVerifier: String
+    @Binding var isLoading: Bool
+    let onSuccess: (CodexTokenResponse) -> Void
+    let onError: (String) -> Void
+
+    private let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
+    private let issuer = "https://auth.openai.com"
+    private let redirectUri = "http://localhost:1455/auth/callback"
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent() // Ephemeral session
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        let parent: CodexOAuthWebViewRepresentable
+
+        init(_ parent: CodexOAuthWebViewRepresentable) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            DispatchQueue.main.async {
+                self.parent.isLoading = false
+            }
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            guard let url = navigationAction.request.url else {
+                decisionHandler(.allow)
+                return
+            }
+
+            print("[CodexOAuth] Navigation to: \(url)")
+
+            // Intercept localhost redirect
+            if url.host == "localhost" && url.port == 1455 {
+                print("[CodexOAuth] Intercepted callback URL!")
+                decisionHandler(.cancel)
+
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+
+                // Check for error
+                if let error = components?.queryItems?.first(where: { $0.name == "error" })?.value {
+                    let desc = components?.queryItems?.first(where: { $0.name == "error_description" })?.value
+                    parent.onError("\(error): \(desc ?? "Unknown error")")
+                    return
+                }
+
+                // Get authorization code
+                guard let code = components?.queryItems?.first(where: { $0.name == "code" })?.value else {
+                    parent.onError("No authorization code received")
+                    return
+                }
+
+                print("[CodexOAuth] Got code: \(code.prefix(20))...")
+
+                Task {
+                    await exchangeCode(code)
+                }
+                return
+            }
+
+            decisionHandler(.allow)
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            // Ignore localhost connection errors - we intercept before they happen
+            if (error as NSError).domain == NSURLErrorDomain &&
+               (error as NSError).code == NSURLErrorCannotConnectToHost {
+                return
+            }
+            parent.onError("Navigation failed: \(error.localizedDescription)")
+        }
+
+        private func exchangeCode(_ code: String) async {
+            let tokenURL = URL(string: "\(parent.issuer)/oauth/token")!
+
+            var request = URLRequest(url: tokenURL)
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+            let body = [
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": parent.redirectUri,
+                "client_id": parent.clientId,
+                "code_verifier": parent.codeVerifier,
+            ]
+
+            request.httpBody = body
+                .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+                .joined(separator: "&")
+                .data(using: .utf8)
+
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    await MainActor.run { parent.onError("Invalid response") }
+                    return
+                }
+
+                if httpResponse.statusCode != 200 {
+                    let errorText = String(data: data, encoding: .utf8) ?? "Unknown error"
+                    await MainActor.run { parent.onError("Token exchange failed: \(httpResponse.statusCode) - \(errorText)") }
+                    return
+                }
+
+                let tokens = try JSONDecoder().decode(CodexTokenResponse.self, from: data)
+
+                await MainActor.run {
+                    parent.onSuccess(tokens)
+                }
+
+            } catch {
+                await MainActor.run {
+                    parent.onError("Network error: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CodexOAuthView()
+    }
+}

--- a/ios-app/cmux.xcodeproj/project.pbxproj
+++ b/ios-app/cmux.xcodeproj/project.pbxproj
@@ -16,12 +16,15 @@
 		35DD00750B94902B2CF0CDF6 /* ShortThreadLayoutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F680356269E010CC8DDF11B /* ShortThreadLayoutUITests.swift */; };
 		361B05C412BFA1E44BDCAD39 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BA577D046F9E3C331F4986 /* Models.swift */; };
 		3A6FD7E27F3723EF627744A9 /* StackAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2848CBEF6B2A130DF4C9D2 /* StackAuthProvider.swift */; };
+		3D80A48D3964369CC4BAB7DB /* LocalConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1946CEF6B86E10F327352AE4 /* LocalConfig.plist */; };
 		5479917679421FDD8C3C2995 /* ChatFix4_ScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2371E50D0E3E362104DE9177 /* ChatFix4_ScrollViewDelegate.swift */; };
 		6A5960808C1C40C3C1DEEA2E /* ChatFix5_ReducePadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74190A1F266AB5E2C38455 /* ChatFix5_ReducePadding.swift */; };
 		6ED3832765AAB169F7254054 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8CDE2F6CDCAB37E3107C76 /* ContentView.swift */; };
+		7BCA02347A773584F73D8374 /* CodexOAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298CBAF0C277F506858D625E /* CodexOAuthView.swift */; };
 		7E0146088B71697EB516611F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B005E08ACAAF83F6A13F9D8C /* Assets.xcassets */; };
 		8030869706BE8FD94533D58A /* ChatApproachI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9788FAF68766BFAA9A451A8D /* ChatApproachI.swift */; };
 		83357B66D3EF312F35A86BB1 /* CMuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E20F7A729081D044495605 /* CMuxApp.swift */; };
+		88192500271447E51CF6B653 /* LocalConfig.example.plist in Resources */ = {isa = PBXBuildFile; fileRef = D01F9176DE666BAE97AA807B /* LocalConfig.example.plist */; };
 		8B6A74AEAD4EC07300279462 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 2AB0CD82D816F53E55B1E103 /* Sentry */; };
 		8C11E78F09BA811A5EBC33CC /* ChatFix1MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296ACD1C15CC2E35AE162CC /* ChatFix1MainView.swift */; };
 		8DF015A1566E9F288F30C460 /* DebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAECD9944A3CB4779597B8A3 /* DebugSettings.swift */; };
@@ -51,9 +54,11 @@
 
 /* Begin PBXFileReference section */
 		0BE5CB8A89417C399DB8D166 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		1946CEF6B86E10F327352AE4 /* LocalConfig.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = LocalConfig.plist; sourceTree = "<group>"; };
 		1B8CDE2F6CDCAB37E3107C76 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1C74190A1F266AB5E2C38455 /* ChatFix5_ReducePadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFix5_ReducePadding.swift; sourceTree = "<group>"; };
 		2371E50D0E3E362104DE9177 /* ChatFix4_ScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFix4_ScrollViewDelegate.swift; sourceTree = "<group>"; };
+		298CBAF0C277F506858D625E /* CodexOAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexOAuthView.swift; sourceTree = "<group>"; };
 		2DEEADB25149C285A0422125 /* StackAuthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAuthClient.swift; sourceTree = "<group>"; };
 		38A50394379F40101C8A95FC /* ChatFix1_ContentInsetNever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFix1_ContentInsetNever.swift; sourceTree = "<group>"; };
 		4296ACD1C15CC2E35AE162CC /* ChatFix1MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFix1MainView.swift; sourceTree = "<group>"; };
@@ -74,6 +79,7 @@
 		BF2848CBEF6B2A130DF4C9D2 /* StackAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackAuthProvider.swift; sourceTree = "<group>"; };
 		C18818FD4536DFDC6D6FA1D5 /* KeyboardSyncUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSyncUITests.swift; sourceTree = "<group>"; };
 		CAECD9944A3CB4779597B8A3 /* DebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettings.swift; sourceTree = "<group>"; };
+		D01F9176DE666BAE97AA807B /* LocalConfig.example.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = LocalConfig.example.plist; sourceTree = "<group>"; };
 		D8732D7AB61D4190BACAAB03 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		D9BA577D046F9E3C331F4986 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		E6A61F42F94D17993038F637 /* ConvexTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvexTestView.swift; sourceTree = "<group>"; };
@@ -139,6 +145,8 @@
 			isa = PBXGroup;
 			children = (
 				D8732D7AB61D4190BACAAB03 /* Environment.swift */,
+				D01F9176DE666BAE97AA807B /* LocalConfig.example.plist */,
+				1946CEF6B86E10F327352AE4 /* LocalConfig.plist */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -154,6 +162,7 @@
 				8B4E7CFD0EE433DFB9F348A0 /* ChatFix3_AdjustedContentInset.swift */,
 				2371E50D0E3E362104DE9177 /* ChatFix4_ScrollViewDelegate.swift */,
 				1C74190A1F266AB5E2C38455 /* ChatFix5_ReducePadding.swift */,
+				298CBAF0C277F506858D625E /* CodexOAuthView.swift */,
 				E6A61F42F94D17993038F637 /* ConvexTestView.swift */,
 				B87CA70AD58D024077E85845 /* DebugInputBar.swift */,
 			);
@@ -276,6 +285,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				7E0146088B71697EB516611F /* Assets.xcassets in Resources */,
+				88192500271447E51CF6B653 /* LocalConfig.example.plist in Resources */,
+				3D80A48D3964369CC4BAB7DB /* LocalConfig.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,6 +310,7 @@
 				6A5960808C1C40C3C1DEEA2E /* ChatFix5_ReducePadding.swift in Sources */,
 				F6098AD7DB98B95086FD932A /* ChatKeyboardContainer.swift in Sources */,
 				0BEB4F58E65C35CE4E4EE942 /* ChatView.swift in Sources */,
+				7BCA02347A773584F73D8374 /* CodexOAuthView.swift in Sources */,
 				6ED3832765AAB169F7254054 /* ContentView.swift in Sources */,
 				E9D2BFC8E39842DB720CAD9D /* ConversationListView.swift in Sources */,
 				F024C0FD39B57208895F9153 /* ConvexClient.swift in Sources */,

--- a/ios-app/project.yml
+++ b/ios-app/project.yml
@@ -2,7 +2,7 @@ name: cmux
 options:
   bundleIdPrefix: dev.cmux
   deploymentTarget:
-    iOS: "17.0"
+    iOS: "26.0"
   xcodeVersion: "16.0"
 
 configs:

--- a/packages/convex/_shared/convex-env.ts
+++ b/packages/convex/_shared/convex-env.ts
@@ -18,7 +18,6 @@ export const env = createEnv({
     CMUX_CONVERSATION_JWT_SECRET: z.string().min(1).optional(),
     // ACP (Agent Client Protocol) settings
     ACP_CALLBACK_SECRET: z.string().min(1).optional(),
-    ACP_SNAPSHOT_ID: z.string().min(1).optional(),
     CONVEX_SITE_URL: z.string().min(1).optional(),
     OPENAI_API_KEY: z.string().min(1).optional(),
     ANTHROPIC_API_KEY: z.string().min(1).optional(),

--- a/packages/convex/convex/acp.ts
+++ b/packages/convex/convex/acp.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { SignJWT } from "jose";
+import { getDefaultSnapshotId, type SandboxProvider } from "@cmux/shared/convex-safe";
 import { env } from "../_shared/convex-env";
 import { getDefaultSandboxProvider } from "../_shared/sandbox-providers";
 import { getTeamId } from "../_shared/team";
@@ -485,8 +486,8 @@ export const spawnSandbox = internalAction({
     // Get the sandbox provider (currently supports morph, freestyle, daytona)
     const provider = getDefaultSandboxProvider();
 
-    // Get snapshot ID from config
-    const snapshotId = env.ACP_SNAPSHOT_ID ?? "snap_default";
+    // Get snapshot ID from sandbox-snapshots.json based on provider
+    const snapshotId = getDefaultSnapshotId(provider.name as SandboxProvider) ?? "snap_default";
 
     // Create sandbox record first to get ID for JWT
     const sandboxId = await ctx.runMutation(internal.acpSandboxes.create, {

--- a/packages/convex/convex/auth.config.ts
+++ b/packages/convex/convex/auth.config.ts
@@ -1,19 +1,20 @@
-import { env } from "../_shared/convex-env";
+// Use process.env directly to avoid triggering detection of all env vars from convex-env.ts
+const STACK_PROJECT_ID = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
 
 export default {
   providers: [
     {
       type: "customJwt",
-      applicationID: env.NEXT_PUBLIC_STACK_PROJECT_ID,
-      issuer: `https://api.stack-auth.com/api/v1/projects/${env.NEXT_PUBLIC_STACK_PROJECT_ID}`,
-      jwks: `https://api.stack-auth.com/api/v1/projects/${env.NEXT_PUBLIC_STACK_PROJECT_ID}/.well-known/jwks.json?include_anonymous=true`,
+      applicationID: STACK_PROJECT_ID,
+      issuer: `https://api.stack-auth.com/api/v1/projects/${STACK_PROJECT_ID}`,
+      jwks: `https://api.stack-auth.com/api/v1/projects/${STACK_PROJECT_ID}/.well-known/jwks.json?include_anonymous=true`,
       algorithm: "ES256",
     },
     {
       type: "customJwt",
-      applicationID: `${env.NEXT_PUBLIC_STACK_PROJECT_ID}:anon`,
-      issuer: `https://api.stack-auth.com/api/v1/projects-anonymous-users/${env.NEXT_PUBLIC_STACK_PROJECT_ID}`,
-      jwks: `https://api.stack-auth.com/api/v1/projects/${env.NEXT_PUBLIC_STACK_PROJECT_ID}/.well-known/jwks.json?include_anonymous=true`,
+      applicationID: `${STACK_PROJECT_ID}:anon`,
+      issuer: `https://api.stack-auth.com/api/v1/projects-anonymous-users/${STACK_PROJECT_ID}`,
+      jwks: `https://api.stack-auth.com/api/v1/projects/${STACK_PROJECT_ID}/.well-known/jwks.json?include_anonymous=true`,
       algorithm: "ES256",
     },
   ],

--- a/packages/shared/src/convex-safe.ts
+++ b/packages/shared/src/convex-safe.ts
@@ -13,4 +13,5 @@ export * from "./utils/reserved-cmux-ports";
 export * from "./utils/validate-exposed-ports";
 export * from "./screenshots/types";
 export * from "./screenshots/sanitize-markdown";
+export * from "./sandbox-snapshots";
 // Note: worker-schemas is excluded because it imports agentConfig which has Node.js dependencies


### PR DESCRIPTION
## Summary
- Add ability to link OpenAI Codex account from iOS app settings
- Tokens stored securely in Convex with automatic refresh via proxy endpoint
- Tested on physical iPhone with iOS 26

## Changes

### iOS App
- `CodexOAuthView.swift` - Full OAuth flow with WKWebView, PKCE, token exchange
- `LocalConfig.plist` pattern for per-developer Convex URL overrides (gitignored)
- "External Accounts" section in Settings debug menu
- Updated to iOS 26 deployment target

### Convex Backend
- `codexTokens` table for storing OAuth tokens per user/team
- `codexTokens.ts` mutations: get, save, remove, updateAfterRefresh, getByProxyToken
- `/api/oauth/codex/token` HTTP endpoint for Codex CLI refresh proxy
- Removed `ACP_SNAPSHOT_ID` env var, now uses `sandbox-snapshots.json`
- Fixed `auth.config.ts` to not require all env vars during deploy

## Test Plan
- [x] OAuth flow works on iOS simulator
- [x] OAuth flow works on physical iPhone
- [x] Tokens stored in Convex codexTokens table
- [ ] Deploy Convex changes to dev/prod
- [ ] Test refresh proxy endpoint with Codex CLI