### PR TITLE
Rename cmux to Manaflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-<h1 align="center">cmux</h1>
+<h1 align="center">Manaflow</h1>
 <p align="center">Open source Claude Code web/Codex Cloud/Devin alternative</p>
 
 <p align="center">
   <a href="https://www.cmux.dev/direct-download-macos">
-    <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
+    <img src="./docs/assets/macos-badge.png" alt="Download Manaflow for macOS" width="180" />
   </a>
 </p>
 
 <p align="center">
-  Join the <a href="https://discord.gg/SDbQmzQhRK">Discord</a> to talk more about cmux!
+  Join the <a href="https://discord.gg/SDbQmzQhRK">Discord</a> to talk more about Manaflow!
 </p>
 
-cmux lets you spawn Claude Code, Codex CLI, Cursor CLI, Gemini CLI, Amp, Opencode, and other coding agent CLIs in parallel across multiple tasks.
+Manaflow lets you spawn Claude Code, Codex CLI, Cursor CLI, Gemini CLI, Amp, Opencode, and other coding agent CLIs in parallel across multiple tasks.
 
 Every run spins up an isolated VS Code workspace either in the cloud or in a local Docker container with the git diff view, terminal, and dev server preview ready so parallel agent work stays verifiable, fast, and ready to ship.
 
@@ -60,7 +60,7 @@ Every run spins up an isolated VS Code workspace either in the cloud or in a loc
 </td>
 <td width="50%">
 <h3>One-Click PR Creation</h3>
-<p>Review diffs, squash and merge, or open pull requests directly from the workspace. View GitHub Action results and CI status without leaving cmux.</p>
+<p>Review diffs, squash and merge, or open pull requests directly from the workspace. View GitHub Action results and CI status without leaving Manaflow.</p>
 </td>
 </tr>
 </table>
@@ -91,10 +91,10 @@ Every run spins up an isolated VS Code workspace either in the cloud or in a loc
 
 ## Install
 
-cmux supports macOS. Linux in beta. Windows coming soon.
+Manaflow supports macOS. Linux in beta. Windows coming soon.
 
 <a href="https://www.cmux.dev/direct-download-macos">
-  <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
+  <img src="./docs/assets/macos-badge.png" alt="Download Manaflow for macOS" width="180" />
 </a>
 
 <!-- ```bash


### PR DESCRIPTION
## Summary
- Rename all user-facing `cmux` references to `Manaflow` in README.md (title, description, install section, badge alt text, Discord link)
- Image file paths left unchanged since they reference actual filenames

## Test plan
- [ ] Verify README renders correctly on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only rename with no code or behavior changes; risk limited to potential mismatched branding/links in the README.
> 
> **Overview**
> Updates `README.md` branding from **cmux** to **Manaflow** across the title, intro copy, install section, and macOS badge alt text, plus updates the Discord callout to reference Manaflow.
> 
> Links and image paths remain unchanged (still pointing at `cmux` assets/URLs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196fa348cfd99ccb8806ee73a0445c0c49055268. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->