### PR TITLE
Persist cmux diff sidebar width across views

### DIFF
--- a/apps/client/src/components/heatmap-diff-viewer/git-diff-review-viewer.tsx
+++ b/apps/client/src/components/heatmap-diff-viewer/git-diff-review-viewer.tsx
@@ -170,7 +170,7 @@ type GitDiffHeatmapReviewViewerProps = {
   onToggleHeatmap?: () => void;
 };
 
-const SIDEBAR_WIDTH_STORAGE_KEY = "cmux:git-diff-viewer:file-tree-width";
+const SIDEBAR_WIDTH_STORAGE_KEY = "cmux:monaco-diff-sidebar:width";
 const SIDEBAR_DEFAULT_WIDTH = 280;
 const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 442;


### PR DESCRIPTION
the sidebar for the git diff viewer is not persisted to the same width for both the cmux heatmap and the cmux regular monaco diff viewr