### PR TITLE
Preserve focus during workspace rename

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -733,6 +733,7 @@ function TaskTreeInner({
       aria-invalid={renameError ? true : undefined}
       autoComplete="off"
       spellCheck={false}
+      data-cmux-inline-editing="true"
       className={clsx(
         "inline-flex w-full items-center bg-transparent text-[13px] font-medium text-neutral-900 caret-neutral-600 transition-colors duration-200",
         "leading-[18px] h-[18px] px-0 py-0 align-middle",

--- a/apps/client/src/components/dashboard/DashboardInput.tsx
+++ b/apps/client/src/components/dashboard/DashboardInput.tsx
@@ -123,6 +123,25 @@ export const DashboardInput = memo(
         }, 0);
       };
 
+      const isEditableElement = (element: Element | null): boolean => {
+        if (!element) {
+          return false;
+        }
+        if (
+          element instanceof HTMLInputElement ||
+          element instanceof HTMLTextAreaElement ||
+          element instanceof HTMLSelectElement ||
+          element.getAttribute("contenteditable") === "true"
+        ) {
+          return true;
+        }
+        // Check for elements marked as inline editing (e.g., rename inputs)
+        if (element.closest("[data-cmux-inline-editing]")) {
+          return true;
+        }
+        return false;
+      };
+
       const shouldRestoreFocus = (
         event: FocusEvent,
         candidateActiveElement: Element | null
@@ -149,12 +168,13 @@ export const DashboardInput = memo(
         }
 
         // Don't restore focus if user is interacting with form elements
+        // Check both activeElement and relatedTarget (the element receiving focus)
+        // This handles timing issues where activeElement is briefly document.body
+        const relatedTarget =
+          event.relatedTarget instanceof Element ? event.relatedTarget : null;
         if (
-          candidateActiveElement &&
-          (candidateActiveElement instanceof HTMLInputElement ||
-            candidateActiveElement instanceof HTMLTextAreaElement ||
-            candidateActiveElement instanceof HTMLSelectElement ||
-            candidateActiveElement.getAttribute("contenteditable") === "true")
+          isEditableElement(candidateActiveElement) ||
+          isEditableElement(relatedTarget)
         ) {
           return false;
         }

--- a/apps/client/src/components/dashboard/TaskItem.tsx
+++ b/apps/client/src/components/dashboard/TaskItem.tsx
@@ -346,6 +346,7 @@ export const TaskItem = memo(function TaskItem({
                   aria-invalid={renameError ? true : undefined}
                   autoComplete="off"
                   spellCheck={false}
+                  data-cmux-inline-editing="true"
                   className={clsx(
                     "inline-flex w-full items-center bg-transparent text-[13px] font-medium text-neutral-900 caret-neutral-600 transition-colors duration-200 pr-1",
                     "px-0 py-0 align-middle",

--- a/apps/client/src/components/editable-label.tsx
+++ b/apps/client/src/components/editable-label.tsx
@@ -165,6 +165,7 @@ export function EditableLabel({
           suppressContentEditableWarning
           spellCheck={false}
           data-placeholder={placeholder}
+          data-cmux-inline-editing={isEditing ? "true" : undefined}
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}


### PR DESCRIPTION
sometimes when im renaming a workspace i actually lose focus for some reason, make sure that nothing is able to steal away my focus when im renaming a workspace/task/.. ultrathink