### PR TITLE
Increase preview.new sign-in popup width by 20%

### DIFF
--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -4101,10 +4101,10 @@ function PreviewDashboardInner({
   const repoSelectionBox = !isAuthenticated ? (
     <div className="relative flex flex-1 flex-col items-center justify-center rounded-lg border border-white/5 bg-white/[0.02] backdrop-blur-sm px-4 py-10 overflow-hidden">
       <GrainOverlay opacity={0.02} />
-      <p className="text-sm text-neutral-300/85 pb-6 max-w-xs text-center">
+      <p className="text-sm text-neutral-300/85 pb-6 max-w-sm text-center">
         Select a Git provider to import a Git Repository
       </p>
-      <div className="flex flex-col gap-3 w-full max-w-xs">
+      <div className="flex flex-col gap-3 w-full max-w-sm">
         <Button
           onClick={() => signInWithPopup("github")}
           disabled={signingInProvider !== null}

--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -4101,10 +4101,10 @@ function PreviewDashboardInner({
   const repoSelectionBox = !isAuthenticated ? (
     <div className="relative flex flex-1 flex-col items-center justify-center rounded-lg border border-white/5 bg-white/[0.02] backdrop-blur-sm px-4 py-10 overflow-hidden">
       <GrainOverlay opacity={0.02} />
-      <p className="text-sm text-neutral-300/85 pb-6 max-w-sm text-center">
+      <p className="text-sm text-neutral-300/85 pb-6 max-w-xs text-center">
         Select a Git provider to import a Git Repository
       </p>
-      <div className="flex flex-col gap-3 w-full max-w-sm">
+      <div className="flex flex-col gap-3 w-full max-w-xs">
         <Button
           onClick={() => signInWithPopup("github")}
           disabled={signingInProvider !== null}

--- a/apps/www/hooks/use-oauth-popup.ts
+++ b/apps/www/hooks/use-oauth-popup.ts
@@ -156,7 +156,7 @@ export function useOAuthPopup(
       setSigningInProvider(provider);
 
       // Calculate centered position
-      const width = 600;
+      const width = 720;
       const height = 700;
       const screenLeft = window.screenLeft ?? window.screenX ?? 0;
       const screenTop = window.screenTop ?? window.screenY ?? 0;


### PR DESCRIPTION
for preview.new (localhost:9779/preview) select a git provider to import a git repository, for continue .. the popup is not wide enough, make it 20% wider... when we import git repository... not repo picker.. its the sign in page basically for preivew.new for new users