### PR TITLE
Enable expand-all by default in diff viewer

### DIFF
--- a/apps/client/src/components/monaco/monaco-git-diff-viewer.tsx
+++ b/apps/client/src/components/monaco/monaco-git-diff-viewer.tsx
@@ -1051,6 +1051,28 @@ export function MonacoGitDiffViewer({
     () => new Set(diffs.map((diff) => diff.filePath)),
   );
 
+  // Ensure new files are expanded by default when diffs change
+  useEffect(() => {
+    setExpandedFiles((prev) => {
+      const currentFilePaths = new Set(diffs.map((diff) => diff.filePath));
+      const newFilePaths = diffs.filter((diff) => !prev.has(diff.filePath));
+      if (newFilePaths.length === 0) {
+        return prev;
+      }
+      const next = new Set(prev);
+      for (const diff of newFilePaths) {
+        next.add(diff.filePath);
+      }
+      // Remove files that no longer exist in diffs
+      for (const filePath of prev) {
+        if (!currentFilePaths.has(filePath)) {
+          next.delete(filePath);
+        }
+      }
+      return next;
+    });
+  }, [diffs]);
+
   const fileGroups: MonacoFileGroup[] = useMemo(
     () =>
       diffs.map((diff) => {


### PR DESCRIPTION
in the git diff viewers the default view should have all of the files expanded: in the git diff viewer, the default view for the normal viewer is that it should be expand all.. (this is talking about the taskrun agents git diff viewer)