### PR TITLE
Security hardening: Fix critical auth bypass and injection vulnerabilities

### DIFF
--- a/apps/server/src/execWithEnv.test.ts
+++ b/apps/server/src/execWithEnv.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { escapeForSingleQuotes } from "./execWithEnv";
+
+describe("escapeForSingleQuotes", () => {
+  it("returns string unchanged when no single quotes", () => {
+    expect(escapeForSingleQuotes("hello world")).toBe("hello world");
+    expect(escapeForSingleQuotes("echo test")).toBe("echo test");
+    expect(escapeForSingleQuotes("")).toBe("");
+  });
+
+  it("escapes single quotes properly", () => {
+    // A single quote becomes: end quote, escaped quote, start quote: '\''
+    expect(escapeForSingleQuotes("it's")).toBe("it'\\''s");
+    expect(escapeForSingleQuotes("'")).toBe("'\\''");
+    expect(escapeForSingleQuotes("'hello'")).toBe("'\\''hello'\\''");
+  });
+
+  it("handles multiple single quotes", () => {
+    expect(escapeForSingleQuotes("it's a 'test'")).toBe("it'\\''s a '\\''test'\\''");
+    expect(escapeForSingleQuotes("'''")).toBe("'\\'''\\'''\\''");
+  });
+
+  it("prevents shell injection via single quote escape", () => {
+    // Attack: trying to break out of quotes with: foo'; rm -rf /; echo '
+    // Without escaping, wrapping in single quotes would allow injection:
+    //   /bin/zsh -c 'foo'; rm -rf /; echo ''
+    // With escaping, the single quotes become literal:
+    //   /bin/zsh -c 'foo'\''; rm -rf /; echo '\'''
+    const malicious = "foo'; rm -rf /; echo '";
+    const escaped = escapeForSingleQuotes(malicious);
+
+    // Each ' becomes '\''
+    // So: foo' -> foo'\''
+    // ; rm -rf /; echo  -> stays same (no single quotes)
+    // ' -> '\''
+    // Result: foo'\''; rm -rf /; echo '\''
+    expect(escaped).toBe("foo'\\''; rm -rf /; echo '\\''");
+  });
+
+  it("handles command injection attempts with backticks safely", () => {
+    // Backticks are safe inside single quotes - they're treated literally
+    const withBackticks = "echo `whoami`";
+    expect(escapeForSingleQuotes(withBackticks)).toBe("echo `whoami`");
+  });
+
+  it("handles command injection attempts with $(...) safely", () => {
+    // $() is safe inside single quotes - treated literally
+    const withSubshell = "echo $(whoami)";
+    expect(escapeForSingleQuotes(withSubshell)).toBe("echo $(whoami)");
+  });
+
+  it("handles simple injection with single quote", () => {
+    // Simple case: just one single quote
+    const input = "test'end";
+    const expected = "test'\\''end";
+    expect(escapeForSingleQuotes(input)).toBe(expected);
+  });
+});

--- a/apps/server/src/execWithEnv.ts
+++ b/apps/server/src/execWithEnv.ts
@@ -4,9 +4,28 @@ import { promisify } from "node:util";
 // Helper to execute commands with inherited environment
 const execAsync = promisify(exec);
 
