### PR TITLE
Fix local workspace startup failure

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -834,19 +834,36 @@ function TaskTreeInner({
       }
     }
 
-    // Local/cloud workspaces should show their type icon, never a checkmark
+    // Checkmark only for completed regular tasks (not workspaces)
+    if (task.isCompleted && !isLocalWorkspace && !isCloudWorkspace) {
+      return <CheckCircle className="w-3 h-3 text-green-500" />;
+    }
+
+    // Local workspaces: show error if failed, monitor otherwise
     if (isLocalWorkspace) {
+      // Check if the workspace run failed
+      const hasFailed = localWorkspaceRun?.status === "failed";
+      if (hasFailed) {
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <XCircle className="w-3 h-3 text-red-500" />
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {localWorkspaceRun?.errorMessage || "Failed to start workspace"}
+            </TooltipContent>
+          </Tooltip>
+        );
+      }
       return <Monitor className="w-3 h-3 text-neutral-400" />;
     }
 
+    // Cloud workspaces always show cloud icon
     if (isCloudWorkspace) {
       return <Cloud className="w-3 h-3 text-neutral-400" />;
     }
 
-    if (task.isCompleted) {
-      return <CheckCircle className="w-3 h-3 text-green-500" />;
-    }
-
+    // Pending/in-progress tasks show pulsing circle
     return <Circle className="w-3 h-3 text-neutral-400 animate-pulse" />;
   })();
 

--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -834,16 +834,17 @@ function TaskTreeInner({
       }
     }
 
-    if (task.isCompleted) {
-      return <CheckCircle className="w-3 h-3 text-green-500" />;
-    }
-
+    // Local/cloud workspaces should show their type icon, never a checkmark
     if (isLocalWorkspace) {
       return <Monitor className="w-3 h-3 text-neutral-400" />;
     }
 
     if (isCloudWorkspace) {
       return <Cloud className="w-3 h-3 text-neutral-400" />;
+    }
+
+    if (task.isCompleted) {
+      return <CheckCircle className="w-3 h-3 text-green-500" />;
     }
 
     return <Circle className="w-3 h-3 text-neutral-400 animate-pulse" />;

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -66,6 +66,8 @@ import {
   getVSCodeServeWebBaseUrl,
   getVSCodeServeWebPort,
   waitForVSCodeServeWebBaseUrl,
+  getLastVSCodeDetectionResult,
+  refreshVSCodeDetection,
 } from "./vscode/serveWeb";
 import { getProjectPaths } from "./workspace";
 import {
@@ -857,6 +859,80 @@ export function setupSocketHandlers(
       }
     );
 
