### PR TITLE
Add ffmpeg video capture to screenshot flow

### DIFF
--- a/apps/worker/src/screenshotCollector/runTaskScreenshots.ts
+++ b/apps/worker/src/screenshotCollector/runTaskScreenshots.ts
@@ -22,12 +22,27 @@ export interface RunTaskScreenshotsOptions {
 
 function resolveContentType(filePath: string): string {
   const extension = path.extname(filePath).toLowerCase();
+  // Image types
   if (extension === ".jpg" || extension === ".jpeg") {
     return "image/jpeg";
   }
   if (extension === ".webp") {
     return "image/webp";
   }
+  if (extension === ".png") {
+    return "image/png";
+  }
+  // Video types
+  if (extension === ".mp4") {
+    return "video/mp4";
+  }
+  if (extension === ".webm") {
+    return "video/webm";
+  }
+  if (extension === ".mov") {
+    return "video/quicktime";
+  }
+  // Default to png for unknown image types
   return "image/png";
 }
 


### PR DESCRIPTION
currently we have the screenshot agent that takes screenshots. we want to extend this further by allowing it to take video clips using ffmpeg recording tool. we want to augment to the screenshotSet to take in both images and videos... it will upload to the same place in the convex database.. we need to make it so that this video and images are both rendered in every place with the screenshot gallery etc etc... make it work. try to make no changes in the schema, just put the video urls as strings in the images, same thing. you can probably just use everything to be the same and not have to rewrite schemas.. because they are uploaded and just links anyways right? ultrathink... we need to add ffmpeg so that the screenshotCollector has this tool and can use it to record videos... you need to modify snapshot.py and both the screenshotColelctor inside worker and also in the hostScreenshotCollector... make this work completely...