### PR TITLE
Fix Codex task terminals not showing in VS Code

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "apps/client": {
       "name": "@cmux/client",
-      "version": "1.0.256",
+      "version": "1.0.258",
       "dependencies": {
         "@base-ui-components/react": "1.0.0-beta.2",
         "@cmux/convex": "workspace:*",
@@ -525,6 +525,7 @@
       "version": "0.0.1",
       "dependencies": {
         "socket.io-client": "^4.6.1",
+        "ws": "^8.18.3",
       },
       "devDependencies": {
         "@cmux/shared": "workspace:*",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -106,6 +106,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "socket.io-client": "^4.6.1"
+    "socket.io-client": "^4.6.1",
+    "ws": "^8.18.3"
   }
 }


### PR DESCRIPTION
### Problem
For Codex-backed tasks, the cmux VS Code extension sometimes never created/attached to the cmux-pty terminal, so the user couldn't see what the agent was doing.

### Root Cause
The extension's PTY transport assumed a browser/modern-Node `WebSocket` global and specific `message` data shapes. In some environments the extension host runs without a global `WebSocket`, or delivers binary frames as `Buffer`/`Uint8Array`, causing the cmux-pty connection to fail and the terminal never to appear.

### Fix
- Add a small WebSocket wrapper that uses `globalThis.WebSocket` when available, otherwise falls back to the `ws` package.
- Normalize `message` decoding to support `string`, `ArrayBuffer`, and `ArrayBufferView` (Buffer/Uint8Array), plus Blob.
- Stop relying on `WebSocket.OPEN/CONNECTING` constants and use numeric ready states.

Files:
- `packages/vscode-extension/src/terminal.ts`
- `packages/vscode-extension/package.json` (add `ws`)
- `bun.lock`

### Testing
- `bun check`
- `cd packages/vscode-extension && bun run compile-bun`