+    // Handler to check VS Code availability and optionally refresh detection
+    socket.on(
+      "check-vscode-availability",
+      async (
+        data: { refresh?: boolean } | undefined,
+        callback?: (response: {
+          available: boolean;
+          executablePath: string | null;
+          variant: string | null;
+          source: string | null;
+          suggestions: string[];
+          errors: string[];
+        }) => void
+      ) => {
+        if (!callback) {
+          return;
+        }
+
+        // In web mode, local VSCode is not used
+        if (env.NEXT_PUBLIC_WEB_MODE) {
+          callback({
+            available: false,
+            executablePath: null,
+            variant: null,
+            source: null,
+            suggestions: ["Local workspaces are not available in the web version."],
+            errors: [],
+          });
+          return;
+        }
+
+        try {
+          let result = getLastVSCodeDetectionResult();
+
+          // If refresh requested or no cached result, re-detect
+          if (data?.refresh || !result) {
+            result = await refreshVSCodeDetection(serverLogger);
+          }
+
+          if (result?.found && result.installation) {
+            callback({
+              available: true,
+              executablePath: result.installation.executablePath,
+              variant: result.installation.variant,
+              source: result.installation.source,
+              suggestions: [],
+              errors: result.errors,
+            });
+          } else {
+            callback({
+              available: false,
+              executablePath: null,
+              variant: null,
+              source: null,
+              suggestions: result?.suggestions ?? [
+                "Install VS Code from https://code.visualstudio.com/",
+              ],
+              errors: result?.errors ?? [],
+            });
+          }
+        } catch (error) {
+          serverLogger.error("Failed to check VS Code availability:", error);
+          callback({
+            available: false,
+            executablePath: null,
+            variant: null,
+            source: null,
+            suggestions: ["An error occurred while checking VS Code availability."],
+            errors: [error instanceof Error ? error.message : "Unknown error"],
+          });
+        }
+      }
+    );
+
     socket.on(
       "create-local-workspace",
       async (
@@ -924,13 +1000,30 @@ export function setupSocketHandlers(
           // Give serve-web a short window to become ready (it might be starting up)
           const serveWebUrl = await waitForVSCodeServeWebBaseUrl(5_000);
           if (!serveWebUrl) {
+            // Get detailed detection result for better error messaging
+            const detectionResult = getLastVSCodeDetectionResult();
+            const suggestions = detectionResult?.suggestions ?? [];
+
             serverLogger.warn(
-              "[create-local-workspace] VS Code serve-web is not available. Local workspaces require VS Code CLI to be installed."
+              "[create-local-workspace] VS Code serve-web is not available. Local workspaces require VS Code CLI to be installed.",
+              detectionResult
+                ? {
+                    searchedLocations: detectionResult.searchedLocations.length,
+                    errors: detectionResult.errors,
+                  }
+                : {}
             );
+
+            // Build user-friendly error message with suggestions
+            let errorMessage =
+              "VS Code is not available. Local workspaces require VS Code to be installed.";
+            if (suggestions.length > 0) {
+              errorMessage += "\n\nTo fix this:\n• " + suggestions.slice(0, 3).join("\n• ");
+            }
+
             callback({
               success: false,
-              error:
-                "VS Code is not available. Please install VS Code and ensure the 'code' command is accessible from your terminal, then restart the app.",
+              error: errorMessage,
             });
             return;
           }

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -994,11 +994,11 @@ export function setupSocketHandlers(
         }
 
         // Early check: verify VS Code serve-web is available before doing expensive operations
-        // This provides a fast failure instead of waiting 15+ seconds for the timeout
         const earlyServeWebCheck = getVSCodeServeWebBaseUrl();
         if (!earlyServeWebCheck) {
-          // Give serve-web a short window to become ready (it might be starting up)
-          const serveWebUrl = await waitForVSCodeServeWebBaseUrl(5_000);
+          // Give serve-web the full startup window to become ready (it might be starting up)
+          // Using the default timeout (~15s) to avoid premature failures on slower machines
+          const serveWebUrl = await waitForVSCodeServeWebBaseUrl();
           if (!serveWebUrl) {
             // Get detailed detection result for better error messaging
             const detectionResult = getLastVSCodeDetectionResult();

--- a/apps/server/src/vscode/serveWeb.ts
+++ b/apps/server/src/vscode/serveWeb.ts
@@ -509,6 +509,63 @@ async function resolveVSCodeExecutable(logger: Logger) {
     }
   }
 
+  // Fallback: check common installation paths on macOS
+  if (!resolvedVSCodeExecutable && process.platform === "darwin") {
+    const macOSPaths = [
+      "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+      path.join(
+        os.homedir(),
+        "Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+      ),
+      // VS Code Insiders
+      "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders",
+      path.join(
+        os.homedir(),
+        "Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders"
+      ),
+    ];
+
+    for (const codePath of macOSPaths) {
+      try {
+        await access(codePath, fsConstants.X_OK);
+        resolvedVSCodeExecutable = codePath;
+        logger.info(
+          `Resolved VS Code CLI executable via macOS path lookup: ${codePath}`
+        );
+        break;
+      } catch {
+        logger.debug?.(
+          `VS Code CLI not found at macOS path: ${codePath}`
+        );
+      }
+    }
+  }
+
+  // Fallback: check common installation paths on Linux
+  if (!resolvedVSCodeExecutable && process.platform === "linux") {
+    const linuxPaths = [
+      "/usr/share/code/bin/code",
+      "/usr/bin/code",
+      "/snap/bin/code",
+      path.join(os.homedir(), ".local/share/code/bin/code"),
+    ];
+
+    for (const codePath of linuxPaths) {
+      try {
+        await access(codePath, fsConstants.X_OK);
+        resolvedVSCodeExecutable = codePath;
+        logger.info(
+          `Resolved VS Code CLI executable via Linux path lookup: ${codePath}`
+        );
+        break;
+      } catch {
+        logger.debug?.(
+          `VS Code CLI not found at Linux path: ${codePath}`
+        );
+      }
+    }
+  }
+
   return resolvedVSCodeExecutable;
 }
 

--- a/apps/server/src/vscode/vscodeDetection.ts
+++ b/apps/server/src/vscode/vscodeDetection.ts
@@ -1,0 +1,666 @@
+import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access, readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+type Logger = {
+  info: (message: string, ...args: unknown[]) => void;
+  warn: (message: string, ...args: unknown[]) => void;
+  error: (message: string, ...args: unknown[]) => void;
+  debug?: (message: string, ...args: unknown[]) => void;
+};
+
+/**
+ * Supported VS Code variants in order of preference
+ */
+export type VSCodeVariant = "stable" | "insiders" | "codium" | "oss";
+
+/**
+ * How the VS Code installation was discovered
+ */
+export type DetectionSource =
+  | "env-override" // CMUX_VSCODE_PATH environment variable
+  | "path-lookup" // Found via which/where in PATH
+  | "shell-lookup" // Found via login shell command -v
+  | "spotlight" // Found via macOS mdfind (Spotlight)
+  | "common-path" // Found at a known installation path
+  | "homebrew"; // Found in Homebrew Caskroom
+
+/**
+ * Information about a discovered VS Code installation
+ */
+export interface VSCodeInstallation {
+  /** Full path to the code CLI executable */
+  executablePath: string;
+  /** Which variant of VS Code this is */
+  variant: VSCodeVariant;
+  /** How it was discovered */
+  source: DetectionSource;
+}
+
+/**
+ * Result of VS Code detection
+ */
+export interface VSCodeDetectionResult {
+  /** Whether a working VS Code installation was found */
+  found: boolean;
+  /** The installation details if found */
+  installation: VSCodeInstallation | null;
+  /** All locations that were searched (for debugging) */
+  searchedLocations: string[];
+  /** Human-readable suggestions if VS Code wasn't found */
+  suggestions: string[];
+  /** Any errors encountered during detection */
+  errors: string[];
+}
+
+/**
+ * macOS bundle identifiers for different VS Code variants
+ */
+const MACOS_BUNDLE_IDS: Record<VSCodeVariant, string> = {
+  stable: "com.microsoft.VSCode",
+  insiders: "com.microsoft.VSCodeInsiders",
+  codium: "com.vscodium",
+  oss: "com.visualstudio.code.oss",
+};
+
+/**
+ * CLI binary names for different platforms and variants
+ */
+const CLI_NAMES: Record<VSCodeVariant, { unix: string; windows: string[] }> = {
+  stable: { unix: "code", windows: ["code.cmd", "code.exe", "code"] },
+  insiders: {
+    unix: "code-insiders",
+    windows: ["code-insiders.cmd", "code-insiders.exe", "code-insiders"],
+  },
+  codium: { unix: "codium", windows: ["codium.cmd", "codium.exe", "codium"] },
+  oss: { unix: "code-oss", windows: ["code-oss.cmd", "code-oss.exe", "code-oss"] },
+};
+
+/**
+ * Common installation paths per platform
+ */
+function getCommonPaths(variant: VSCodeVariant): string[] {
+  const home = os.homedir();
+
+  if (process.platform === "darwin") {
+    const appNames: Record<VSCodeVariant, string[]> = {
+      stable: ["Visual Studio Code.app"],
+      insiders: ["Visual Studio Code - Insiders.app"],
+      codium: ["VSCodium.app"],
+      oss: ["Code - OSS.app"],
+    };
+
+    const apps = appNames[variant];
+    const paths: string[] = [];
+
+    for (const app of apps) {
+      // Standard locations
+      paths.push(`/Applications/${app}/Contents/Resources/app/bin/code`);
+      paths.push(
+        path.join(home, `Applications/${app}/Contents/Resources/app/bin/code`)
+      );
+    }
+
+    return paths;
+  }
+
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+    const programFiles = process.env.ProgramFiles || "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+
+    const folderNames: Record<VSCodeVariant, string> = {
+      stable: "Microsoft VS Code",
+      insiders: "Microsoft VS Code Insiders",
+      codium: "VSCodium",
+      oss: "Code - OSS",
+    };
+
+    const folder = folderNames[variant];
+    const cli = CLI_NAMES[variant].windows[0];
+
+    return [
+      path.join(localAppData, "Programs", folder, "bin", cli),
+      path.join(programFiles, folder, "bin", cli),
+      path.join(programFilesX86, folder, "bin", cli),
+    ];
+  }
+
+  // Linux
+  const binNames: Record<VSCodeVariant, string> = {
+    stable: "code",
+    insiders: "code-insiders",
+    codium: "codium",
+    oss: "code-oss",
+  };
+
+  const bin = binNames[variant];
+
+  return [
+    `/usr/bin/${bin}`,
+    `/usr/share/code/bin/${bin}`,
+    `/snap/bin/${bin}`,
+    `/var/lib/flatpak/exports/bin/com.visualstudio.code`,
+    path.join(home, ".local/bin", bin),
+    path.join(home, `.local/share/${bin}/bin/${bin}`),
+  ];
+}
+
+/**
+ * Check if a file exists and is executable
+ */
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    if (process.platform === "win32") {
+      await access(filePath, fsConstants.F_OK);
+    } else {
+      await access(filePath, fsConstants.X_OK);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Use macOS Spotlight (mdfind) to find VS Code installations
+ */
+async function findViaMdfind(
+  variant: VSCodeVariant,
+  logger: Logger
+): Promise<string | null> {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+
+  const bundleId = MACOS_BUNDLE_IDS[variant];
+
+  try {
+    const { stdout } = await execFileAsync("mdfind", [
+      `kMDItemCFBundleIdentifier == '${bundleId}'`,
+    ]);
+
+    const appPath = stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.endsWith(".app"));
+
+    if (appPath) {
+      // Construct path to the CLI binary inside the app bundle
+      const cliPath = path.join(appPath, "Contents/Resources/app/bin/code");
+      if (await isExecutable(cliPath)) {
+        logger.debug?.(
+          `Found VS Code ${variant} via Spotlight: ${cliPath}`
+        );
+        return cliPath;
+      }
+    }
+  } catch (error) {
+    logger.debug?.(`Spotlight search for ${variant} failed:`, error);
+  }
+
+  return null;
+}
+
+/**
+ * Search Homebrew Caskroom for VS Code installations
+ */
+async function findViaHomebrew(
+  variant: VSCodeVariant,
+  logger: Logger
+): Promise<string | null> {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+
+  const caskNames: Record<VSCodeVariant, string> = {
+    stable: "visual-studio-code",
+    insiders: "visual-studio-code-insiders",
+    codium: "vscodium",
+    oss: "code-oss", // Not typically available via Homebrew
+  };
+
+  const cask = caskNames[variant];
+  const homebrewPaths = [
+    "/opt/homebrew/Caskroom", // Apple Silicon
+    "/usr/local/Caskroom", // Intel
+  ];
+
+  for (const caskroom of homebrewPaths) {
+    try {
+      const caskPath = path.join(caskroom, cask);
+      const versions = await readdir(caskPath).catch(() => []);
+
+      for (const version of versions) {
+        // Find the .app inside the version folder
+        const versionPath = path.join(caskPath, version);
+        const contents = await readdir(versionPath).catch(() => []);
+        const appName = contents.find((f) => f.endsWith(".app"));
+
+        if (appName) {
+          const cliPath = path.join(
+            versionPath,
+            appName,
+            "Contents/Resources/app/bin/code"
+          );
+          if (await isExecutable(cliPath)) {
+            logger.debug?.(
+              `Found VS Code ${variant} via Homebrew: ${cliPath}`
+            );
+            return cliPath;
+          }
+        }
+      }
+    } catch {
+      // Cask not installed, continue
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Search PATH using which/where
+ */
+async function findViaPath(
+  variant: VSCodeVariant,
+  logger: Logger
+): Promise<string | null> {
+  const isWindows = process.platform === "win32";
+  const cliNames = isWindows
+    ? CLI_NAMES[variant].windows
+    : [CLI_NAMES[variant].unix];
+
+  for (const cli of cliNames) {
+    try {
+      const command = isWindows ? "where" : "which";
+      const { stdout } = await execFileAsync(command, [cli]);
+      const candidate = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+
+      if (candidate && (await isExecutable(candidate))) {
+        logger.debug?.(
+          `Found VS Code ${variant} via PATH lookup: ${candidate}`
+        );
+        return normalizeExecutablePath(candidate);
+      }
+    } catch {
+      // Not found in PATH
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Search using login shell (picks up shell profile PATH modifications)
+ */
+async function findViaShell(
+  variant: VSCodeVariant,
+  logger: Logger
+): Promise<string | null> {
+  if (process.platform === "win32" || !process.env.SHELL) {
+    return null;
+  }
+
+  const cli = CLI_NAMES[variant].unix;
+
+  try {
+    const { stdout } = await execFileAsync(process.env.SHELL, [
+      "-lc",
+      `command -v ${cli}`,
+    ]);
+
+    const candidate = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+
+    if (candidate && (await isExecutable(candidate))) {
+      logger.debug?.(
+        `Found VS Code ${variant} via shell lookup: ${candidate}`
+      );
+      return normalizeExecutablePath(candidate);
+    }
+  } catch {
+    // Not found via shell
+  }
+
+  return null;
+}
+
+/**
+ * Normalize executable path (handle aliases, symlinks, etc.)
+ */
+function normalizeExecutablePath(candidate: string): string {
+  // Handle shell alias format: alias code='/path/to/code'
+  const aliasMatch = candidate.match(/^alias\s+\w+=['"]?([^'"]+)['"]?$/);
+  if (aliasMatch) {
+    return aliasMatch[1];
+  }
+
+  // Handle 'code is /path/to/code' format from some shells
+  const isMatch = candidate.match(/^\w+\s+is\s+(.+)$/);
+  if (isMatch) {
+    return isMatch[1];
+  }
+
+  return candidate;
+}
+
+/**
+ * Verify that a VS Code executable actually works by running --version
+ */
+async function verifyExecutable(
+  executablePath: string,
+  logger: Logger
+): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(executablePath, ["--version"], {
+      timeout: 10_000,
+    });
+    const version = stdout.split("\n")[0]?.trim();
+    logger.debug?.(`Verified VS Code executable: ${executablePath} (${version})`);
+    return true;
+  } catch (error) {
+    logger.debug?.(
+      `VS Code executable verification failed for ${executablePath}:`,
+      error
+    );
+    return false;
+  }
+}
+
+/**
+ * Main detection function - finds VS Code using all available methods
+ */
+export async function detectVSCode(
+  logger: Logger,
+  options: {
+    /** Skip verification step (faster but less reliable) */
+    skipVerification?: boolean;
+    /** Only search for specific variants */
+    variants?: VSCodeVariant[];
+  } = {}
+): Promise<VSCodeDetectionResult> {
+  const searchedLocations: string[] = [];
+  const errors: string[] = [];
+  const variants = options.variants || ["stable", "insiders", "codium", "oss"];
+
+  // Strategy 0: Check for environment variable override (highest priority)
+  const envOverride = process.env.CMUX_VSCODE_PATH;
+  if (envOverride) {
+    searchedLocations.push(`CMUX_VSCODE_PATH=${envOverride}`);
+    if (await isExecutable(envOverride)) {
+      const verified =
+        options.skipVerification || (await verifyExecutable(envOverride, logger));
+      if (verified) {
+        logger.info(
+          `Using VS Code from CMUX_VSCODE_PATH environment variable: ${envOverride}`
+        );
+        return {
+          found: true,
+          installation: {
+            executablePath: envOverride,
+            variant: "stable", // Assume stable for manual override
+            source: "env-override",
+          },
+          searchedLocations,
+          suggestions: [],
+          errors,
+        };
+      } else {
+        errors.push(
+          `CMUX_VSCODE_PATH is set to ${envOverride} but it's not a working VS Code executable`
+        );
+      }
+    } else {
+      errors.push(
+        `CMUX_VSCODE_PATH is set to ${envOverride} but the file doesn't exist or isn't executable`
+      );
+    }
+  }
+
+  // Try each variant in order of preference
+  for (const variant of variants) {
+    // Strategy 1: PATH lookup (fastest)
+    const pathResult = await findViaPath(variant, logger);
+    if (pathResult) {
+      searchedLocations.push(`PATH lookup for ${CLI_NAMES[variant].unix}`);
+      const verified =
+        options.skipVerification || (await verifyExecutable(pathResult, logger));
+      if (verified) {
+        return {
+          found: true,
+          installation: {
+            executablePath: pathResult,
+            variant,
+            source: "path-lookup",
+          },
+          searchedLocations,
+          suggestions: [],
+          errors,
+        };
+      }
+    }
+
+    // Strategy 2: Shell lookup (handles PATH from shell profiles)
+    const shellResult = await findViaShell(variant, logger);
+    if (shellResult) {
+      searchedLocations.push(`Shell lookup for ${CLI_NAMES[variant].unix}`);
+      const verified =
+        options.skipVerification || (await verifyExecutable(shellResult, logger));
+      if (verified) {
+        return {
+          found: true,
+          installation: {
+            executablePath: shellResult,
+            variant,
+            source: "shell-lookup",
+          },
+          searchedLocations,
+          suggestions: [],
+          errors,
+        };
+      }
+    }
+
+    // Strategy 3: macOS Spotlight (very reliable on macOS)
+    if (process.platform === "darwin") {
+      const spotlightResult = await findViaMdfind(variant, logger);
+      if (spotlightResult) {
+        searchedLocations.push(`Spotlight search for ${MACOS_BUNDLE_IDS[variant]}`);
+        const verified =
+          options.skipVerification ||
+          (await verifyExecutable(spotlightResult, logger));
+        if (verified) {
+          return {
+            found: true,
+            installation: {
+              executablePath: spotlightResult,
+              variant,
+              source: "spotlight",
+            },
+            searchedLocations,
+            suggestions: [],
+            errors,
+          };
+        }
+      }
+
+      // Strategy 4: Homebrew Caskroom
+      const homebrewResult = await findViaHomebrew(variant, logger);
+      if (homebrewResult) {
+        searchedLocations.push(`Homebrew Caskroom for ${variant}`);
+        const verified =
+          options.skipVerification ||
+          (await verifyExecutable(homebrewResult, logger));
+        if (verified) {
+          return {
+            found: true,
+            installation: {
+              executablePath: homebrewResult,
+              variant,
+              source: "homebrew",
+            },
+            searchedLocations,
+            suggestions: [],
+            errors,
+          };
+        }
+      }
+    }
+
+    // Strategy 5: Common installation paths
+    const commonPaths = getCommonPaths(variant);
+    for (const commonPath of commonPaths) {
+      searchedLocations.push(commonPath);
+      if (await isExecutable(commonPath)) {
+        const verified =
+          options.skipVerification ||
+          (await verifyExecutable(commonPath, logger));
+        if (verified) {
+          return {
+            found: true,
+            installation: {
+              executablePath: commonPath,
+              variant,
+              source: "common-path",
+            },
+            searchedLocations,
+            suggestions: [],
+            errors,
+          };
+        }
+      }
+    }
+  }
+
+  // Not found - provide helpful suggestions
+  const suggestions = generateSuggestions();
+
+  logger.warn(
+    `VS Code not found. Searched ${searchedLocations.length} locations.`
+  );
+
+  return {
+    found: false,
+    installation: null,
+    searchedLocations,
+    suggestions,
+    errors,
+  };
+}
+
+/**
+ * Generate platform-specific suggestions for installing VS Code
+ */
+function generateSuggestions(): string[] {
+  const suggestions: string[] = [];
+
+  suggestions.push(
+    "Download and install VS Code from https://code.visualstudio.com/"
+  );
+
+  if (process.platform === "darwin") {
+    suggestions.push(
+      "Or install via Homebrew: brew install --cask visual-studio-code"
+    );
+    suggestions.push(
+      "After installing, open VS Code and run 'Shell Command: Install code command in PATH' from the Command Palette (Cmd+Shift+P)"
+    );
+  } else if (process.platform === "win32") {
+    suggestions.push(
+      "Make sure to check 'Add to PATH' during installation"
+    );
+  } else {
+    suggestions.push(
+      "Or install via snap: sudo snap install code --classic"
+    );
+    suggestions.push(
+      "Or install via your package manager (apt, dnf, pacman, etc.)"
+    );
+  }
+
+  suggestions.push(
+    "Alternatively, set the CMUX_VSCODE_PATH environment variable to the full path of your VS Code CLI executable"
+  );
+
+  return suggestions;
+}
+
+/**
+ * Cached detection result
+ */
+let cachedResult: VSCodeDetectionResult | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 60_000; // Re-check every 60 seconds if not found
+
+/**
+ * Get VS Code installation with caching
+ * Re-detects if not found and cache is stale
+ */
+export async function getVSCodeInstallation(
+  logger: Logger,
+  options: { forceRefresh?: boolean } = {}
+): Promise<VSCodeDetectionResult> {
+  const now = Date.now();
+
+  // Return cached result if valid
+  if (
+    cachedResult &&
+    !options.forceRefresh &&
+    (cachedResult.found || now - cacheTimestamp < CACHE_TTL_MS)
+  ) {
+    return cachedResult;
+  }
+
+  // Perform detection
+  cachedResult = await detectVSCode(logger);
+  cacheTimestamp = now;
+
+  return cachedResult;
+}
+
+/**
+ * Clear the cached detection result (useful after user installs VS Code)
+ */
+export function clearVSCodeDetectionCache(): void {
+  cachedResult = null;
+  cacheTimestamp = 0;
+}
+
+/**
+ * Format detection result for user-friendly display
+ */
+export function formatDetectionResultForUser(
+  result: VSCodeDetectionResult
+): string {
+  if (result.found && result.installation) {
+    return `VS Code found: ${result.installation.executablePath} (${result.installation.variant}, via ${result.installation.source})`;
+  }
+
+  const lines = ["VS Code was not found on your system.", ""];
+
+  if (result.errors.length > 0) {
+    lines.push("Errors encountered:");
+    for (const error of result.errors) {
+      lines.push(`  • ${error}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("To fix this:");
+  for (const suggestion of result.suggestions) {
+    lines.push(`  • ${suggestion}`);
+  }
+
+  return lines.join("\n");
+}

--- a/apps/server/src/vscode/vscodeDetection.ts
+++ b/apps/server/src/vscode/vscodeDetection.ts
@@ -322,11 +322,16 @@ async function findViaShell(
       .map((line) => line.trim())
       .find((line) => line.length > 0);
 
-    if (candidate && (await isExecutable(candidate))) {
-      logger.debug?.(
-        `Found VS Code ${variant} via shell lookup: ${candidate}`
-      );
-      return normalizeExecutablePath(candidate);
+    if (candidate) {
+      // Normalize first to handle alias/descriptor output from `command -v`
+      // (e.g., "alias code='/path/to/code'" or "code is /path/to/code")
+      const normalizedPath = normalizeExecutablePath(candidate);
+      if (await isExecutable(normalizedPath)) {
+        logger.debug?.(
+          `Found VS Code ${variant} via shell lookup: ${normalizedPath}`
+        );
+        return normalizedPath;
+      }
     }
   } catch {
     // Not found via shell

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -580,6 +580,17 @@ export interface ClientToServerEvents {
   "get-local-vscode-serve-web-origin": (
     callback: (response: { baseUrl: string | null; port: number | null }) => void
   ) => void;
+  "check-vscode-availability": (
+    data: { refresh?: boolean } | undefined,
+    callback: (response: {
+      available: boolean;
+      executablePath: string | null;
+      variant: string | null;
+      source: string | null;
+      suggestions: string[];
+      errors: string[];
+    }) => void
+  ) => void;
   "archive-task": (
     data: ArchiveTask,
     callback: (response: { success: boolean; error?: string }) => void


### PR DESCRIPTION
===== main.log =====Last modified: 2026-01-25T23:07:11.418Z[2026-01-25T23:06:38.704Z] [MAIN] [LOG] "[MAIN] Added SPKI whitelist for proxy CA:" "ahKDQys+oUSd4Li6Bg9VwgCvmOgQkkPIrGknTW4YSls="[2026-01-25T23:06:38.759Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.759Z] CmdK debug log path: /Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/logs/cmdk-debug.log"[2026-01-25T23:06:38.759Z] [MAIN] [LOG] [2026-01-25T23:06:38.759Z] [MAIN] [2026-01-25T23:06:38.759Z] CmdK debug log path: /Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/logs/cmdk-debug.log[2026-01-25T23:06:38.762Z] [MAIN] [LOG] "[cmux-preview-proxy] listening on port 39385"[2026-01-25T23:06:38.762Z] [MAIN] [LOG] [2026-01-25T23:06:38.762Z] [cmux-preview-proxy] listening on port 39385[2026-01-25T23:06:38.762Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.762Z] Preview proxy listening { port: 39385 }"[2026-01-25T23:06:38.762Z] [MAIN] [LOG] [2026-01-25T23:06:38.762Z] [MAIN] [2026-01-25T23:06:38.762Z] Preview proxy listening { port: 39385 }[2026-01-25T23:06:38.762Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.762Z] Starting embedded IPC server..."[2026-01-25T23:06:38.762Z] [MAIN] [LOG] [2026-01-25T23:06:38.762Z] [MAIN] [2026-01-25T23:06:38.762Z] Starting embedded IPC server...[2026-01-25T23:06:38.762Z] [MAIN] [LOG] "[EmbeddedServer] Starting full server over IPC transport"[2026-01-25T23:06:38.762Z] [MAIN] [LOG] [2026-01-25T23:06:38.762Z] [EmbeddedServer] Starting full server over IPC transport[2026-01-25T23:06:38.763Z] [MAIN] [LOG] "[INFO]" "Ensuring VS Code serve-web availability..."[2026-01-25T23:06:38.763Z] [MAIN] [LOG] [2026-01-25T23:06:38.763Z] [INFO] Ensuring VS Code serve-web availability...[2026-01-25T23:06:38.763Z] [MAIN] [LOG] "[INFO]" "Attempting to resolve VS Code CLI executable for serve-web."[2026-01-25T23:06:38.763Z] [MAIN] [LOG] [2026-01-25T23:06:38.763Z] [INFO] Attempting to resolve VS Code CLI executable for serve-web.[2026-01-25T23:06:38.850Z] [MAIN] [WARN] "[WARN]" "VS Code CLI executable unavailable; serve-web will not be launched."[2026-01-25T23:06:38.850Z] [MAIN] [WARN] [2026-01-25T23:06:38.850Z] [WARN] VS Code CLI executable unavailable; serve-web will not be launched.[2026-01-25T23:06:38.850Z] [MAIN] [LOG] "[EmbeddedServer] Full server started successfully over IPC"[2026-01-25T23:06:38.850Z] [MAIN] [LOG] [2026-01-25T23:06:38.850Z] [EmbeddedServer] Full server started successfully over IPC[2026-01-25T23:06:38.850Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.850Z] Embedded IPC server started successfully"[2026-01-25T23:06:38.850Z] [MAIN] [LOG] [2026-01-25T23:06:38.850Z] [MAIN] [2026-01-25T23:06:38.850Z] Embedded IPC server started successfully[2026-01-25T23:06:38.852Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.851Z] setAsDefaultProtocolClient(cmux) { ok: true, packaged: true }"[2026-01-25T23:06:38.852Z] [MAIN] [LOG] [2026-01-25T23:06:38.852Z] [MAIN] [2026-01-25T23:06:38.851Z] setAsDefaultProtocolClient(cmux) { ok: true, packaged: true }[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.874Z] Setting up auto-updates { appVersion: '1.0.251', platform: 'darwin', arch: 'arm64' }"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.874Z] Setting up auto-updates { appVersion: '1.0.251', platform: 'darwin', arch: 'arm64' }[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.875Z] Configured autoUpdater channel { channel: 'latest-universal', arch: 'arm64' }"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.875Z] Configured autoUpdater channel { channel: 'latest-universal', arch: 'arm64' }[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.875Z] Auto-updater configuration complete {\n  autoDownload: true,\n  autoInstallOnAppQuit: true,\n  allowPrerelease: false,\n  channel: 'latest-universal'\n}"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.875Z] Auto-updater configuration complete {  autoDownload: true,  autoInstallOnAppQuit: true,  allowPrerelease: false,  channel: 'latest-universal'}[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.875Z] Starting initial auto-update check"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.875Z] Starting initial auto-update check[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.875Z] [updater] Checking for update"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.875Z] [updater] Checking for update[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.875Z] Checking for update…"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.875Z] Checking for update…[2026-01-25T23:06:38.875Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.875Z] Loading renderer (prod) { host: 'cmux.local' }"[2026-01-25T23:06:38.875Z] [MAIN] [LOG] [2026-01-25T23:06:38.875Z] [MAIN] [2026-01-25T23:06:38.875Z] Loading renderer (prod) { host: 'cmux.local' }[2026-01-25T23:06:38.912Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:38.912Z] did-navigate { url: 'https://cmux.local/index-electron.html' }"[2026-01-25T23:06:38.912Z] [MAIN] [LOG] [2026-01-25T23:06:38.912Z] [MAIN] [2026-01-25T23:06:38.912Z] did-navigate { url: 'https://cmux.local/index-electron.html' }[2026-01-25T23:06:39.049Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:39.049Z] Window ready-to-show"[2026-01-25T23:06:39.049Z] [MAIN] [LOG] [2026-01-25T23:06:39.049Z] [MAIN] [2026-01-25T23:06:39.049Z] Window ready-to-show[2026-01-25T23:06:39.053Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:39.053Z] Renderer finished load"[2026-01-25T23:06:39.053Z] [MAIN] [LOG] [2026-01-25T23:06:39.053Z] [MAIN] [2026-01-25T23:06:39.053Z] Renderer finished load[2026-01-25T23:06:40.027Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:40.027Z] [updater] Update for version 1.0.251 is not available (latest version: 1.0.251, downgrade is allowed)."[2026-01-25T23:06:40.028Z] [MAIN] [LOG] [2026-01-25T23:06:40.028Z] [MAIN] [2026-01-25T23:06:40.027Z] [updater] Update for version 1.0.251 is not available (latest version: 1.0.251, downgrade is allowed).[2026-01-25T23:06:40.028Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:40.028Z] No updates available"[2026-01-25T23:06:40.028Z] [MAIN] [LOG] [2026-01-25T23:06:40.028Z] [MAIN] [2026-01-25T23:06:40.028Z] No updates available[2026-01-25T23:06:40.028Z] [MAIN] [LOG] "[MAIN]" "[2026-01-25T23:06:40.028Z] Initial checkForUpdatesAndNotify completed {\n  updateAvailable: false,\n  version: '1.0.251',\n  releaseDate: '2026-01-25T01:52:37.736Z',\n  fileCount: 2,\n  stagingPercentage: null\n}"[2026-01-25T23:06:40.028Z] [MAIN] [LOG] [2026-01-25T23:06:40.028Z] [MAIN] [2026-01-25T23:06:40.028Z] Initial checkForUpdatesAndNotify completed {  updateAvailable: false,  version: '1.0.251',  releaseDate: '2026-01-25T01:52:37.736Z',  fileCount: 2,  stagingPercentage: null}[2026-01-25T23:06:40.389Z] [MAIN] [LOG] "[INFO]" "Client connected:" "cmux_1"[2026-01-25T23:06:40.389Z] [MAIN] [LOG] [2026-01-25T23:06:40.389Z] [INFO] Client connected: cmux_1[2026-01-25T23:06:40.390Z] [MAIN] [LOG] "[INFO]" "Starting GitHub data refresh..."[2026-01-25T23:06:40.390Z] [MAIN] [LOG] [2026-01-25T23:06:40.390Z] [INFO] Starting GitHub data refresh...[2026-01-25T23:06:40.398Z] [MAIN] [LOG] "[INFO]" "Starting Docker container state sync after authenticated connect"[2026-01-25T23:06:40.398Z] [MAIN] [LOG] [2026-01-25T23:06:40.398Z] [INFO] Starting Docker container state sync after authenticated connect[2026-01-25T23:06:40.398Z] [MAIN] [LOG] "[INFO]" "Starting docker event stream for container state sync"[2026-01-25T23:06:40.398Z] [MAIN] [LOG] [2026-01-25T23:06:40.398Z] [INFO] Starting docker event stream for container state sync[2026-01-25T23:06:40.399Z] [MAIN] [WARN] "[WARN]" "[docker events] Docker socket not found at /var/run/docker.sock. Retrying in 1000ms"[2026-01-25T23:06:40.399Z] [MAIN] [WARN] [2026-01-25T23:06:40.399Z] [WARN] [docker events] Docker socket not found at /var/run/docker.sock. Retrying in 1000ms[2026-01-25T23:06:41.400Z] [MAIN] [WARN] "[WARN]" "[docker events] Docker socket not found at /var/run/docker.sock. Retrying in 2000ms"[2026-01-25T23:06:41.400Z] [MAIN] [WARN] [2026-01-25T23:06:41.400Z] [WARN] [docker events] Docker socket not found at /var/run/docker.sock. Retrying in 2000ms[2026-01-25T23:06:43.401Z] [MAIN] [WARN] "[WARN]" "[docker events] Docker socket not found at /var/run/docker.sock. Retrying in 4000ms"[2026-01-25T23:06:43.401Z] [MAIN] [WARN] [2026-01-25T23:06:43.401Z] [WARN] [docker events] Docker socket not found at /var/run/docker.sock. Retrying in 4000ms[2026-01-25T23:06:46.688Z] [MAIN] [LOG] "[INFO]" "Refreshing repository data with 168 repos..."[2026-01-25T23:06:46.689Z] [MAIN] [LOG] [2026-01-25T23:06:46.689Z] [INFO] Refreshing repository data with 168 repos...[2026-01-25T23:06:46.941Z] [MAIN] [LOG] "[INFO]" "Repository data refreshed successfully"[2026-01-25T23:06:46.941Z] [MAIN] [LOG] [2026-01-25T23:06:46.941Z] [INFO] Repository data refreshed successfully[2026-01-25T23:06:46.941Z] [MAIN] [LOG] "[INFO]" "GitHub data refresh completed"[2026-01-25T23:06:46.941Z] [MAIN] [LOG] [2026-01-25T23:06:46.941Z] [INFO] GitHub data refresh completed[2026-01-25T23:06:47.407Z] [MAIN] [WARN] "[WARN]" "[docker events] Docker socket not found at /var/run/docker.sock. Retrying in 8000ms"[2026-01-25T23:06:47.407Z] [MAIN] [WARN] [2026-01-25T23:06:47.407Z] [WARN] [docker events] Docker socket not found at /var/run/docker.sock. Retrying in 8000ms[2026-01-25T23:06:55.411Z] [MAIN] [WARN] "[WARN]" "[docker events] Docker socket not found at /var/run/docker.sock. Retrying in 16000ms"[2026-01-25T23:06:55.412Z] [MAIN] [WARN] [2026-01-25T23:06:55.412Z] [WARN] [docker events] Docker socket not found at /var/run/docker.sock. Retrying in 16000ms[2026-01-25T23:07:02.273Z] [MAIN] [ERROR] "Error occurred in handler for 'cmux:rpc':" {  "name": "Error",  "message": "RPC 'create-local-workspace' timed out waiting for ack",  "stack": "Error: RPC 'create-local-workspace' timed out waiting for ack\n    at Timeout._onTimeout (file:///Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/main/chunks/index-FuEiBP4E.js:25848:22)\n    at listOnTimeout (node:internal/timers:588:17)\n    at process.processTimers (node:internal/timers:523:7)"}[2026-01-25T23:07:02.274Z] [MAIN] [ERROR] [2026-01-25T23:07:02.273Z] Error occurred in handler for 'cmux:rpc': {  name: 'Error',  message: "RPC 'create-local-workspace' timed out waiting for ack",  stack: "Error: RPC 'create-local-workspace' timed out waiting for ack\n" +    '    at Timeout._onTimeout (file:///Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/main/chunks/index-FuEiBP4E.js:25848:22)\n' +    '    at listOnTimeout (node:internal/timers:588:17)\n' +    '    at process.processTimers (node:internal/timers:523:7)'}[2026-01-25T23:07:08.186Z] [MAIN] [ERROR] "[ERROR]" "Error creating local workspace:" Error: VS Code serve-web proxy is not readyError: VS Code serve-web proxy is not ready    at file:///Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/main/chunks/index-FuEiBP4E.js:24320:19[2026-01-25T23:07:08.187Z] [MAIN] [ERROR] [2026-01-25T23:07:08.187Z] [ERROR] Error creating local workspace: Error: VS Code serve-web proxy is not ready    at file:///Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/main/chunks/index-FuEiBP4E.js:24320:19[2026-01-25T23:07:11.418Z] [MAIN] [WARN] "[WARN]" "[docker events] Docker socket not found at /var/run/docker.sock. Retrying in 30000ms"[2026-01-25T23:07:11.418Z] [MAIN] [WARN] [2026-01-25T23:07:11.418Z] [WARN] [docker events] Docker socket not found at /var/run/docker.sock. Retrying in 30000ms===== renderer.log =====Last modified: 2026-01-25T23:07:03.340Z[2026-01-25T23:06:39.011Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.874Z] Setting up auto-updates { appVersion: '1.0.251', platform: 'darwin', arch: 'arm64' } (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.875Z] Configured autoUpdater channel { channel: 'latest-universal', arch: 'arm64' } (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.875Z] Auto-updater configuration complete {  autoDownload: true,  autoInstallOnAppQuit: true,  allowPrerelease: false,  channel: 'latest-universal'} (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.875Z] Starting initial auto-update check (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.875Z] [updater] Checking for update (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.875Z] Checking for update… (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.875Z] Loading renderer (prod) { host: 'cmux.local' } (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.048Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:38.912Z] did-navigate { url: 'https://cmux.local/index-electron.html' } (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.096Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:39.049Z] Window ready-to-show (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:39.096Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:39.053Z] Renderer finished load (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:40.030Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:40.027Z] [updater] Update for version 1.0.251 is not available (latest version: 1.0.251, downgrade is allowed). (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:40.031Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:40.028Z] No updates available (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:40.032Z] [RENDERER] [INFO] [MAIN] [2026-01-25T23:06:40.028Z] Initial checkForUpdatesAndNotify completed {  updateAvailable: false,  version: '1.0.251',  releaseDate: '2026-01-25T01:52:37.736Z',  fileCount: 2,  stagingPercentage: null} (/Users/cmux/actions-runner-2/_work/cmux/cmux/apps/client/dist-electron/mac-arm64/cmux.app/Contents/Resources/app.asar/out/preload/index.cjs:4297)[2026-01-25T23:06:40.375Z] [RENDERER] [WARNING] [ElectronSocket] No auth token yet; delaying connect (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:40.387Z] [RENDERER] [INFO] [ElectronSocket] Connecting via IPC (cmux)... (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:48.417Z] [RENDERER] [ERROR] [ReactQueryError] [object Object] (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:48.417Z] [RENDERER] [ERROR] Failed to preload terminal tabs Error: Failed to load terminals (401) (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:48.513Z] [RENDERER] [ERROR] Failed to create default terminal Error: Failed to create terminal (401) (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:48.525Z] [RENDERER] [ERROR] [ReactQueryError] [object Object] (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:48.525Z] [RENDERER] [ERROR] Failed to preload terminal tabs Error: Failed to load terminals (401) (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:06:48.597Z] [RENDERER] [ERROR] Failed to create default terminal Error: Failed to create terminal (401) (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:07:02.275Z] [RENDERER] [ERROR] [CmuxIpcSocketClient] RPC error [object Object] (https://cmux.local/assets/index-DxfOmA7c.js:5716)[2026-01-25T23:07:03.340Z] [RENDERER] [ERROR] RPC 'create-local-workspace' failed: RPC 'create-local-workspace' failed: Error invoking remote method 'cmux:rpc': [object Object] (https://cmux.local/assets/index-DxfOmA7c.js:5716)cin a fresh install, the local workspaces seem to not be working properly. we get an issue where it is unable to start local workspaceimage.png and there is a checkmark with vscode loading forever.. the local workspace should never have a checkmark... ultrathink