### PR TITLE
Align cloud workspace naming with local workspaces

### DIFF
--- a/apps/client/src/components/CommandBar.tsx
+++ b/apps/client/src/components/CommandBar.tsx
@@ -880,7 +880,7 @@ export function CommandBar({
         // Create task in Convex without task description (it's just a workspace)
         const { taskId } = await createTask({
           teamSlugOrId,
-          text: `Cloud Workspace: ${environmentName}`,
+          text: environmentName,
           projectFullName: undefined, // No repo for cloud environment workspaces
           baseBranch: undefined, // No branch for environments
           environmentId,
@@ -960,7 +960,7 @@ export function CommandBar({
         // Create task in Convex for repo-based cloud workspace
         const { taskId } = await createTask({
           teamSlugOrId,
-          text: `Cloud Workspace: ${projectFullName}`,
+          text: projectFullName,
           projectFullName,
           baseBranch: undefined,
           environmentId: undefined, // No environment for repo-based cloud workspaces

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -1745,6 +1745,7 @@ function TaskRunTreeInner({
         onArchiveToggle={onArchiveToggle}
         showRunNumbers={showRunNumbers}
         isLocalWorkspace={Boolean(isLocalWorkspaceRunEntry)}
+        isCloudWorkspace={Boolean(isCloudWorkspaceRunEntry)}
       />
     </div>
   );
@@ -1888,6 +1889,7 @@ interface TaskRunDetailsProps {
   onArchiveToggle: (runId: Id<"taskRuns">, archive: boolean) => void;
   showRunNumbers: boolean;
   isLocalWorkspace: boolean;
+  isCloudWorkspace: boolean;
 }
 
 function TaskRunDetails({
@@ -1904,6 +1906,7 @@ function TaskRunDetails({
   onArchiveToggle,
   showRunNumbers,
   isLocalWorkspace,
+  isCloudWorkspace,
 }: TaskRunDetailsProps) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -2141,13 +2144,15 @@ function TaskRunDetails({
         onReload={handleReloadVSCode}
       />
 
-      <TaskRunDetailLink
-        to="/$teamSlugOrId/task/$taskId/run/$runId/diff"
-        params={{ teamSlugOrId, taskId, runId: run._id }}
-        icon={<GitCompare className="w-3 h-3 mr-2 text-neutral-400" />}
-        label="Git diff"
-        indentLevel={indentLevel}
-      />
+      {!isCloudWorkspace ? (
+        <TaskRunDetailLink
+          to="/$teamSlugOrId/task/$taskId/run/$runId/diff"
+          params={{ teamSlugOrId, taskId, runId: run._id }}
+          icon={<GitCompare className="w-3 h-3 mr-2 text-neutral-400" />}
+          label="Git diff"
+          indentLevel={indentLevel}
+        />
+      ) : null}
 
       {!isLocalWorkspace ? (
         <TaskRunDetailLink

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -144,7 +144,7 @@ export function WorkspaceCreationButtons({
       // Create task in Convex with environment name
       const { taskId } = await createTask({
         teamSlugOrId,
-        text: `Cloud Workspace: ${environmentName}`,
+        text: environmentName,
         projectFullName: undefined, // No repo for cloud environment workspaces
         baseBranch: undefined, // No branch for environments
         environmentId,


### PR DESCRIPTION
image.png for cloud workspaces, change the name to not include Cloud wrokspace and instaead it should be similar to how we are naming in local workspaces... also gt rid of the cloud-workspace thing its just adding unnecessary extra bit, we just needthe title and then the 4 things right below it... similar to local workspace except we also have git diff browser and terminal....................... except we just want vscode, browser and terminal, no need for git diff...