### PR TITLE
Fix LanguageModelUsage type in branch-name-generator.test.ts

### DIFF
--- a/apps/www/lib/utils/branch-name-generator.test.ts
+++ b/apps/www/lib/utils/branch-name-generator.test.ts
@@ -28,6 +28,15 @@ function createMockResult<RESULT>(
       inputTokens: 1,
       outputTokens: 1,
       totalTokens: 2,
+      inputTokenDetails: {
+        noCacheTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokenDetails: {
+        textTokens: undefined,
+        reasoningTokens: undefined,
+      },
     },
     warnings: undefined,
     request: { body: undefined },


### PR DESCRIPTION
Add missing inputTokenDetails and outputTokenDetails properties to the mock usage object to match the updated LanguageModelUsage type interface.