### PR TITLE
fix: use newline separator for ANTHROPIC_CUSTOM_HEADERS

### DIFF
--- a/packages/host-screenshot-collector/src/index.ts
+++ b/packages/host-screenshot-collector/src/index.ts
@@ -395,7 +395,7 @@ INCOMPLETE CAPTURE: Missing important UI elements. Ensure full components are vi
         ? {
           ANTHROPIC_API_KEY: "sk_placeholder_cmux_anthropic_api_key",
           ANTHROPIC_BASE_URL: anthropicBaseUrl,
-          ANTHROPIC_CUSTOM_HEADERS: `x-cmux-token:${auth.taskRunJwt},x-cmux-source:preview-new`,
+          ANTHROPIC_CUSTOM_HEADERS: `x-cmux-token:${auth.taskRunJwt}\nx-cmux-source:preview-new`,
         }
         : {}),
     };

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -242,7 +242,7 @@ exit 0`;
         ? {}
         : {
           ANTHROPIC_BASE_URL: `${ctx.callbackUrl}/api/anthropic`,
-          ANTHROPIC_CUSTOM_HEADERS: `x-cmux-token:${ctx.taskRunJwt},x-cmux-source:cmux`,
+          ANTHROPIC_CUSTOM_HEADERS: `x-cmux-token:${ctx.taskRunJwt}\nx-cmux-source:cmux`,
         }
       ),
     },


### PR DESCRIPTION
## Summary

Fix header parsing issue introduced in #1568.

Claude Code parses `ANTHROPIC_CUSTOM_HEADERS` by splitting on **newlines**, not commas. Using commas was causing:
1. JWT token value to be corrupted (appending `,x-cmux-source:cmux` to it)
2. `x-cmux-source` header to be dropped entirely
3. Tracking to fall back to "unknown" values
4. Would break auth once re-enabled

## Changes

- `packages/shared/src/providers/anthropic/environment.ts`: Use `\n` instead of `,`
- `packages/host-screenshot-collector/src/index.ts`: Use `\n` instead of `,`

## Test plan

- [ ] Verify cmux task runs send both headers correctly
- [ ] Verify preview.new runs send both headers correctly
- [ ] Check PostHog events have correct `cmux_source` values