### PR TITLE
feat: Add claude-opus-4-6 to AWS Bedrock model mappings

### DIFF
--- a/packages/convex/convex/bedrock_utils.ts
+++ b/packages/convex/convex/bedrock_utils.ts
@@ -33,6 +33,8 @@ export const BEDROCK_INFERENCE_PROFILE: "us" | "global" = "us";
  * The prefix (us/global) is applied dynamically based on BEDROCK_INFERENCE_PROFILE.
  */
 const BASE_MODELS = {
+  // Claude 4.6 models
+  "opus-4-6": "anthropic.claude-opus-4-6-v1",
   // Claude 4.5 models
   "sonnet-4-5": "anthropic.claude-sonnet-4-5-20250929-v1:0",
   "opus-4-5": "anthropic.claude-opus-4-5-20251101-v1:0",
@@ -62,6 +64,9 @@ function withPrefix(baseModel: string): string {
  * Uses the configured BEDROCK_INFERENCE_PROFILE prefix.
  */
 export const MODEL_MAP: Record<string, string> = {
+  // Opus 4.6 variants
+  "claude-opus-4-6": withPrefix(BASE_MODELS["opus-4-6"]),
+  "claude-4-6-opus": withPrefix(BASE_MODELS["opus-4-6"]),
   // Sonnet 4.5 variants
   "claude-sonnet-4-5-20250929": withPrefix(BASE_MODELS["sonnet-4-5"]),
   "claude-sonnet-4-5": withPrefix(BASE_MODELS["sonnet-4-5"]),

--- a/packages/shared/src/utils/anthropic.ts
+++ b/packages/shared/src/utils/anthropic.ts
@@ -8,6 +8,8 @@ export const CMUX_ANTHROPIC_PROXY_PLACEHOLDER_API_KEY =
  * AWS Bedrock model IDs for Claude models.
  * Used by code review heatmap feature.
  */
+export const ANTHROPIC_MODEL_OPUS_46 =
+  "global.anthropic.claude-opus-4-6-v1";
 export const ANTHROPIC_MODEL_OPUS_45 =
   "global.anthropic.claude-opus-4-5-20251101-v1:0";
 export const ANTHROPIC_MODEL_HAIKU_45 =


### PR DESCRIPTION
## Summary
- Add `anthropic.claude-opus-4-6-v1` to Bedrock `BASE_MODELS` and `MODEL_MAP` in `bedrock_utils.ts`
- Add `ANTHROPIC_MODEL_OPUS_46` export (`global.anthropic.claude-opus-4-6-v1`) in shared anthropic utils

## Test plan
- [ ] Verify `toBedrockModelId("claude-opus-4-6")` resolves correctly
- [ ] Verify passthrough works for `global.anthropic.claude-opus-4-6-v1` via `ANTHROPIC_MODEL` env var