### PR TITLE
Fix E2B template: make bun/rust globally accessible

### DIFF
--- a/packages/cmux-devbox-2/npm/cmux/package.json
+++ b/packages/cmux-devbox-2/npm/cmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "CLI tool to instantly spin up cloud VMs preloaded with Chrome, VNC, SSH, and rsync",
   "keywords": [
     "cli",
@@ -31,11 +31,11 @@
     "postinstall": "node lib/postinstall.js"
   },
   "optionalDependencies": {
-    "cmux-darwin-arm64": "0.7.19",
-    "cmux-darwin-x64": "0.7.19",
-    "cmux-linux-arm64": "0.7.19",
-    "cmux-linux-x64": "0.7.19",
-    "cmux-win32-x64": "0.7.19"
+    "cmux-darwin-arm64": "0.7.20",
+    "cmux-darwin-x64": "0.7.20",
+    "cmux-linux-arm64": "0.7.20",
+    "cmux-linux-x64": "0.7.20",
+    "cmux-win32-x64": "0.7.20"
   },
   "engines": {
     "node": ">=16"

--- a/packages/cmux-devbox-2/npm/darwin-arm64/package.json
+++ b/packages/cmux-devbox-2/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux-darwin-arm64",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "cmux binary for macOS ARM64",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/cmux-devbox-2/npm/darwin-x64/package.json
+++ b/packages/cmux-devbox-2/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux-darwin-x64",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "cmux binary for macOS x64",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/cmux-devbox-2/npm/linux-arm64/package.json
+++ b/packages/cmux-devbox-2/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux-linux-arm64",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "cmux binary for Linux ARM64",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/cmux-devbox-2/npm/linux-x64/package.json
+++ b/packages/cmux-devbox-2/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux-linux-x64",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "cmux binary for Linux x64",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/cmux-devbox-2/npm/win32-x64/package.json
+++ b/packages/cmux-devbox-2/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux-win32-x64",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "cmux binary for Windows x64",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/packages/cmux-devbox-2/template/e2b.Dockerfile
+++ b/packages/cmux-devbox-2/template/e2b.Dockerfile
@@ -47,10 +47,19 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm@latest
 
-# Install Bun
-RUN curl -fsSL https://bun.sh/install | bash
-ENV BUN_INSTALL="/root/.bun"
-ENV PATH="$BUN_INSTALL/bin:$PATH"
+# Install Bun globally (accessible to all users, not just root)
+RUN curl -fsSL https://bun.sh/install | bash \
+    && cp /root/.bun/bin/bun /usr/local/bin/bun \
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx
+
+# Install Rust globally (rustup + toolchain accessible to all users)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo sh -s -- -y --default-toolchain stable --no-modify-path \
+    && chmod -R a+rX /usr/local/rustup /usr/local/cargo \
+    && ln -s /usr/local/cargo/bin/* /usr/local/bin/ \
+    && echo 'export RUSTUP_HOME=/usr/local/rustup' >> /etc/profile.d/rust.sh \
+    && echo 'export CARGO_HOME=/usr/local/cargo' >> /etc/profile.d/rust.sh
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/packages/cmux-devbox-2/template/e2b.docker.Dockerfile
+++ b/packages/cmux-devbox-2/template/e2b.docker.Dockerfile
@@ -57,10 +57,19 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm@latest
 
-# Install Bun
-RUN curl -fsSL https://bun.sh/install | bash
-ENV BUN_INSTALL="/root/.bun"
-ENV PATH="$BUN_INSTALL/bin:$PATH"
+# Install Bun globally (accessible to all users, not just root)
+RUN curl -fsSL https://bun.sh/install | bash \
+    && cp /root/.bun/bin/bun /usr/local/bin/bun \
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx
+
+# Install Rust globally (rustup + toolchain accessible to all users)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo sh -s -- -y --default-toolchain stable --no-modify-path \
+    && chmod -R a+rX /usr/local/rustup /usr/local/cargo \
+    && ln -s /usr/local/cargo/bin/* /usr/local/bin/ \
+    && echo 'export RUSTUP_HOME=/usr/local/rustup' >> /etc/profile.d/rust.sh \
+    && echo 'export CARGO_HOME=/usr/local/cargo' >> /etc/profile.d/rust.sh
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary
- Fix bun installation in E2B sandbox: copy binary to `/usr/local/bin/` instead of relying on `/root/.bun/` (inaccessible to `user` account due to 700 perms on `/root/`)
- Add Rust/cargo globally with `RUSTUP_HOME=/usr/local/rustup` and `CARGO_HOME=/usr/local/cargo`, exposed via `/etc/profile.d/rust.sh`
- Apply fixes to both `e2b.Dockerfile` and `e2b.docker.Dockerfile`
- Bump npm packages to v0.7.20 with production credentials (already published)

## Test plan
- [x] Built and deployed E2B template
- [x] Verified `bun --version`, `cargo --version`, `rustc --version` all work as `user` account in sandbox
- [x] Published npm packages v0.7.20 with production credentials