+/**
+ * Escape a string for safe inclusion in single-quoted shell arguments.
+ * In shell, to include a literal single quote inside single quotes,
+ * you must: end the single-quoted string, add an escaped single quote,
+ * and restart the single-quoted string. Example: ' becomes '\''
+ *
+ * SECURITY: This prevents shell injection when the command contains
+ * user-controlled input with single quotes.
+ */
+export function escapeForSingleQuotes(str: string): string {
+  // Replace each single quote with: end quote, escaped quote, start quote
+  return str.replace(/'/g, "'\\''");
+}
+
 export const execWithEnv = (command: string) => {
+  // SECURITY: Escape single quotes in the command to prevent shell injection.
+  // Without this, a command like "echo 'foo'; malicious; echo '" would break
+  // out of the quotes and execute arbitrary code.
+  const escapedCommand = escapeForSingleQuotes(command);
+
   // Use zsh to ensure we get the user's shell environment and gh auth
-  return execAsync(`/bin/zsh -c '${command}'`, {
+  return execAsync(`/bin/zsh -c '${escapedCommand}'`, {
     env: {
       ...process.env,
     },

--- a/apps/server/src/vscode/DockerVSCodeInstance.security.test.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.security.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { isValidGitConfigKey } from "./DockerVSCodeInstance";
+
+describe("isValidGitConfigKey", () => {
+  describe("valid git config keys", () => {
+    it("accepts standard git config keys", () => {
+      expect(isValidGitConfigKey("user.name")).toBe(true);
+      expect(isValidGitConfigKey("user.email")).toBe(true);
+      expect(isValidGitConfigKey("core.autocrlf")).toBe(true);
+      expect(isValidGitConfigKey("http.sslVerify")).toBe(true);
+    });
+
+    it("accepts keys with dots, dashes, and underscores", () => {
+      expect(isValidGitConfigKey("remote.origin.url")).toBe(true);
+      expect(isValidGitConfigKey("branch.my-feature.merge")).toBe(true);
+      expect(isValidGitConfigKey("core.file_mode")).toBe(true);
+      expect(isValidGitConfigKey("http.proxy")).toBe(true);
+    });
+
+    it("accepts keys with numbers", () => {
+      expect(isValidGitConfigKey("remote.origin2.url")).toBe(true);
+      expect(isValidGitConfigKey("branch.v1.0.0.merge")).toBe(true);
+    });
+  });
+
+  describe("rejects injection attempts", () => {
+    it("rejects keys starting with dash (option injection)", () => {
+      // Attacker tries to inject --global option
+      expect(isValidGitConfigKey("--global")).toBe(false);
+      expect(isValidGitConfigKey("-v")).toBe(false);
+      expect(isValidGitConfigKey("--help")).toBe(false);
+      expect(isValidGitConfigKey("-c")).toBe(false);
+    });
+
+    it("rejects keys with shell metacharacters", () => {
+      // Semicolon (command separator)
+      expect(isValidGitConfigKey("user.name; rm -rf /")).toBe(false);
+      expect(isValidGitConfigKey("; whoami")).toBe(false);
+
+      // Pipe
+      expect(isValidGitConfigKey("user.name | cat /etc/passwd")).toBe(false);
+
+      // Ampersand
+      expect(isValidGitConfigKey("user.name && rm -rf /")).toBe(false);
+      expect(isValidGitConfigKey("user.name & echo test")).toBe(false);
+
+      // Backtick (command substitution)
+      expect(isValidGitConfigKey("user.name`whoami`")).toBe(false);
+      expect(isValidGitConfigKey("`id`")).toBe(false);
+
+      // Dollar sign (variable expansion)
+      expect(isValidGitConfigKey("user.$HOME")).toBe(false);
+      expect(isValidGitConfigKey("$(whoami)")).toBe(false);
+
+      // Quotes
+      expect(isValidGitConfigKey("user.name'")).toBe(false);
+      expect(isValidGitConfigKey('user.name"')).toBe(false);
+
+      // Newlines
+      expect(isValidGitConfigKey("user.name\nwhoami")).toBe(false);
+
+      // Spaces
+      expect(isValidGitConfigKey("user name")).toBe(false);
+
+      // Slashes
+      expect(isValidGitConfigKey("/etc/passwd")).toBe(false);
+      expect(isValidGitConfigKey("user\\name")).toBe(false);
+    });
+
+    it("rejects keys with parentheses", () => {
+      expect(isValidGitConfigKey("user.name()")).toBe(false);
+      expect(isValidGitConfigKey("$(cat)")).toBe(false);
+    });
+
+    it("rejects empty strings", () => {
+      expect(isValidGitConfigKey("")).toBe(false);
+    });
+
+    it("rejects keys with special URL characters", () => {
+      expect(isValidGitConfigKey("user@name")).toBe(false);
+      expect(isValidGitConfigKey("user:name")).toBe(false);
+      expect(isValidGitConfigKey("user?name")).toBe(false);
+      expect(isValidGitConfigKey("user#name")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("accepts single character keys", () => {
+      expect(isValidGitConfigKey("a")).toBe(true);
+      expect(isValidGitConfigKey("1")).toBe(true);
+    });
+
+    it("allows dashes in the middle of keys", () => {
+      expect(isValidGitConfigKey("my-key")).toBe(true);
+      expect(isValidGitConfigKey("user.my-name")).toBe(true);
+      expect(isValidGitConfigKey("branch.feature-branch.merge")).toBe(true);
+    });
+
+    it("rejects only a dash", () => {
+      expect(isValidGitConfigKey("-")).toBe(false);
+    });
+  });
+});

--- a/apps/server/src/vscode/DockerVSCodeInstance.ts
+++ b/apps/server/src/vscode/DockerVSCodeInstance.ts
@@ -16,6 +16,18 @@ import {
   type VSCodeInstanceInfo,
 } from "./VSCodeInstance";
 
+/**
+ * Validate that a git config key is safe to use in shell commands.
+ * Git config keys should only contain alphanumeric characters, dots, dashes, and underscores.
+ * This prevents shell injection via malicious key names like "--global" or "; rm -rf /".
+ */
+export function isValidGitConfigKey(key: string): boolean {
+  // Git config keys are in format section.subsection.name or section.name
+  // Only allow safe characters: alphanumeric, dots, dashes, underscores
+  // Reject keys starting with dash to prevent option injection
+  return /^[a-zA-Z0-9._-]+$/.test(key) && !key.startsWith("-");
+}
+
 // Global port mapping storage
 export interface ContainerMapping {
   containerName: string;
@@ -1030,17 +1042,22 @@ export class DockerVSCodeInstance extends VSCodeInstance {
         `Setting up GitHub CLI authentication in container ${this.containerName}...`
       );
 
-      // Prepare command to authenticate gh CLI with token
+      // SECURITY: Pass token via environment variable and stdin to avoid exposure in process list.
+      // The token is passed as an env var to the container and piped to gh auth via stdin.
+      // This prevents the token from appearing in `ps aux` output.
       const authCmd = [
         "bash",
         "-lc",
-        `echo '${githubToken}' | gh auth login --with-token 2>&1`,
+        // Read token from env var and pipe to gh auth (avoids token in command line args)
+        `printenv GH_AUTH_TOKEN | gh auth login --with-token 2>&1`,
       ];
 
       const exec = await this.container.exec({
         Cmd: authCmd,
         AttachStdout: true,
         AttachStderr: true,
+        AttachStdin: false,
+        Env: [`GH_AUTH_TOKEN=${githubToken}`],
       });
 
       await new Promise<void>((resolve, reject) => {
@@ -1337,8 +1354,24 @@ export class DockerVSCodeInstance extends VSCodeInstance {
     }
   }
 
+  /**
+   * Validate that a git config key is safe to use in shell commands.
+   * Git config keys should only contain alphanumeric characters, dots, dashes, and underscores.
+   * This prevents shell injection via malicious key names.
+   */
+  private isValidGitConfigKey(key: string): boolean {
+    return isValidGitConfigKey(key);
+  }
+
   private async getGitConfigValue(key: string): Promise<string | undefined> {
     try {
+      // SECURITY: Validate the key to prevent shell injection.
+      // Reject keys with special characters or that start with dashes (could be interpreted as options).
+      if (!this.isValidGitConfigKey(key)) {
+        dockerLogger.warn(`Invalid git config key rejected: ${key}`);
+        return undefined;
+      }
+
       const { execSync } = await import("child_process");
       const value = execSync(`git config --global ${key}`).toString().trim();
       return value || undefined;

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -859,17 +859,42 @@ sandboxesRouter.openapi(
     responses: {
       204: { description: "Sandbox stopped" },
       401: { description: "Unauthorized" },
+      403: { description: "Forbidden - not authorized to access this instance" },
       404: { description: "Not found" },
       500: { description: "Failed to stop sandbox" },
     },
   }),
   async (c) => {
-    const id = c.req.valid("param").id;
-    const token = await getAccessTokenFromRequest(c.req.raw);
-    if (!token) return c.text("Unauthorized", 401);
+    const user = await getUserFromRequest(c.req.raw);
+    if (!user) {
+      return c.text("Unauthorized", 401);
+    }
+
+    const { id } = c.req.valid("param");
 
     try {
+      const { accessToken } = await user.getAuthJson();
+      if (!accessToken) {
+        return c.text("Unauthorized", 401);
+      }
+      const convex = getConvex({ accessToken });
+
       const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
+
+      // SECURITY: Verify the user owns or has team access to this instance
+      const ownershipResult = await verifyInstanceOwnership(
+        client,
+        id,
+        user.id,
+        async () => {
+          const memberships = await convex.query(api.teams.listTeamMemberships, {});
+          return memberships.map((m) => ({ teamId: m.team.teamId }));
+        }
+      );
+      if (!ownershipResult.authorized) {
+        return c.text(ownershipResult.message, ownershipResult.status);
+      }
+
       const instance = await client.instances.get({ instanceId: id });
       // Kill all dev servers and user processes before pausing to avoid port conflicts on resume
       await instance.exec(VM_CLEANUP_COMMANDS);
@@ -907,15 +932,42 @@ sandboxesRouter.openapi(
         description: "Sandbox status",
       },
       401: { description: "Unauthorized" },
+      403: { description: "Forbidden - not authorized to access this instance" },
+      404: { description: "Instance not found" },
       500: { description: "Failed to get status" },
     },
   }),
   async (c) => {
-    const id = c.req.valid("param").id;
-    const token = await getAccessTokenFromRequest(c.req.raw);
-    if (!token) return c.text("Unauthorized", 401);
+    const user = await getUserFromRequest(c.req.raw);
+    if (!user) {
+      return c.text("Unauthorized", 401);
+    }
+
+    const { id } = c.req.valid("param");
+
     try {
+      const { accessToken } = await user.getAuthJson();
+      if (!accessToken) {
+        return c.text("Unauthorized", 401);
+      }
+      const convex = getConvex({ accessToken });
+
       const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
+
+      // SECURITY: Verify the user owns or has team access to this instance
+      const ownershipResult = await verifyInstanceOwnership(
+        client,
+        id,
+        user.id,
+        async () => {
+          const memberships = await convex.query(api.teams.listTeamMemberships, {});
+          return memberships.map((m) => ({ teamId: m.team.teamId }));
+        }
+      );
+      if (!ownershipResult.authorized) {
+        return c.text(ownershipResult.message, ownershipResult.status);
+      }
+
       const instance = await client.instances.get({ instanceId: id });
       const vscodeService = instance.networking.httpServices.find(
         (s) => s.port === 39378,
@@ -975,16 +1027,43 @@ sandboxesRouter.openapi(
         description: "Exposed ports list",
       },
       401: { description: "Unauthorized" },
+      403: { description: "Forbidden - not authorized to access this instance" },
+      404: { description: "Instance not found" },
       500: { description: "Failed to publish devcontainer networking" },
     },
   }),
   async (c) => {
-    const token = await getAccessTokenFromRequest(c.req.raw);
-    if (!token) return c.text("Unauthorized", 401);
+    const user = await getUserFromRequest(c.req.raw);
+    if (!user) {
+      return c.text("Unauthorized", 401);
+    }
+
     const { id } = c.req.valid("param");
     const { teamSlugOrId, taskRunId } = c.req.valid("json");
+
     try {
+      const { accessToken } = await user.getAuthJson();
+      if (!accessToken) {
+        return c.text("Unauthorized", 401);
+      }
+      const convex = getConvex({ accessToken });
+
       const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
+
+      // SECURITY: Verify the user owns or has team access to this instance
+      const ownershipResult = await verifyInstanceOwnership(
+        client,
+        id,
+        user.id,
+        async () => {
+          const memberships = await convex.query(api.teams.listTeamMemberships, {});
+          return memberships.map((m) => ({ teamId: m.team.teamId }));
+        }
+      );
+      if (!ownershipResult.authorized) {
+        return c.text(ownershipResult.message, ownershipResult.status);
+      }
+
       const instance = await client.instances.get({ instanceId: id });
 
       const reservedPorts = RESERVED_CMUX_PORT_SET;
@@ -1012,7 +1091,6 @@ sandboxesRouter.openapi(
       ).metadata;
 
       // Resolve environment-exposed ports (preferred)
-      const convex = getConvex({ accessToken: token });
       let environmentPorts: number[] | undefined;
       if (instanceMeta?.environmentId) {
         try {

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -1131,6 +1131,10 @@ export type PostApiDevServerStartData = {
      */
     body: {
         /**
+         * Team slug or ID for authorization
+         */
+        teamSlugOrId: string;
+        /**
          * GitHub repository URL
          */
         repoUrl: string;
@@ -1185,6 +1189,14 @@ export type PostApiDevServerStartData = {
 };
 
 export type PostApiDevServerStartErrors = {
+    /**
+     * Unauthorized - authentication required
+     */
+    401: unknown;
+    /**
+     * Forbidden - not a member of the specified team
+     */
+    403: unknown;
     /**
      * Failed to start development server
      */
@@ -2560,6 +2572,10 @@ export type PostApiSandboxesByIdStopErrors = {
      */
     401: unknown;
     /**
+     * Forbidden - not authorized to access this instance
+     */
+    403: unknown;
+    /**
      * Not found
      */
     404: unknown;
@@ -2592,6 +2608,14 @@ export type GetApiSandboxesByIdStatusErrors = {
      * Unauthorized
      */
     401: unknown;
+    /**
+     * Forbidden - not authorized to access this instance
+     */
+    403: unknown;
+    /**
+     * Instance not found
+     */
+    404: unknown;
     /**
      * Failed to get status
      */
@@ -2629,6 +2653,14 @@ export type PostApiSandboxesByIdPublishDevcontainerErrors = {
      * Unauthorized
      */
     401: unknown;
+    /**
+     * Forbidden - not authorized to access this instance
+     */
+    403: unknown;
+    /**
+     * Instance not found
+     */
+    404: unknown;
     /**
      * Failed to publish devcontainer networking
      */


### PR DESCRIPTION
## Summary

This PR addresses several critical and high-severity security vulnerabilities discovered in the codebase:

### CRITICAL Fixes
- **Unauthenticated /dev-server/start endpoint**: The endpoint had NO authentication, allowing anyone to spawn Morph sandbox instances. Added `getUserFromRequest` and `verifyTeamAccess` checks, plus team/user metadata tracking.
- **Token exposure in Docker GitHub auth**: GitHub token was visible in process list via `echo '${token}' | gh auth login`. Changed to use environment variable (`GH_AUTH_TOKEN`) passed to the exec call.

### HIGH Fixes
- **Missing team ownership on sandbox stop/status endpoints**: Any authenticated user could stop or query any sandbox by ID. Added `verifyInstanceOwnership` checks.
- **Missing team ownership on publish-devcontainer endpoint**: Same issue as above, now fixed.
- **Shell injection in execWithEnv**: Commands containing single quotes could break out and execute arbitrary code. Added proper shell escaping (`escapeForSingleQuotes`).
- **Git config key injection**: Unvalidated key parameter in `git config --global ${key}` could inject options. Added `isValidGitConfigKey` validation.

### Tests Added
- `execWithEnv.test.ts`: Tests for shell quote escaping including injection attack patterns
- `DockerVSCodeInstance.security.test.ts`: Tests for git config key validation

## Test plan
- [x] `bun check` passes
- [x] Security unit tests pass (18 tests)
- [ ] Manual test: Unauthenticated request to /dev-server/start returns 401
- [ ] Manual test: Authenticated user cannot stop another team's sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)