### PR TITLE
Fix unresizable, expanding sidebar on resize

### DIFF
--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -513,6 +513,12 @@ pre,
 }
 
 /* Sidebar responsive width */
+[style*="--sidebar-width"] {
+  width: min(var(--sidebar-width), 75vw) !important;
+  min-width: min(var(--sidebar-width), 75vw) !important;
+  max-width: min(var(--sidebar-width), 75vw) !important;
+}
+
 @media (min-width: 768px) {
   [style*="--sidebar-width"] {
     width: var(--sidebar-width) !important;


### PR DESCRIPTION
image.png the sidebar is weird and unresizable, it also expands to this for some reason when we shrink the width of the brwoser tab... this is in chrome mode and electron, both happens. we need a fix for this