### PR TITLE
Remove extra space in diff view and screenshots

### DIFF
--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -448,7 +448,7 @@ export function RunScreenshotGallery(props: RunScreenshotGalleryProps) {
           Latest capture
         </span>
       </div>
-      <div className="px-3.5 pb-4 space-y-4">
+      <div className="px-3.5 pb-2 space-y-4">
         {currentEntry ? (
           <Dialog.Root
             open={isSlideshowOpen}

--- a/apps/client/src/components/heatmap-diff-viewer/git-diff-viewer-with-heatmap.tsx
+++ b/apps/client/src/components/heatmap-diff-viewer/git-diff-viewer-with-heatmap.tsx
@@ -224,7 +224,7 @@ export const GitDiffViewerWithHeatmap = memo(
       <div
         ref={containerRef}
         className={cn(
-          "flex flex-col gap-2 p-3.5 pb-28",
+          "flex flex-col gap-2 px-3.5 pb-28",
           classNames?.container
         )}
       >

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -1098,7 +1098,7 @@ function RunDiffPage() {
               />
             ) : null}
             <div
-              className={cn("flex-1 min-h-0", screenshotSets.length > 0 && "mt-6")}
+              className="flex-1 min-h-0"
               style={{ "--cmux-diff-header-offset": "56px" } as React.CSSProperties}
             >
               <Suspense


### PR DESCRIPTION
image.pngthere seems to be a weird space above the files for the git diff view and under the screenshots, remove that extra spacing