### PR TITLE
Show dual vscode icons in diff viewer

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -2131,22 +2131,33 @@ function TaskRunDetails({
     <Loader2 className="w-3 h-3 animate-spin text-neutral-400" />
   ) : null;
 
-  // For VSCode, combine environment error with status indicator
-  const vscodeTrailing = environmentErrorIndicator || statusIndicator;
-
   // Determine linked local workspace status
   const hasLinkedLocalWorkspace = Boolean(linkedLocalWorkspace);
   const linkedLocalTaskRunId = linkedLocalWorkspace?.taskRun?._id;
   const linkedLocalTaskId = linkedLocalWorkspace?.task?._id;
   const isLinkedLocalVSCodeReady =
     linkedLocalWorkspace?.taskRun?.vscode?.status === "running";
+
+  // For VSCode, combine environment error with status indicator
+  const vscodeTrailing = environmentErrorIndicator || statusIndicator;
+
+  // Trailing for linked local VS Code - show loading or Monitor icon
   const linkedLocalVSCodeTrailing = !isLinkedLocalVSCodeReady ? (
     <Loader2 className="w-3 h-3 animate-spin text-neutral-400" />
-  ) : null;
+  ) : (
+    <Monitor className="w-3 h-3 text-neutral-400" />
+  );
+
+  // Trailing for cloud VS Code when there's a linked local workspace
+  const cloudVSCodeTrailing = hasLinkedLocalWorkspace ? (
+    <Cloud className="w-3 h-3 text-neutral-400" />
+  ) : (
+    vscodeTrailing
+  );
 
   return (
     <Fragment>
-      {/* Linked local workspace VS Code (shown first with Monitor/computer icon) */}
+      {/* Linked local workspace VS Code (shown first with Monitor icon on trailing) */}
       {hasLinkedLocalWorkspace && linkedLocalTaskId && linkedLocalTaskRunId ? (
         <TaskRunDetailLink
           to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
@@ -2155,19 +2166,14 @@ function TaskRunDetails({
             taskId: linkedLocalTaskId,
             runId: linkedLocalTaskRunId,
           }}
-          icon={
-            <div className="relative mr-2">
-              <VSCodeIcon className="w-3 h-3 text-neutral-400 grayscale opacity-60" />
-              <Monitor className="w-2 h-2 absolute -bottom-0.5 -right-1 text-neutral-500 dark:text-neutral-400" />
-            </div>
-          }
+          icon={<VSCodeIcon className="w-3 h-3 mr-2 text-neutral-400 grayscale opacity-60" />}
           label="VS Code"
           indentLevel={indentLevel}
           trailing={linkedLocalVSCodeTrailing}
         />
       ) : null}
 
-      {/* Cloud VS Code (show with Cloud icon if there's a linked local workspace) */}
+      {/* Cloud VS Code (with Cloud icon on trailing if there's a linked local workspace) */}
       <TaskRunDetailLink
         to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
         params={{
@@ -2175,19 +2181,10 @@ function TaskRunDetails({
           taskId,
           runId: run._id,
         }}
-        icon={
-          hasLinkedLocalWorkspace ? (
-            <div className="relative mr-2">
-              <VSCodeIcon className="w-3 h-3 text-neutral-400 grayscale opacity-60" />
-              <Cloud className="w-2 h-2 absolute -bottom-0.5 -right-1 text-neutral-500 dark:text-neutral-400" />
-            </div>
-          ) : (
-            <VSCodeIcon className="w-3 h-3 mr-2 text-neutral-400 grayscale opacity-60" />
-          )
-        }
+        icon={<VSCodeIcon className="w-3 h-3 mr-2 text-neutral-400 grayscale opacity-60" />}
         label="VS Code"
         indentLevel={indentLevel}
-        trailing={vscodeTrailing}
+        trailing={cloudVSCodeTrailing}
         onReload={handleReloadVSCode}
       />
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -57,6 +57,9 @@ import {
 import z from "zod";
 import { useLocalVSCodeServeWebQuery } from "@/queries/local-vscode-serve-web";
 import { convexQueryClient } from "@/contexts/convex/convex-query-client";
+import { useSocket } from "@/contexts/socket/use-socket";
+import type { CreateLocalWorkspaceResponse } from "@cmux/shared";
+import { toast } from "sonner";
 
 type TaskRunListItem = (typeof api.taskRuns.getByTask._returnType)[number];
 type IframeStatusEntry = {
@@ -305,6 +308,7 @@ function TaskDetailPage() {
   const { taskId, teamSlugOrId } = Route.useParams();
   const search = Route.useSearch();
   const localServeWeb = useLocalVSCodeServeWebQuery();
+  const { socket } = useSocket();
   const task = useQuery(api.tasks.getById, {
     teamSlugOrId,
     id: taskId,
@@ -639,6 +643,53 @@ function TaskDetailPage() {
     };
   }, [selectedRun, taskRuns?.length]);
 
+  // Get primary repo from task for local workspace creation
+  const primaryRepo = task?.projectFullName;
+
+  // Handle opening a local workspace for the current task run
+  const handleOpenLocalWorkspace = useCallback(() => {
+    if (!socket) {
+      toast.error("Socket not connected");
+      return;
+    }
+
+    if (!primaryRepo) {
+      toast.error("No repository information available");
+      return;
+    }
+
+    if (!selectedRun?.newBranch) {
+      toast.error("No branch information available");
+      return;
+    }
+
+    const loadingToast = toast.loading("Creating local workspace...");
+
+    socket.emit(
+      "create-local-workspace",
+      {
+        teamSlugOrId,
+        projectFullName: primaryRepo,
+        repoUrl: `https://github.com/${primaryRepo}.git`,
+        branch: selectedRun.newBranch,
+        linkedFromCloudTaskRunId: selectedRun._id, // Link to the current cloud task run
+      },
+      (response: CreateLocalWorkspaceResponse) => {
+        if (response.success && response.workspacePath) {
+          toast.success("Local workspace created!", {
+            id: loadingToast,
+            description: "VS Code (Local) is now available in the sidebar",
+          });
+          // Don't navigate - the local VS Code entry will appear under the current task run
+        } else {
+          toast.error(response.error || "Failed to create workspace", {
+            id: loadingToast,
+          });
+        }
+      }
+    );
+  }, [socket, teamSlugOrId, primaryRepo, selectedRun?.newBranch, selectedRun?._id]);
+
   // Determine workspace type for layout overrides
   const isLocalWorkspaceTask = task?.isLocalWorkspace;
   const isCloudWorkspaceTask = task?.isCloudWorkspace;
@@ -784,6 +835,12 @@ function TaskDetailPage() {
           taskRunId={headerTaskRunId}
           teamSlugOrId={teamSlugOrId}
           onPanelSettings={handleOpenPanelSettings}
+          onOpenLocalWorkspace={
+            // Only show folder icon for regular tasks (not local/cloud workspaces)
+            !isLocalWorkspaceTask && !isCloudWorkspaceTask
+              ? handleOpenLocalWorkspace
+              : undefined
+          }
         />
         <PanelConfigModal
           open={isPanelSettingsOpen}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -478,6 +478,13 @@ function TaskDetailPage() {
   }, [search.runId, taskRunIndex, taskRuns]);
 
   const selectedRunId = selectedRun?._id ?? null;
+
+  // Query for existing linked local workspace (to prevent creating duplicates)
+  const linkedLocalWorkspace = useQuery(
+    api.tasks.getLinkedLocalWorkspace,
+    selectedRunId ? { teamSlugOrId, cloudTaskRunId: selectedRunId } : "skip"
+  );
+
   useEffect(() => {
     const previousRunId = previousSelectedRunIdRef.current;
     if (previousRunId === selectedRunId) {
@@ -648,6 +655,14 @@ function TaskDetailPage() {
 
   // Handle opening a local workspace for the current task run
   const handleOpenLocalWorkspace = useCallback(() => {
+    // If a linked local workspace already exists, just show a message
+    if (linkedLocalWorkspace) {
+      toast.info("Local workspace already exists", {
+        description: "VS Code (Local) is available in the sidebar",
+      });
+      return;
+    }
+
     if (!socket) {
       toast.error("Socket not connected");
       return;
@@ -688,7 +703,7 @@ function TaskDetailPage() {
         }
       }
     );
-  }, [socket, teamSlugOrId, primaryRepo, selectedRun?.newBranch, selectedRun?._id]);
+  }, [socket, teamSlugOrId, primaryRepo, selectedRun?.newBranch, selectedRun?._id, linkedLocalWorkspace]);
 
   // Determine workspace type for layout overrides
   const isLocalWorkspaceTask = task?.isLocalWorkspace;

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -21,7 +21,7 @@ import type { CreateLocalWorkspaceResponse, ReplaceDiffEntry } from "@cmux/share
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery as useRQ } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import {
   Suspense,
@@ -971,8 +971,6 @@ function RunDiffPage() {
 
   const taskRunId = selectedRun?._id ?? runId;
 
-  const navigate = useNavigate();
-
   const handleOpenLocalWorkspace = useCallback(() => {
     if (!socket) {
       toast.error("Socket not connected");
@@ -998,25 +996,15 @@ function RunDiffPage() {
         projectFullName: primaryRepo,
         repoUrl: `https://github.com/${primaryRepo}.git`,
         branch: selectedRun.newBranch,
+        linkedFromCloudTaskRunId: selectedRun._id, // Link to the current cloud task run
       },
       (response: CreateLocalWorkspaceResponse) => {
         if (response.success && response.workspacePath) {
-          toast.success("Workspace created successfully!", {
+          toast.success("Local workspace created!", {
             id: loadingToast,
-            description: `Opening workspace at ${response.workspacePath}`,
+            description: "VS Code (Local) is now available in the sidebar",
           });
-
-          // Navigate to the vscode view for this task run
-          if (response.taskRunId) {
-            navigate({
-              to: "/$teamSlugOrId/task/$taskId/run/$runId/vscode",
-              params: {
-                teamSlugOrId,
-                taskId,
-                runId: response.taskRunId,
-              },
-            });
-          }
+          // Don't navigate - the local VS Code entry will appear under the current task run
         } else {
           toast.error(response.error || "Failed to create workspace", {
             id: loadingToast,
@@ -1024,7 +1012,7 @@ function RunDiffPage() {
         }
       }
     );
-  }, [socket, teamSlugOrId, primaryRepo, selectedRun?.newBranch, navigate, taskId]);
+  }, [socket, teamSlugOrId, primaryRepo, selectedRun?.newBranch, selectedRun?._id]);
 
   // 404 if selected run is missing
   if (!selectedRun) {

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -849,6 +849,7 @@ export function setupSocketHandlers(
           taskRunId: providedTaskRunId,
           workspaceName: providedWorkspaceName,
           descriptor: providedDescriptor,
+          linkedFromCloudTaskRunId,
         } = parsed.data;
         const teamSlugOrId = requestedTeamSlugOrId || safeTeam;
 
@@ -923,6 +924,7 @@ export function setupSocketHandlers(
                 projectFullName: projectFullName ?? undefined,
                 repoUrl,
                 branch,
+                linkedFromCloudTaskRunId,
               }
             );
             taskId = reservation.taskId;

--- a/packages/convex/convex/localWorkspaces.ts
+++ b/packages/convex/convex/localWorkspaces.ts
@@ -54,6 +54,7 @@ export const reserve = authMutation({
     projectFullName: v.optional(v.string()),
     repoUrl: v.optional(v.string()),
     branch: v.optional(v.string()),
+    linkedFromCloudTaskRunId: v.optional(v.id("taskRuns")),
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
@@ -100,6 +101,7 @@ export const reserve = authMutation({
       worktreePath: undefined,
       isCompleted: false,
       isLocalWorkspace: true,
+      linkedFromCloudTaskRunId: args.linkedFromCloudTaskRunId,
       createdAt: now,
       updatedAt: now,
       lastActivityAt: now,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -99,6 +99,7 @@ const convexSchema = defineSchema({
     isPreview: v.optional(v.boolean()),
     isLocalWorkspace: v.optional(v.boolean()),
     isCloudWorkspace: v.optional(v.boolean()),
+    linkedFromCloudTaskRunId: v.optional(v.id("taskRuns")), // For local workspaces created from a cloud task run's git diff viewer
     description: v.optional(v.string()),
     pullRequestTitle: v.optional(v.string()),
     pullRequestDescription: v.optional(v.string()),
@@ -167,7 +168,8 @@ const convexSchema = defineSchema({
     .index("by_team_user_activity", ["teamId", "userId", "lastActivityAt"])
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
-    .index("by_team_preview", ["teamId", "isPreview"]),
+    .index("by_team_preview", ["teamId", "isPreview"])
+    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"]),
 
   taskRuns: defineTable({
     taskId: v.id("tasks"),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -345,6 +345,16 @@ const convexSchema = defineSchema({
         description: v.optional(v.string()),
       }),
     ),
+    videos: v.optional(
+      v.array(
+        v.object({
+          storageId: v.id("_storage"),
+          mimeType: v.string(),
+          fileName: v.optional(v.string()),
+          description: v.optional(v.string()),
+        }),
+      ),
+    ),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -31,6 +31,9 @@ export const get = authQuery({
     // Exclude preview tasks from the main tasks list
     q = q.filter((qq) => qq.neq(qq.field("isPreview"), true));
 
+    // Exclude linked local workspaces (they're shown under their parent cloud run)
+    q = q.filter((qq) => qq.eq(qq.field("linkedFromCloudTaskRunId"), undefined));
+
     // Exclude local workspaces when in web mode
     if (args.excludeLocalWorkspaces) {
       q = q.filter((qq) => qq.neq(qq.field("isLocalWorkspace"), true));
@@ -86,7 +89,9 @@ export const getArchivedPaginated = authQuery({
         idx.eq("teamId", teamId).eq("userId", userId),
       )
       .filter((qq) => qq.eq(qq.field("isArchived"), true))
-      .filter((qq) => qq.neq(qq.field("isPreview"), true));
+      .filter((qq) => qq.neq(qq.field("isPreview"), true))
+      // Exclude linked local workspaces (they're shown under their parent cloud run)
+      .filter((qq) => qq.eq(qq.field("linkedFromCloudTaskRunId"), undefined));
 
     // Exclude local workspaces when in web mode
     if (args.excludeLocalWorkspaces) {
@@ -1123,5 +1128,49 @@ export const setCompletedInternal = internalMutation({
         crownEvaluationStatus: args.crownEvaluationStatus,
       }),
     });
+  },
+});
+
+/**
+ * Get local workspace task linked from a cloud task run.
+ * Used to show linked local VS Code entry in the sidebar under cloud task runs.
+ */
+export const getLinkedLocalWorkspace = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    cloudTaskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+
+    // Find local workspace task linked from this cloud task run
+    const linkedTask = await ctx.db
+      .query("tasks")
+      .withIndex("by_linked_cloud_task_run", (q) =>
+        q.eq("linkedFromCloudTaskRunId", args.cloudTaskRunId),
+      )
+      .filter((q) => q.eq(q.field("teamId"), teamId))
+      .filter((q) => q.eq(q.field("userId"), userId))
+      .first();
+
+    if (!linkedTask) {
+      return null;
+    }
+
+    // Get the task run for the linked local workspace (we need its ID and vscode status)
+    const taskRun = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_task", (q) => q.eq("taskId", linkedTask._id))
+      .first();
+
+    if (!taskRun) {
+      return null;
+    }
+
+    return {
+      task: linkedTask,
+      taskRun,
+    };
   },
 });

--- a/packages/convex/convex/tasks.ts
+++ b/packages/convex/convex/tasks.ts
@@ -156,6 +156,9 @@ export const getWithNotificationOrder = authQuery({
 
     q = q.filter((qq) => qq.neq(qq.field("isPreview"), true));
 
+    // Exclude linked local workspaces (they're shown under their parent cloud run)
+    q = q.filter((qq) => qq.eq(qq.field("linkedFromCloudTaskRunId"), undefined));
+
     // Exclude local workspaces when in web mode
     if (args.excludeLocalWorkspaces) {
       q = q.filter((qq) => qq.neq(qq.field("isLocalWorkspace"), true));

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -62,6 +62,7 @@ export const CreateLocalWorkspaceSchema = z.object({
   workspaceName: z.string().optional(),
   descriptor: z.string().optional(),
   sequence: z.number().optional(),
+  linkedFromCloudTaskRunId: typedZid("taskRuns").optional(), // Links this local workspace to a cloud task run
 });
 
 export const CreateLocalWorkspaceResponseSchema = z.object({


### PR DESCRIPTION
currently in the git diff viewer there is a folder icon next to the fire icon that opens a vscode locally in that branch... whenw e press that button instead of opening just oening a new local workspace and creating something in the sidebar... image.png can we just add two vscodes... like one vscode with the cloud icon on the right and one vscode (the top) with the computer icon on the right to suggest that it is a local vscode in that branch.... ultrathink so its easy to access... we should just add it under the claude/opus-4.5 that it was opened and dont include a separte thing in the sidebar... ultrathink... make sure this only happens when we press that button inside the git diff viewer. and for all task detail header we should have the folder icon to open up the local workspace in that specific branch... with everything already setup properly... ultrathink and do this carefullyimage.png ... we should be putting the local workspace that is in th4e sidebar but just put it under directly under the claude/opus-4.5 or agent name instead.. th4e only difference is that we are creating the local workspace within that taskrun sidebar nested... so its not its standalone workspace.. its easier to see it in the same category.. dont put it directly in the git diff page... the icon should open it up... ultrathink.. just instead of a separate workspace just put vscode (with computer icon) on top of the cloud vscode opened for that task.. so we cna click on it to get the local vscode version of that branch... ultrathink