### PR TITLE
perf: parallelize and batch post-boot sandbox setup

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1215,7 +1215,7 @@ const convexSchema = defineSchema({
   // Provider-specific info for devbox instances (maps our ID to provider details)
   devboxInfo: defineTable({
     devboxId: v.string(), // Our friendly ID (cmux_xxxxxxxx)
-    provider: v.union(v.literal("morph"), v.literal("e2b")), // Provider name (extensible for future providers)
+    provider: v.union(v.literal("morph"), v.literal("e2b"), v.literal("daytona")), // Provider name (extensible for future providers)
     providerInstanceId: v.string(), // Provider's instance ID (e.g., morphvm_xxx)
     snapshotId: v.optional(v.string()), // Snapshot ID used to create the instance
     createdAt: v.number(),


### PR DESCRIPTION
## Summary

- **Fail-fast GitHub token check**: Validates credentials _before_ starting the VM, saving 3-8s on bad creds instead of wasting a Morph instance
- **Batched setup into ONE `instance.exec()` call**: Combines envctl load, `gh auth login` (with bash retry loop), and `git config` into a single combined bash script — eliminates 2-4 sequential network round-trips (~1-5s saved)
- **Parallel post-boot tracks**: After `instances.start()` returns, runs two concurrent tracks:
  - **Track A** (frontend): Re-fetch instance networking → parallel(waitForVSCode, persist URLs to Convex)
  - **Track B** (sandbox config): parallel(fetch git identity, fetch env vars) → combined exec → hydrate workspace
- **Early repo URL validation**: Moved `repoConfig` building before VM boot for fast 400 on bad URLs

### Before (sequential waterfall)
```
instances.start() → re-fetch → waitForVSCode → persist URLs → envctl exec → gh auth exec (5 retries) → git config exec → hydrate exec
```

### After (parallel + batched)
```
instances.start() →
  Track A: re-fetch → parallel(waitForVSCode, persist URLs)
  Track B: gather inputs → ONE combined exec → hydrate
  ↓
  Promise.all([A, B])
```

**Estimated savings**: ~4-7s on happy path, ~7-15s when gh auth retries are needed.

## Test plan
- [ ] Start a sandbox with a repo URL — verify VSCode loads, repo is cloned, git identity is configured
- [ ] Start a sandbox without a repo URL — verify basic startup works
- [ ] Start a sandbox with bad GitHub credentials — verify fast 401 before VM starts
- [ ] Start a sandbox with an invalid repo URL — verify fast 400 before VM starts
- [ ] Verify maintenance/dev scripts still run after setup completes
- [ ] Check logs for combined setup success messages