### PR TITLE
Prototype dashboard prewarming morph instances

### DIFF
--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -17,6 +17,8 @@ import {
   type CreateLocalWorkspaceResponse,
   CreateCloudWorkspaceSchema,
   type CreateCloudWorkspaceResponse,
+  PrewarmCloudSandboxSchema,
+  type PrewarmCloudSandboxResponse,
   type AvailableEditors,
   type FileInfo,
   isLoopbackHostname,
@@ -27,6 +29,7 @@ import {
   type PullRequestActionResult,
   type StoredPullRequestInfo,
 } from "@cmux/shared/pull-request-state";
+import { parseGithubRepoUrl } from "@cmux/shared/utils/parse-github-repo-url";
 import fuzzysort from "fuzzysort";
 import { parse as parseDotenv } from "dotenv";
 import { minimatch } from "minimatch";
@@ -52,6 +55,7 @@ import { serverLogger } from "./utils/fileLogger";
 import { getGitHubOAuthToken } from "./utils/getGitHubToken";
 import { createDraftPr, fetchPrDetail } from "./utils/githubPr";
 import { getOctokit } from "./utils/octokit";
+import { prewarmCloudSandboxManager } from "./utils/prewarmCloudSandboxes";
 import {
   checkAllProvidersStatus,
   checkAllProvidersStatusWebMode,
@@ -62,6 +66,7 @@ import { extractSandboxStartError } from "./utils/sandboxErrors";
 import { getWwwClient } from "./utils/wwwClient";
 import { getWwwOpenApiModule } from "./utils/wwwOpenApiModule";
 import { DockerVSCodeInstance } from "./vscode/DockerVSCodeInstance";
+import type { PrewarmedSandboxInfo } from "./vscode/VSCodeInstance";
 import {
   getVSCodeServeWebBaseUrl,
   getVSCodeServeWebPort,
@@ -262,6 +267,108 @@ export function setupSocketHandlers(
       runWithAuth(currentAuthToken, currentAuthHeaderJson, () => {
         callback?.({ ok: true });
       });
+    });
+
+    socket.on(
+      "prewarm-cloud-sandbox",
+      async (rawData, callback?: (response: PrewarmCloudSandboxResponse) => void) => {
+        if (!callback) {
+          return;
+        }
+
+        try {
+          const data = PrewarmCloudSandboxSchema.parse(rawData);
+          const hasScripts = await (async () => {
+            try {
+              if (data.environmentId) {
+                const environment = await getConvex().query(
+                  api.environments.get,
+                  {
+                    teamSlugOrId: data.teamSlugOrId,
+                    id: data.environmentId,
+                  }
+                );
+                const maintenanceScript = environment?.maintenanceScript ?? "";
+                const devScript = environment?.devScript ?? "";
+                return (
+                  maintenanceScript.trim().length > 0 ||
+                  devScript.trim().length > 0
+                );
+              }
+
+              if (data.repoUrl) {
+                const parsed = parseGithubRepoUrl(data.repoUrl);
+                if (!parsed) {
+                  return false;
+                }
+                const workspaceConfig = await getConvex().query(
+                  api.workspaceConfigs.get,
+                  {
+                    teamSlugOrId: data.teamSlugOrId,
+                    projectFullName: parsed.fullName,
+                  }
+                );
+                const maintenanceScript =
+                  workspaceConfig?.maintenanceScript ?? "";
+                return maintenanceScript.trim().length > 0;
+              }
+
+              return false;
+            } catch (error) {
+              console.error(
+                "[Prewarm] Failed to check scripts for prewarm",
+                error
+              );
+              serverLogger.error(
+                "[Prewarm] Failed to check scripts for prewarm",
+                error
+              );
+              return true;
+            }
+          })();
+
+          if (hasScripts) {
+            callback({
+              success: false,
+              status: "failed",
+              error: "Prewarm skipped for scripted environments",
+            });
+            return;
+          }
+
+          const status = await prewarmCloudSandboxManager.requestPrewarm(
+            socket.id,
+            {
+              teamSlugOrId: data.teamSlugOrId,
+              repoUrl: data.repoUrl,
+              branch: data.branch,
+              environmentId: data.environmentId,
+            }
+          );
+
+          callback({
+            success: status.status !== "failed",
+            status: status.status,
+            instanceId: status.instanceId,
+            error: status.error,
+          });
+        } catch (error) {
+          console.error("[Prewarm] Failed to start prewarm request", error);
+          const message = error instanceof Error ? error.message : String(error);
+          callback({ success: false, status: "failed", error: message });
+        }
+      }
+    );
+
+    socket.on("disconnect", () => {
+      void prewarmCloudSandboxManager
+        .cancelPrewarm(socket.id, "socket-disconnect")
+        .catch((error) => {
+          serverLogger.error(
+            "[Prewarm] Failed to cancel prewarm on disconnect",
+            error
+          );
+        });
     });
 
     // Rust N-API test endpoint
@@ -661,6 +768,87 @@ export function setupSocketHandlers(
             // Spawn all agents in parallel
             // - If taskRunIds provided, uses pre-created runs (fast path)
             // - If branchNames generated above, passes them to avoid re-generating
+            let prewarmedSandboxes: PrewarmedSandboxInfo[] | undefined;
+
+            if (taskData.isCloudMode) {
+              const target = taskData.environmentId
+                ? {
+                    teamSlugOrId: safeTeam,
+                    environmentId: taskData.environmentId,
+                  }
+                : taskData.repoUrl && taskData.branch
+                  ? {
+                      teamSlugOrId: safeTeam,
+                      repoUrl: taskData.repoUrl,
+                      branch: taskData.branch,
+                    }
+                  : null;
+
+              if (target) {
+                const hasScripts = await (async () => {
+                  try {
+                    if (taskData.environmentId) {
+                      const environment = await getConvex().query(
+                        api.environments.get,
+                        {
+                          teamSlugOrId: safeTeam,
+                          id: taskData.environmentId,
+                        }
+                      );
+                      const maintenanceScript = environment?.maintenanceScript ?? "";
+                      const devScript = environment?.devScript ?? "";
+                      return (
+                        maintenanceScript.trim().length > 0 ||
+                        devScript.trim().length > 0
+                      );
+                    }
+
+                    const projectFullName = taskData.projectFullName;
+                    if (!projectFullName || projectFullName.startsWith("env:")) {
+                      return false;
+                    }
+
+                    const workspaceConfig = await getConvex().query(
+                      api.workspaceConfigs.get,
+                      {
+                        teamSlugOrId: safeTeam,
+                        projectFullName,
+                      }
+                    );
+
+                    const maintenanceScript =
+                      workspaceConfig?.maintenanceScript ?? "";
+                    return maintenanceScript.trim().length > 0;
+                  } catch (error) {
+                    console.error(
+                      "[Prewarm] Failed to check scripts; skipping prewarm",
+                      error
+                    );
+                    serverLogger.error(
+                      "[Prewarm] Failed to check scripts; skipping prewarm",
+                      error
+                    );
+                    return true;
+                  }
+                })();
+
+                if (hasScripts) {
+                  await prewarmCloudSandboxManager.cancelPrewarm(
+                    socket.id,
+                    "scripts-present"
+                  );
+                } else {
+                  const prewarmed = await prewarmCloudSandboxManager.claimPrewarm(
+                    socket.id,
+                    target
+                  );
+                  if (prewarmed) {
+                    prewarmedSandboxes = [prewarmed];
+                  }
+                }
+              }
+            }
+
             const agentResults = await spawnAllAgents(
               taskId,
               {
@@ -676,7 +864,8 @@ export function setupSocketHandlers(
                 theme: taskData.theme,
                 environmentId: taskData.environmentId,
               },
-              safeTeam
+              safeTeam,
+              prewarmedSandboxes
             );
 
             // Check if at least one agent spawned successfully

--- a/apps/server/src/utils/prewarmCloudSandboxes.ts
+++ b/apps/server/src/utils/prewarmCloudSandboxes.ts
@@ -1,0 +1,363 @@
+import type { Id } from "@cmux/convex/dataModel";
+import type { PrewarmedSandboxInfo } from "../vscode/VSCodeInstance";
+import { serverLogger } from "./fileLogger";
+import {
+  getAuthHeaderJson,
+  getAuthToken,
+  runWithAuth,
+} from "./requestContext";
+import { extractSandboxStartError } from "./sandboxErrors";
+import { getWwwClient } from "./wwwClient";
+import { getWwwOpenApiModule } from "./wwwOpenApiModule";
+
+const PREWARM_TTL_SECONDS = 20 * 60;
+const PREWARM_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+const PREWARM_CLAIM_TIMEOUT_MS = 30 * 1000;
+
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+type PrewarmEntryStatus = "starting" | "ready" | "failed";
+
+export type PrewarmTarget = {
+  teamSlugOrId: string;
+  repoUrl?: string;
+  branch?: string;
+  environmentId?: Id<"environments">;
+};
+
+export type PrewarmStatus = {
+  status: PrewarmEntryStatus;
+  instanceId?: string;
+  error?: string;
+};
+
+type PrewarmEntry = {
+  targetKey: string;
+  target: PrewarmTarget;
+  status: PrewarmEntryStatus;
+  instance?: PrewarmedSandboxInfo;
+  error?: string;
+  startedAt: number;
+  readyPromise: Promise<PrewarmedSandboxInfo>;
+  stopOnReady: boolean;
+  claimed: boolean;
+  expiryTimer?: TimeoutHandle;
+  authToken?: string;
+  authHeaderJson?: string;
+};
+
+class PrewarmCloudSandboxManager {
+  private entries = new Map<string, PrewarmEntry>();
+
+  async requestPrewarm(
+    socketId: string,
+    target: PrewarmTarget
+  ): Promise<PrewarmStatus> {
+    const validationError = this.validateTarget(target);
+    if (validationError) {
+      return { status: "failed", error: validationError };
+    }
+
+    const targetKey = this.buildTargetKey(target);
+    const existing = this.entries.get(socketId);
+
+    if (existing && existing.targetKey === targetKey) {
+      return {
+        status: existing.status,
+        instanceId: existing.instance?.instanceId,
+        error: existing.error,
+      };
+    }
+
+    if (existing) {
+      await this.cancelPrewarm(socketId, "target-changed");
+    }
+
+    const authToken = getAuthToken();
+    const authHeaderJson = getAuthHeaderJson();
+    const readyPromise = this.startSandbox(socketId, target);
+    const entry: PrewarmEntry = {
+      targetKey,
+      target,
+      status: "starting",
+      startedAt: Date.now(),
+      readyPromise,
+      stopOnReady: false,
+      claimed: false,
+      authToken,
+      authHeaderJson,
+    };
+
+    this.entries.set(socketId, entry);
+
+    entry.readyPromise
+      .then((instance) => {
+        entry.status = "ready";
+        entry.instance = instance;
+        entry.error = undefined;
+
+        if (entry.stopOnReady) {
+          void this.stopSandbox(
+            instance.instanceId,
+            "prewarm-canceled",
+            entry
+          );
+          this.clearEntry(socketId, entry);
+          return;
+        }
+
+        if (!entry.claimed) {
+          this.scheduleExpiry(socketId, entry);
+        }
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        entry.status = "failed";
+        entry.error = message;
+        console.error("[Prewarm] Sandbox start failed", error);
+        serverLogger.error("[Prewarm] Sandbox start failed", error);
+        this.clearEntry(socketId, entry);
+      });
+
+    return { status: "starting" };
+  }
+
+  async claimPrewarm(
+    socketId: string,
+    target: PrewarmTarget
+  ): Promise<PrewarmedSandboxInfo | null> {
+    const validationError = this.validateTarget(target);
+    if (validationError) {
+      return null;
+    }
+
+    const targetKey = this.buildTargetKey(target);
+    const entry = this.entries.get(socketId);
+    if (!entry || entry.targetKey !== targetKey) {
+      return null;
+    }
+
+    if (entry.status === "ready" && entry.instance) {
+      entry.claimed = true;
+      this.clearEntry(socketId, entry);
+      return entry.instance;
+    }
+
+    if (entry.status !== "starting") {
+      this.clearEntry(socketId, entry);
+      return null;
+    }
+
+    entry.claimed = true;
+
+    const resolved = await this.withTimeout(
+      entry.readyPromise,
+      PREWARM_CLAIM_TIMEOUT_MS
+    );
+
+    if (resolved) {
+      this.clearEntry(socketId, entry);
+      return resolved;
+    }
+
+    entry.claimed = false;
+    await this.cancelPrewarm(socketId, "claim-timeout");
+    return null;
+  }
+
+  async cancelPrewarm(socketId: string, reason: string): Promise<void> {
+    const entry = this.entries.get(socketId);
+    if (!entry) {
+      return;
+    }
+
+    entry.stopOnReady = true;
+    this.clearEntry(socketId, entry);
+    serverLogger.info(`[Prewarm] Canceled prewarm (${reason}) for ${socketId}`);
+
+    if (entry.status === "ready" && entry.instance) {
+      await this.stopSandbox(entry.instance.instanceId, reason, entry);
+    }
+  }
+
+  private buildTargetKey(target: PrewarmTarget): string {
+    if (target.environmentId) {
+      return `${target.teamSlugOrId}|env:${target.environmentId}`;
+    }
+    const repoUrl = target.repoUrl ?? "";
+    const branch = target.branch ?? "";
+    return `${target.teamSlugOrId}|repo:${repoUrl}|branch:${branch}`;
+  }
+
+  private validateTarget(target: PrewarmTarget): string | null {
+    if (!target.teamSlugOrId) {
+      return "Missing team slug";
+    }
+    if (target.environmentId) {
+      return null;
+    }
+    if (!target.repoUrl) {
+      return "Missing repo URL";
+    }
+    if (!target.branch) {
+      return "Missing branch";
+    }
+    return null;
+  }
+
+  private async startSandbox(
+    socketId: string,
+    target: PrewarmTarget
+  ): Promise<PrewarmedSandboxInfo> {
+    const { postApiSandboxesStart } = await getWwwOpenApiModule();
+
+    const body = {
+      teamSlugOrId: target.teamSlugOrId,
+      ttlSeconds: PREWARM_TTL_SECONDS,
+      metadata: this.buildMetadata(target),
+      ...(target.environmentId ? { environmentId: target.environmentId } : {}),
+      ...(target.repoUrl
+        ? { repoUrl: target.repoUrl, branch: target.branch, depth: 1 }
+        : {}),
+    };
+
+    serverLogger.info("[Prewarm] Starting sandbox", {
+      socketId,
+      target,
+    });
+
+    const startRes = await postApiSandboxesStart({
+      client: getWwwClient(),
+      body,
+    });
+
+    const data = startRes.data;
+    if (!data) {
+      throw new Error(extractSandboxStartError(startRes));
+    }
+
+    return {
+      instanceId: data.instanceId,
+      vscodeUrl: data.vscodeUrl,
+      workerUrl: data.workerUrl,
+      provider: data.provider ?? "morph",
+    };
+  }
+
+  private buildMetadata(target: PrewarmTarget): Record<string, string> {
+    const metadata: Record<string, string> = {
+      instance: `cmux-prewarm-${Date.now()}`,
+      prewarm: "1",
+    };
+
+    if (target.environmentId) {
+      metadata.environmentId = String(target.environmentId);
+    }
+
+    if (target.repoUrl) {
+      metadata.repoUrl = target.repoUrl;
+    }
+
+    if (target.branch) {
+      metadata.branch = target.branch;
+    }
+
+    return metadata;
+  }
+
+  private scheduleExpiry(socketId: string, entry: PrewarmEntry): void {
+    this.clearExpiry(entry);
+
+    entry.expiryTimer = setTimeout(() => {
+      if (entry.status !== "ready" || entry.claimed || entry.stopOnReady) {
+        return;
+      }
+
+      serverLogger.info("[Prewarm] Expiring unused sandbox", {
+        socketId,
+        instanceId: entry.instance?.instanceId,
+      });
+
+      entry.stopOnReady = true;
+      if (entry.instance) {
+        void this.stopSandbox(entry.instance.instanceId, "idle-timeout", entry);
+      }
+
+      this.clearEntry(socketId, entry);
+    }, PREWARM_IDLE_TIMEOUT_MS);
+  }
+
+  private clearEntry(socketId: string, entry: PrewarmEntry): void {
+    this.clearExpiry(entry);
+    const current = this.entries.get(socketId);
+    if (current === entry) {
+      this.entries.delete(socketId);
+    }
+  }
+
+  private clearExpiry(entry: PrewarmEntry): void {
+    if (entry.expiryTimer) {
+      clearTimeout(entry.expiryTimer);
+      entry.expiryTimer = undefined;
+    }
+  }
+
+  private async stopSandbox(
+    instanceId: string,
+    reason: string,
+    entry: PrewarmEntry
+  ): Promise<void> {
+    const stop = async () => {
+      const { postApiSandboxesByIdStop } = await getWwwOpenApiModule();
+      await postApiSandboxesByIdStop({
+        client: getWwwClient(),
+        path: { id: instanceId },
+      });
+      serverLogger.info("[Prewarm] Stopped sandbox", {
+        instanceId,
+        reason,
+      });
+    };
+
+    try {
+      if (entry.authHeaderJson) {
+        await runWithAuth(entry.authToken, entry.authHeaderJson, stop);
+        return;
+      }
+      await stop();
+    } catch (error) {
+      console.error("[Prewarm] Failed to stop sandbox", error);
+      serverLogger.error("[Prewarm] Failed to stop sandbox", error);
+    }
+  }
+
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number
+  ): Promise<T | null> {
+    let timeoutHandle: TimeoutHandle | undefined;
+    const timeoutPromise: Promise<T | null> = new Promise((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(null), timeoutMs);
+    });
+
+    try {
+      const result = await Promise.race([promise, timeoutPromise]);
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      if (result === null) {
+        return null;
+      }
+      return result;
+    } catch (error) {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      console.error("[Prewarm] Failed to await sandbox readiness", error);
+      serverLogger.error("[Prewarm] Failed to await sandbox readiness", error);
+      return null;
+    }
+  }
+}
+
+export const prewarmCloudSandboxManager = new PrewarmCloudSandboxManager();

--- a/apps/server/src/vscode/VSCodeInstance.ts
+++ b/apps/server/src/vscode/VSCodeInstance.ts
@@ -21,6 +21,8 @@ export interface VSCodeInstanceConfig {
   taskRunJwt?: string;
   // Optional: environment variables to pass to the container
   envVars?: Record<string, string>;
+  // Optional: prewarmed Morph instance to attach instead of starting a new one
+  prewarmedSandbox?: PrewarmedSandboxInfo;
 }
 
 export interface VSCodeInstanceInfo {
@@ -31,6 +33,13 @@ export interface VSCodeInstanceInfo {
   provider: "docker" | "morph" | "daytona";
   /** If true, VSCode URLs were already persisted to Convex by www */
   vscodePersisted?: boolean;
+}
+
+export interface PrewarmedSandboxInfo {
+  instanceId: string;
+  vscodeUrl: string;
+  workerUrl: string;
+  provider?: "morph";
 }
 
 export abstract class VSCodeInstance extends EventEmitter {

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -594,22 +594,28 @@ sandboxesRouter.openapi(
       }
 
       if (maintenanceScript || devScript) {
-        (async () => {
-          await runMaintenanceAndDevScripts({
-            instance,
-            maintenanceScript: maintenanceScript || undefined,
-            devScript: devScript || undefined,
-            identifiers: scriptIdentifiers ?? undefined,
-            convexUrl: env.NEXT_PUBLIC_CONVEX_URL,
-            taskRunJwt: body.taskRunJwt || undefined,
-            isCloudWorkspace,
-          });
-        })().catch((error) => {
-          console.error(
-            "[sandboxes.start] Background script execution failed:",
-            error,
+        if (!body.taskRunJwt) {
+          console.warn(
+            "[sandboxes.start] Skipping maintenance/dev scripts (missing taskRunJwt)",
           );
-        });
+        } else {
+          (async () => {
+            await runMaintenanceAndDevScripts({
+              instance,
+              maintenanceScript: maintenanceScript || undefined,
+              devScript: devScript || undefined,
+              identifiers: scriptIdentifiers ?? undefined,
+              convexUrl: env.NEXT_PUBLIC_CONVEX_URL,
+              taskRunJwt: body.taskRunJwt,
+              isCloudWorkspace,
+            });
+          })().catch((error) => {
+            console.error(
+              "[sandboxes.start] Background script execution failed:",
+              error,
+            );
+          });
+        }
       }
 
       await configureGitIdentityTask;

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -99,6 +99,29 @@ export const CreateCloudWorkspaceResponseSchema = z.object({
   error: z.string().optional(),
 });
 
+export const PrewarmCloudSandboxSchema = z
+  .object({
+    teamSlugOrId: z.string(),
+    repoUrl: z.string().optional(),
+    branch: z.string().optional(),
+    environmentId: typedZid("environments").optional(),
+  })
+  .refine(
+    (value) => Boolean(value.environmentId || value.repoUrl),
+    "Either environmentId or repoUrl is required"
+  )
+  .refine(
+    (value) => (!value.repoUrl ? true : Boolean(value.branch)),
+    "branch is required when repoUrl is provided"
+  );
+
+export const PrewarmCloudSandboxResponseSchema = z.object({
+  success: z.boolean(),
+  status: z.enum(["starting", "ready", "failed"]).optional(),
+  instanceId: z.string().optional(),
+  error: z.string().optional(),
+});
+
 export const AuthenticateSchema = z.object({
   authToken: z.string(),
   authJson: z.string().optional(),
@@ -439,6 +462,10 @@ export type CreateCloudWorkspace = z.infer<typeof CreateCloudWorkspaceSchema>;
 export type CreateCloudWorkspaceResponse = z.infer<
   typeof CreateCloudWorkspaceResponseSchema
 >;
+export type PrewarmCloudSandbox = z.infer<typeof PrewarmCloudSandboxSchema>;
+export type PrewarmCloudSandboxResponse = z.infer<
+  typeof PrewarmCloudSandboxResponseSchema
+>;
 export type Authenticate = z.infer<typeof AuthenticateSchema>;
 export type TerminalCreated = z.infer<typeof TerminalCreatedSchema>;
 export type TerminalOutput = z.infer<typeof TerminalOutputSchema>;
@@ -498,6 +525,10 @@ export interface ClientToServerEvents {
   "start-task": (
     data: StartTask,
     callback: (response: TaskAcknowledged | TaskStarted | TaskError) => void
+  ) => void;
+  "prewarm-cloud-sandbox": (
+    data: PrewarmCloudSandbox,
+    callback: (response: PrewarmCloudSandboxResponse) => void
   ) => void;
   "create-local-workspace": (
     data: CreateLocalWorkspace,


### PR DESCRIPTION
can you prewarm morph instances of that repo or environment when the user is typing prompts on the dashboard??? we need some conception of prewaming instances somehow without necessarily taking a prompt in yet