### PR TITLE
Set CODEX_API_KEY alongside OPENAI_API_KEY to skip Codex sign-in screen

### DIFF
--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -37,9 +37,12 @@ export function applyCodexApiKeys(
   }
 
   // Fallback: inject OPENAI_API_KEY as environment variable
+  // Also set CODEX_API_KEY to the same value to skip the sign-in screen
+  // (OPENAI_API_KEY only pre-fills the input, CODEX_API_KEY bypasses it entirely)
   const openaiKey = keys.OPENAI_API_KEY;
   if (openaiKey) {
     env.OPENAI_API_KEY = openaiKey;
+    env.CODEX_API_KEY = openaiKey;
   }
 
   return { files, env };


### PR DESCRIPTION
## Summary
- When using `OPENAI_API_KEY` to authenticate with Codex CLI, also set `CODEX_API_KEY` to the same value
- This bypasses the sign-in screen entirely

## Background
In Codex CLI, these environment variables behave differently:
- `OPENAI_API_KEY` - Only pre-fills the API key input field during onboarding, still shows sign-in screen
- `CODEX_API_KEY` - Automatically authenticates and skips the sign-in screen entirely

By setting both to the same value, users don't have to interact with the sign-in flow.

## Test plan
- [ ] Spawn a Codex agent with `OPENAI_API_KEY` configured
- [ ] Verify the sign-in screen is skipped and Codex starts directly