### PR TITLE
Show dual vscode icons in diff viewer

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -2102,6 +2102,8 @@ function TaskRunDetails({
 
   // Determine loading/error state for the detail links
   const isVSCodeReady = run.vscode?.status === "running";
+  const isLocalVSCodeReady = run.localVscode?.status === "running";
+  const hasLocalVscode = Boolean(run.localVscode);
   const isRunFailed = run.status === "failed";
 
   // Show error icon with tooltip if run failed, otherwise show loading spinner
@@ -2126,8 +2128,48 @@ function TaskRunDetails({
   // For VSCode, combine environment error with status indicator
   const vscodeTrailing = environmentErrorIndicator || statusIndicator;
 
+  // Local VS Code status indicator
+  const localVscodeStatusIndicator = !isLocalVSCodeReady ? (
+    <Loader2 className="w-3 h-3 animate-spin text-neutral-400" />
+  ) : null;
+
   return (
     <Fragment>
+      {/* Local VS Code - shown first when available (from folder icon in git diff) */}
+      {hasLocalVscode ? (
+        <TaskRunDetailLink
+          to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
+          params={{
+            teamSlugOrId,
+            taskId,
+            runId: run._id,
+          }}
+          // Navigate with ?local=true to indicate local VS Code
+          onClick={(event) => {
+            event.preventDefault();
+            void navigate({
+              to: "/$teamSlugOrId/task/$taskId/run/$runId/vscode",
+              params: {
+                teamSlugOrId,
+                taskId,
+                runId: run._id,
+              },
+              search: { local: true },
+            });
+          }}
+          icon={
+            <VSCodeIcon className="w-3 h-3 mr-2 text-neutral-400 grayscale opacity-60" />
+          }
+          label="VS Code"
+          indentLevel={indentLevel}
+          trailing={
+            localVscodeStatusIndicator ?? (
+              <Monitor className="w-3 h-3 text-neutral-500" />
+            )
+          }
+        />
+      ) : null}
+      {/* Cloud VS Code - shown with cloud icon when local VS Code exists, otherwise standard */}
       <TaskRunDetailLink
         to="/$teamSlugOrId/task/$taskId/run/$runId/vscode"
         params={{
@@ -2140,7 +2182,13 @@ function TaskRunDetails({
         }
         label="VS Code"
         indentLevel={indentLevel}
-        trailing={vscodeTrailing}
+        trailing={
+          hasLocalVscode ? (
+            vscodeTrailing ?? <Cloud className="w-3 h-3 text-neutral-500" />
+          ) : (
+            vscodeTrailing
+          )
+        }
         onReload={handleReloadVSCode}
       />
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -244,7 +244,7 @@ const convexSchema = defineSchema({
     screenshotFileName: v.optional(v.string()),
     screenshotCommitSha: v.optional(v.string()),
     latestScreenshotSetId: v.optional(v.id("taskRunScreenshotSets")),
-    // VSCode instance information
+    // VSCode instance information (cloud workspace)
     vscode: v.optional(
       v.object({
         provider: v.union(
@@ -276,6 +276,19 @@ const convexSchema = defineSchema({
         lastAccessedAt: v.optional(v.number()), // Track when user last accessed the container
         keepAlive: v.optional(v.boolean()), // User requested to keep container running
         scheduledStopAt: v.optional(v.number()), // When container is scheduled to stop
+      })
+    ),
+    // Local VSCode workspace (created from folder icon in git diff viewer)
+    localVscode: v.optional(
+      v.object({
+        status: v.union(
+          v.literal("starting"),
+          v.literal("running"),
+          v.literal("stopped")
+        ),
+        workspacePath: v.string(), // Absolute path to local worktree
+        workspaceUrl: v.optional(v.string()), // VS Code serve-web URL
+        startedAt: v.optional(v.number()),
       })
     ),
     networking: v.optional(

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -62,6 +62,8 @@ export const CreateLocalWorkspaceSchema = z.object({
   workspaceName: z.string().optional(),
   descriptor: z.string().optional(),
   sequence: z.number().optional(),
+  // When true, attach local workspace to existing task run instead of creating new one
+  attachToExistingRun: z.boolean().optional(),
 });
 
 export const CreateLocalWorkspaceResponseSchema = z.object({


### PR DESCRIPTION
currently in the git diff viewer there is a folder icon next to the fire icon that opens a vscode locally in that branch... whenw e press that button instead of opening just oening a new local workspace and creating something in the sidebar... image.png can we just add two vscodes... like one vscode with the cloud icon on the right and one vscode (the top) with the computer icon on the right to suggest that it is a local vscode in that branch.... ultrathink so its easy to access... we should just add it under the claude/opus-4.5 that it was opened and dont include a separte thing in the sidebar... ultrathink... make sure this only happens when we press that button inside the git diff viewer. and for all task detail header we should have the folder icon to open up the local workspace in that specific branch... with everything already setup properly... ultrathink and do this carefullyimage.png ... we should be putting the local workspace that is in th4e sidebar but just put it under directly under the claude/opus-4.5 or agent name instead.. th4e only difference is that we are creating the local workspace within that taskrun sidebar nested... so its not its standalone workspace.. its easier to see it in the same category.. dont put it directly in the git diff page... the icon should open it up... ultrathink.. just instead of a separate workspace just put vscode (with computer icon) on top of the cloud vscode opened for that task.. so we cna click on it to get the local vscode version of that branch... ultrathink