### PR TITLE
fix blank preview in fake mock ui

### DIFF
--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -980,7 +980,7 @@ function MockGitHubPRBrowser() {
                     main
                   </span>
                   {" from "}
-                  <span className="px-1.5 py-0.5 rounded-md bg-[#388bfd26] text-[#2f81f7] text-xs font-mono"></span>
+                  <span className="px-1.5 py-0.5 rounded-md bg-[#388bfd26] text-[#2f81f7] text-xs font-mono">cmux/test-re6k4tq</span>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
fix this branch is blank in the fake mock ui for preview.new, just call it cmux/test-re6k4tq as branch name when it says from main to [branch-name] in the fake ui