### PR TITLE
fix: update repo references from manaflow-ai/cmux to manaflow-ai/manaflow

### DIFF
--- a/CLEANUP.md
+++ b/CLEANUP.md
@@ -2,6 +2,6 @@ Important scripts for manual cleanup
 
 
 ```bash
-bun run ./scripts/prune-convex-preview-deployments.ts --github-repo manaflow-ai/cmux --min-age-days 3 --exclude adorable-wombat-701 polite-canary-804 famous-camel-162
+bun run ./scripts/prune-convex-preview-deployments.ts --github-repo manaflow-ai/manaflow --min-age-days 3 --exclude adorable-wombat-701 polite-canary-804 famous-camel-162
 bun run ./scripts/morph-pause-old-active-instances.ts
 ```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-<h1 align="center">cmux</h1>
+<h1 align="center">Manaflow</h1>
 <p align="center">Open source Claude Code web/Codex Cloud/Devin alternative</p>
 
 <p align="center">
   <a href="https://www.cmux.dev/direct-download-macos">
-    <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
+    <img src="./docs/assets/macos-badge.png" alt="Download Manaflow for macOS" width="180" />
   </a>
 </p>
 
 <p align="center">
-  Join the <a href="https://discord.gg/SDbQmzQhRK">Discord</a> to talk more about cmux!
+  Join the <a href="https://discord.gg/SDbQmzQhRK">Discord</a> to talk more about Manaflow!
 </p>
 
-cmux lets you spawn Claude Code, Codex CLI, Cursor CLI, Gemini CLI, Amp, Opencode, and other coding agent CLIs in parallel across multiple tasks.
+Manaflow lets you spawn Claude Code, Codex CLI, Cursor CLI, Gemini CLI, Amp, Opencode, and other coding agent CLIs in parallel across multiple tasks.
 
 Every run spins up an isolated VS Code workspace either in the cloud or in a local Docker container with the git diff view, terminal, and dev server preview ready so parallel agent work stays verifiable, fast, and ready to ship.
 
@@ -60,7 +60,7 @@ Every run spins up an isolated VS Code workspace either in the cloud or in a loc
 </td>
 <td width="50%">
 <h3>One-Click PR Creation</h3>
-<p>Review diffs, squash and merge, or open pull requests directly from the workspace. View GitHub Action results and CI status without leaving cmux.</p>
+<p>Review diffs, squash and merge, or open pull requests directly from the workspace. View GitHub Action results and CI status without leaving Manaflow.</p>
 </td>
 </tr>
 </table>
@@ -91,10 +91,10 @@ Every run spins up an isolated VS Code workspace either in the cloud or in a loc
 
 ## Install
 
-cmux supports macOS. Linux in beta. Windows coming soon.
+Manaflow supports macOS. Linux in beta. Windows coming soon.
 
 <a href="https://www.cmux.dev/direct-download-macos">
-  <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
+  <img src="./docs/assets/macos-badge.png" alt="Download Manaflow for macOS" width="180" />
 </a>
 
 <!-- ```bash

--- a/apps/client/electron/main/protocol-registration.ts
+++ b/apps/client/electron/main/protocol-registration.ts
@@ -11,7 +11,6 @@ function looksLikeOption(arg: string): boolean {
 function looksLikeUrl(arg: string): boolean {
   // Protocol URLs may include auth tokens; treat all URLs as non-paths here.
   try {
-    // eslint-disable-next-line no-new
     new URL(arg);
     return true;
   } catch {
@@ -48,4 +47,3 @@ export function computeSetAsDefaultProtocolClientCall(params: {
     args: [resolve(appPathArg)],
   };
 }
-

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/manaflow-ai/cmux.git"
+    "url": "https://github.com/manaflow-ai/manaflow.git"
   },
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/server/native/core/src/tests.rs
+++ b/apps/server/native/core/src/tests.rs
@@ -923,7 +923,7 @@ fn fuzz_merge_commit_inference_matches_github() {
 fn debug_single_pr() {
     let truth = ground_truth();
     let target_repo =
-        std::env::var("DEBUG_PR_REPO").unwrap_or_else(|_| "manaflow-ai/cmux".to_string());
+        std::env::var("DEBUG_PR_REPO").unwrap_or_else(|_| "manaflow-ai/manaflow".to_string());
     let target_number: u64 = std::env::var("DEBUG_PR_NUMBER")
         .ok()
         .and_then(|v| v.parse().ok())

--- a/apps/server/src/diffs/compareRefs.realrepo.test.ts
+++ b/apps/server/src/diffs/compareRefs.realrepo.test.ts
@@ -8,7 +8,7 @@ describe.sequential.skip("getGitDiff - real repo (cmux PR 259)", () => {
     const entries = await getGitDiff({
       baseRef: "main",
       headRef: "cmux/update-readme-to-bold-its-last-line-rpics",
-      repoFullName: "manaflow-ai/cmux",
+      repoFullName: "manaflow-ai/manaflow",
       teamSlugOrId: "test-team",
       includeContents: true,
     } as unknown as Parameters<typeof getGitDiff>[0]);

--- a/apps/server/src/scripts/test-agent-spawner-cloud.ts
+++ b/apps/server/src/scripts/test-agent-spawner-cloud.ts
@@ -15,7 +15,7 @@ console.log("Running with agent config:", agentConfig);
 
 const { taskId } = await getConvex().mutation(api.tasks.create, {
   teamSlugOrId: "default",
-  projectFullName: "manaflow-ai/cmux",
+  projectFullName: "manaflow-ai/manaflow",
   text: "whats the time rn?",
 });
 
@@ -24,7 +24,7 @@ const result = await spawnAgent(
   agentConfig,
   taskId,
   {
-    repoUrl: "https://github.com/manaflow-ai/cmux",
+    repoUrl: "https://github.com/manaflow-ai/manaflow",
     branch: "main",
     taskDescription: "whats the time rn?",
     isCloudMode: true,

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -2785,7 +2785,7 @@ Please address the issue mentioned in the comment above.`;
         const { taskId } = await getConvex().mutation(api.tasks.create, {
           teamSlugOrId: safeTeam,
           text: formattedPrompt,
-          projectFullName: "manaflow-ai/cmux",
+          projectFullName: "manaflow-ai/manaflow",
         });
         // Create a comment reply with link to the task
         try {
@@ -2809,7 +2809,7 @@ Please address the issue mentioned in the comment above.`;
         const agentResults = await spawnAllAgents(
           taskId,
           {
-            repoUrl: "https://github.com/manaflow-ai/cmux.git",
+            repoUrl: "https://github.com/manaflow-ai/manaflow.git",
             branch: "main",
             taskDescription: formattedPrompt,
             isCloudMode: true,

--- a/apps/www/app/heatmap/page.tsx
+++ b/apps/www/app/heatmap/page.tsx
@@ -109,7 +109,7 @@ export default function HeatmapPage() {
               className="break-all text-black underline"
             >
               https://github.com/manaflow-ai/
-              <span className="bg-blue-200 px-1">cmux</span>
+              <span className="bg-blue-200 px-1">manaflow</span>
             </a>
           </div>
         </div>

--- a/apps/www/app/heatmap/page.tsx
+++ b/apps/www/app/heatmap/page.tsx
@@ -86,13 +86,13 @@ export default function HeatmapPage() {
               /simonw/datasette/pull/2548
             </a>
             <a
-              href="https://0github.com/manaflow-ai/cmux/pull/666"
+              href="https://0github.com/manaflow-ai/manaflow/pull/666"
               target="_blank"
               rel="noopener noreferrer"
               className="break-all text-black underline"
             >
               https://<span className="bg-yellow-300 px-1">0github.com</span>
-              /manaflow-ai/cmux/pull/666
+              /manaflow-ai/manaflow/pull/666
             </a>
           </div>
         </div>
@@ -103,7 +103,7 @@ export default function HeatmapPage() {
           </p>
           <div className="flex flex-col gap-2">
             <a
-              href="https://github.com/manaflow-ai/cmux"
+              href="https://github.com/manaflow-ai/manaflow"
               target="_blank"
               rel="noopener noreferrer"
               className="break-all text-black underline"

--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -35,7 +35,7 @@ export default function ManaflowPage() {
                 cmux.dev
               </a>
               <a
-                href="https://github.com/manaflow-ai/cmux"
+                href="https://github.com/manaflow-ai/manaflow"
                 target="_blank"
                 className="text-neutral-500 hover:text-neutral-700 hover:underline text-sm"
               >

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -245,7 +245,7 @@ export default async function LandingPage() {
               </div>
               {latestVersion ? (
                 <p className="text-xs text-neutral-400">
-                  Latest release: {latestVersion}. Need another build? Visit the{" "}
+                  Latest release: Manaflow {latestVersion}. Need another build? Visit the{" "}
                   <a
                     href="https://github.com/manaflow-ai/manaflow/releases"
                     target="_blank"

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -225,8 +225,8 @@ export default async function LandingPage() {
                   className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-neutral-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800"
                   title={
                     latestVersion
-                      ? `Download ${latestVersion} for macOS`
-                      : "Download for macOS"
+                      ? `Download Manaflow ${latestVersion} for macOS`
+                      : "Download Manaflow for macOS"
                   }
                   urls={macDownloadUrls}
                 >

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -225,8 +225,8 @@ export default async function LandingPage() {
                   className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/10 bg-neutral-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-neutral-800"
                   title={
                     latestVersion
-                      ? `Download cmux ${latestVersion} for macOS`
-                      : "Download cmux for macOS"
+                      ? `Download ${latestVersion} for macOS`
+                      : "Download for macOS"
                   }
                   urls={macDownloadUrls}
                 >
@@ -245,7 +245,7 @@ export default async function LandingPage() {
               </div>
               {latestVersion ? (
                 <p className="text-xs text-neutral-400">
-                  Latest release: cmux {latestVersion}. Need another build? Visit the{" "}
+                  Latest release: {latestVersion}. Need another build? Visit the{" "}
                   <a
                     href="https://github.com/manaflow-ai/manaflow/releases"
                     target="_blank"

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -247,7 +247,7 @@ export default async function LandingPage() {
                 <p className="text-xs text-neutral-400">
                   Latest release: cmux {latestVersion}. Need another build? Visit the{" "}
                   <a
-                    href="https://github.com/manaflow-ai/cmux/releases"
+                    href="https://github.com/manaflow-ai/manaflow/releases"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-neutral-300"
@@ -546,7 +546,7 @@ export default async function LandingPage() {
           <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
             <a
               className="transition hover:text-white"
-              href="https://github.com/manaflow-ai/cmux"
+              href="https://github.com/manaflow-ai/manaflow"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/apps/www/components/pr/pull-request-diff-viewer.tsx
+++ b/apps/www/components/pr/pull-request-diff-viewer.tsx
@@ -2371,7 +2371,7 @@ export function PullRequestDiffViewer({
                   </pre>
                 </div>
                 <a
-                  href="https://github.com/manaflow-ai/cmux"
+                  href="https://github.com/manaflow-ai/manaflow"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 border border-neutral-200 px-3 py-1.5 text-xs font-semibold text-neutral-500 transition hover:border-neutral-300 hover:bg-neutral-50 select-none"
@@ -2510,7 +2510,7 @@ function CmuxPromoCard() {
         </div>
         <div className="flex flex-wrap gap-2 pt-1">
           <a
-            href="https://github.com/manaflow-ai/cmux"
+            href="https://github.com/manaflow-ai/manaflow"
             target="_blank"
             rel="noopener noreferrer"
             className="font-sans inline-flex items-center gap-1 border border-neutral-200 px-3 py-1.5 text-xs font-semibold text-neutral-700 transition hover:border-neutral-300 hover:bg-neutral-50"

--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -1228,7 +1228,7 @@ function MockGitHubPRBrowser() {
                   rel="noopener noreferrer"
                   className="text-[#2f81f7] font-semibold hover:underline cursor-pointer"
                 >
-                  cmux
+                  manaflow
                 </a>
               </div>
             </div>

--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -704,7 +704,7 @@ function MockCmuxStartRun() {
             <div className="mt-3 flex items-center gap-2">
               <div className="flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-950/70 px-3 py-1 text-[11px] text-neutral-200">
                 <Github className="h-3 w-3" />
-                manaflow-ai/cmux
+                manaflow-ai/manaflow
               </div>
               <div className="flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-950/70 px-3 py-1 text-[11px] text-neutral-200">
                 <GitBranch className="h-3 w-3 text-emerald-400" />
@@ -1182,7 +1182,7 @@ function MockGitHubPRBrowser() {
               {activeTab === "github" ? (
                 <>
                   <span className="text-[#9AA0A6]">github.com/</span>
-                  <span>manaflow-ai/cmux/pull/1124</span>
+                  <span>manaflow-ai/manaflow/pull/1124</span>
                 </>
               ) : (
                 <>
@@ -1223,7 +1223,7 @@ function MockGitHubPRBrowser() {
                 </a>
                 <span className="text-[#7d8590]">/</span>
                 <a
-                  href="https://github.com/manaflow-ai/cmux"
+                  href="https://github.com/manaflow-ai/manaflow"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-[#2f81f7] font-semibold hover:underline cursor-pointer"
@@ -2227,7 +2227,7 @@ function MockGitHubPRBrowser() {
                     <div className="space-y-px">
                       <PreviewItemButton
                         title="Preview screenshots for PR #1168"
-                        subtitle="main • manaflow-ai/cmux"
+                        subtitle="main • manaflow-ai/manaflow"
                         isExpanded={expandedTasks.has("task-1")}
                         isSelected={selectedTaskId === "task-1"}
                         isPRMerged={isPRMerged}
@@ -2358,7 +2358,7 @@ function MockGitHubPRBrowser() {
                     <div className="space-y-px">
                       <PreviewItemButton
                         title="Preview screenshots for PR #1142"
-                        subtitle="feat/dark-mode • manaflow-ai/cmux"
+                        subtitle="feat/dark-mode • manaflow-ai/manaflow"
                         isExpanded={expandedTasks.has("task-2")}
                         isSelected={selectedTaskId === "task-2"}
                         onToggleExpand={() => toggleTaskExpanded("task-2")}
@@ -2478,7 +2478,7 @@ function MockGitHubPRBrowser() {
                     <div className="space-y-px">
                       <PreviewItemButton
                         title="Preview screenshots for PR #1098"
-                        subtitle="fix/auth-redirect • manaflow-ai/cmux"
+                        subtitle="fix/auth-redirect • manaflow-ai/manaflow"
                         isExpanded={expandedTasks.has("task-3")}
                         isSelected={selectedTaskId === "task-3"}
                         onToggleExpand={() => toggleTaskExpanded("task-3")}
@@ -4856,7 +4856,7 @@ function PreviewDashboardInner({
             </p>
             <div className="flex items-center gap-3 pt-2">
               <Link
-                href="https://github.com/manaflow-ai/cmux"
+                href="https://github.com/manaflow-ai/manaflow"
                 className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-white"
               >
                 <Star className="h-3.5 w-3.5" />

--- a/apps/www/components/site-header.tsx
+++ b/apps/www/components/site-header.tsx
@@ -142,8 +142,8 @@ export function SiteHeader({
               className="hidden md:inline-flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-neutral-800"
               title={
                 latestVersion
-                  ? `Download cmux ${latestVersion} for macOS`
-                  : "Download cmux for macOS"
+                  ? `Download ${latestVersion} for macOS`
+                  : "Download for macOS"
               }
               urls={effectiveUrls}
             >
@@ -176,8 +176,8 @@ function GithubRepoButton({
   const formattedStars = formatStarCount(stars);
   const ariaLabel =
     typeof stars === "number"
-      ? `View cmux on GitHub (${formattedStars} stars)`
-      : "View cmux on GitHub";
+      ? `View on GitHub (${formattedStars} stars)`
+      : "View on GitHub";
 
   return (
     <a

--- a/apps/www/components/site-header.tsx
+++ b/apps/www/components/site-header.tsx
@@ -142,8 +142,8 @@ export function SiteHeader({
               className="hidden md:inline-flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-neutral-800"
               title={
                 latestVersion
-                  ? `Download ${latestVersion} for macOS`
-                  : "Download for macOS"
+                  ? `Download Manaflow ${latestVersion} for macOS`
+                  : "Download Manaflow for macOS"
               }
               urls={effectiveUrls}
             >
@@ -176,8 +176,8 @@ function GithubRepoButton({
   const formattedStars = formatStarCount(stars);
   const ariaLabel =
     typeof stars === "number"
-      ? `View on GitHub (${formattedStars} stars)`
-      : "View on GitHub";
+      ? `View Manaflow on GitHub (${formattedStars} stars)`
+      : "View Manaflow on GitHub";
 
   return (
     <a

--- a/apps/www/components/site-header.tsx
+++ b/apps/www/components/site-header.tsx
@@ -33,7 +33,7 @@ const DEFAULT_DOWNLOAD_URLS: MacDownloadUrls = {
   x64: null,
 };
 
-const DEFAULT_GITHUB_URL = "https://github.com/manaflow-ai/cmux";
+const DEFAULT_GITHUB_URL = "https://github.com/manaflow-ai/manaflow";
 
 const compactNumberFormatter = new Intl.NumberFormat("en-US", {
   notation: "compact",
@@ -59,7 +59,7 @@ const formatStarCount = (stars?: number | null): string => {
 export function SiteHeader({
   linkPrefix = "",
   showDownload = true,
-  fallbackUrl = "https://github.com/manaflow-ai/cmux/releases",
+  fallbackUrl = "https://github.com/manaflow-ai/manaflow/releases",
   latestVersion,
   macDownloadUrls,
   extraEndContent,

--- a/apps/www/lib/fetch-github-stars.ts
+++ b/apps/www/lib/fetch-github-stars.ts
@@ -1,5 +1,5 @@
-const CMUX_REPO_API_URL = "https://api.github.com/repos/manaflow-ai/cmux";
-export const CMUX_REPO_URL = "https://github.com/manaflow-ai/cmux";
+const CMUX_REPO_API_URL = "https://api.github.com/repos/manaflow-ai/manaflow";
+export const CMUX_REPO_URL = "https://github.com/manaflow-ai/manaflow";
 
 type GithubRepoResponse = {
   stargazers_count?: number;
@@ -23,7 +23,7 @@ export async function fetchGithubRepoStats(): Promise<GithubRepoStats> {
       },
       next: {
         revalidate: 1800,
-        tags: ["github:repo:manaflow-ai/cmux"],
+        tags: ["github:repo:manaflow-ai/manaflow"],
       },
     });
 

--- a/apps/www/lib/github/framework-detection.test.ts
+++ b/apps/www/lib/github/framework-detection.test.ts
@@ -16,8 +16,8 @@ describe.skipIf(shouldSkip)("detectFrameworkAndPackageManager", () => {
     expect(result.devScript).toBe("pnpm run dev");
   }, 30000);
 
-  it("detects manaflow-ai/cmux as bun (no dev script in package.json)", async () => {
-    const result = await detectFrameworkAndPackageManager("manaflow-ai/cmux", GITHUB_TOKEN);
+  it("detects manaflow-ai/manaflow as bun (no dev script in package.json)", async () => {
+    const result = await detectFrameworkAndPackageManager("manaflow-ai/manaflow", GITHUB_TOKEN);
 
     expect(result.packageManager).toBe("bun");
     expect(result.maintenanceScript).toBe("bun install");

--- a/apps/www/lib/releases.ts
+++ b/apps/www/lib/releases.ts
@@ -1,8 +1,8 @@
 export const RELEASE_PAGE_URL =
-  "https://github.com/manaflow-ai/cmux/releases";
+  "https://github.com/manaflow-ai/manaflow/releases";
 
 export const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/manaflow-ai/cmux/releases?per_page=20";
+  "https://api.github.com/repos/manaflow-ai/manaflow/releases?per_page=20";
 
 export const DMG_SUFFIXES = {
   universal: "-universal.dmg",

--- a/apps/www/scripts/backfill-pr.ts
+++ b/apps/www/scripts/backfill-pr.ts
@@ -7,7 +7,7 @@ import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 
 const TEAM = process.env.CMUX_TEAM_SLUG || "manaflow";
-const PR_URL = process.env.CMUX_PR_URL || "https://github.com/manaflow-ai/cmux/pull/255";
+const PR_URL = process.env.CMUX_PR_URL || "https://github.com/manaflow-ai/manaflow/pull/255";
 
 async function main() {
   const m = PR_URL.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);

--- a/apps/www/scripts/backfill-repo.ts
+++ b/apps/www/scripts/backfill-repo.ts
@@ -7,7 +7,7 @@ import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
 
 const TEAM = process.env.CMUX_TEAM_SLUG || "manaflow";
-const REPO = process.env.CMUX_REPO || "manaflow-ai/cmux";
+const REPO = process.env.CMUX_REPO || "manaflow-ai/manaflow";
 const STATE = (process.env.CMUX_STATE as "open" | "closed" | "all") || "all";
 const MAX_PAGES = Number(process.env.CMUX_MAX_PAGES || 50);
 

--- a/apps/www/scripts/pr-review-local.ts
+++ b/apps/www/scripts/pr-review-local.ts
@@ -21,7 +21,7 @@ import type {
   PrReviewStrategyId,
 } from "./pr-review/core/options";
 
-const DEFAULT_PR_URL = "https://github.com/manaflow-ai/cmux/pull/653";
+const DEFAULT_PR_URL = "https://github.com/manaflow-ai/manaflow/pull/653";
 const DEFAULT_IMAGE_TAG = "cmux-pr-review-local:latest";
 const LOGS_SUBDIR = "pr-review";
 const WORKSPACE_DIR = "/workspace";

--- a/apps/www/scripts/pr-review.ts
+++ b/apps/www/scripts/pr-review.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/pr-review";
 import { parsePrUrl } from "./pr-review/github";
 
-const DEFAULT_PR_URL = "https://github.com/manaflow-ai/cmux/pull/653";
+const DEFAULT_PR_URL = "https://github.com/manaflow-ai/manaflow/pull/653";
 const execFileAsync = promisify(execFile);
 
 import type {

--- a/apps/www/scripts/pr-review/README.md
+++ b/apps/www/scripts/pr-review/README.md
@@ -94,7 +94,7 @@ annotations instead of relying on the agent's chat response.
 
 ## Demo Harness
 
-`run-strategy-demo.ts` fetches PR [#709](https://github.com/manaflow-ai/cmux/pull/709/files),
+`run-strategy-demo.ts` fetches PR [#709](https://github.com/manaflow-ai/manaflow/pull/709/files),
 runs each strategy with synthetic model outputs, and stores prompts/responses
 under `tmp/strategy-demo/`. This is useful for quick smoke tests without
 calling the OpenAI API:

--- a/apps/www/scripts/pr-review/evals/dataset.ts
+++ b/apps/www/scripts/pr-review/evals/dataset.ts
@@ -44,7 +44,7 @@ export const EVAL_DATASET: EvalDataset = {
       tags: ["typescript", "react", "baseline"],
       metadata: {
         owner: "manaflow-ai",
-        repo: "cmux",
+        repo: "manaflow",
         number: 728,
         language: "typescript",
         filesChanged: 0, // Will be populated by fetch

--- a/apps/www/scripts/pr-review/evals/dataset.ts
+++ b/apps/www/scripts/pr-review/evals/dataset.ts
@@ -38,7 +38,7 @@ export const EVAL_DATASET: EvalDataset = {
   prs: [
     {
       id: "cmux-728",
-      url: "https://github.com/manaflow-ai/cmux/pull/728/files",
+      url: "https://github.com/manaflow-ai/manaflow/pull/728/files",
       title: "Initial PR for eval dataset",
       description: "Base case PR from cmux repo",
       tags: ["typescript", "react", "baseline"],

--- a/apps/www/scripts/pr-review/run-strategy-demo.ts
+++ b/apps/www/scripts/pr-review/run-strategy-demo.ts
@@ -8,7 +8,7 @@ import type {
   StrategyProcessContext,
 } from "./core/types";
 
-const DIFF_URL = "https://patch-diff.githubusercontent.com/raw/manaflow-ai/cmux/pull/709.diff";
+const DIFF_URL = "https://patch-diff.githubusercontent.com/raw/manaflow-ai/manaflow/pull/709.diff";
 const TEMP_DIFF_PATH = "/tmp/pr-709.diff";
 const OUTPUT_ROOT = join(process.cwd(), "tmp", "strategy-demo");
 

--- a/apps/www/scripts/start-code-review.ts
+++ b/apps/www/scripts/start-code-review.ts
@@ -10,7 +10,7 @@ import {
   startCodeReviewJob,
 } from "@/lib/services/code-review/start-code-review";
 
-const DEFAULT_PR_URL = "https://github.com/manaflow-ai/cmux/pull/661";
+const DEFAULT_PR_URL = "https://github.com/manaflow-ai/manaflow/pull/661";
 type CliOptions = {
   prUrl: string;
   commitRef?: string;

--- a/configs/nfpm/cmux.yaml
+++ b/configs/nfpm/cmux.yaml
@@ -9,7 +9,7 @@ maintainer: cmux <eng@cmux.dev>
 description: |
   cmux host runtime and services packaged for native installation.
 license: MIT
-homepage: https://github.com/lawrencecchen/cmux
+homepage: https://github.com/manaflow-ai/manaflow
 depends:
   - systemd
   - bash

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,8 @@ export default tseslint.config(
     '**/dist-electron',
     '**/.next',
     '**/build',
+    '**/.vscode-test',
+    '**/.vscode-test/**',
     'node_modules',
     '**/node_modules',
     // Generated files

--- a/evals/screenshot/fetch-bot-comments.ts
+++ b/evals/screenshot/fetch-bot-comments.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 import process from "node:process";
 
 const API_ROOT = "https://api.github.com";
-const REPO = "manaflow-ai/cmux" as const;
+const REPO = "manaflow-ai/manaflow" as const;
 const OUTPUT_DIR = resolve(import.meta.dirname, "data");
 const CHECKPOINT_FILE = resolve(OUTPUT_DIR, "checkpoint.json");
 const OUTPUT_FILE = resolve(OUTPUT_DIR, "bot-comments.jsonl");

--- a/packages/cmux-devbox-2/internal/cli/skills.go
+++ b/packages/cmux-devbox-2/internal/cli/skills.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	skillsBaseURL = "https://raw.githubusercontent.com/manaflow-ai/cmux/main/skills"
+	skillsBaseURL = "https://raw.githubusercontent.com/manaflow-ai/manaflow/main/skills"
 )
 
 var skillsCmd = &cobra.Command{

--- a/packages/cmux-devbox-2/npm/cmux/package.json
+++ b/packages/cmux-devbox-2/npm/cmux/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://cmux.sh",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "apps/cmux-devbox-2"
   },
   "license": "MIT",

--- a/packages/cmux-devbox/npm/cmux/llms.txt
+++ b/packages/cmux-devbox/npm/cmux/llms.txt
@@ -67,4 +67,4 @@ cmux computer screenshot cmux_abc123 test.png
 
 - Homepage: https://cmux.sh
 - Documentation: https://cmux.sh/docs
-- GitHub: https://github.com/manaflow-ai/cmux
+- GitHub: https://github.com/manaflow-ai/manaflow

--- a/packages/cmux-devbox/npm/cmux/package.json
+++ b/packages/cmux-devbox/npm/cmux/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://cmux.sh",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "packages/cmux-devbox"
   },
   "license": "MIT",

--- a/packages/cmux-devbox/npm/darwin-arm64/package.json
+++ b/packages/cmux-devbox/npm/darwin-arm64/package.json
@@ -6,7 +6,7 @@
   "cpu": ["arm64"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "packages/cmux-devbox"
   },
   "license": "MIT",

--- a/packages/cmux-devbox/npm/darwin-x64/package.json
+++ b/packages/cmux-devbox/npm/darwin-x64/package.json
@@ -6,7 +6,7 @@
   "cpu": ["x64"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "packages/cmux-devbox"
   },
   "license": "MIT",

--- a/packages/cmux-devbox/npm/linux-arm64/package.json
+++ b/packages/cmux-devbox/npm/linux-arm64/package.json
@@ -6,7 +6,7 @@
   "cpu": ["arm64"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "packages/cmux-devbox"
   },
   "license": "MIT",

--- a/packages/cmux-devbox/npm/linux-x64/package.json
+++ b/packages/cmux-devbox/npm/linux-x64/package.json
@@ -6,7 +6,7 @@
   "cpu": ["x64"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "packages/cmux-devbox"
   },
   "license": "MIT",

--- a/packages/cmux-devbox/npm/win32-x64/package.json
+++ b/packages/cmux-devbox/npm/win32-x64/package.json
@@ -6,7 +6,7 @@
   "cpu": ["x64"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "url": "git+https://github.com/manaflow-ai/manaflow.git",
     "directory": "packages/cmux-devbox"
   },
   "license": "MIT",

--- a/packages/cmux/scripts/publish-npm.ts
+++ b/packages/cmux/scripts/publish-npm.ts
@@ -69,7 +69,7 @@ function publish() {
     },
     repository: {
       type: "git",
-      url: "git+https://github.com/manaflow-ai/cmux.git",
+      url: "git+https://github.com/manaflow-ai/manaflow.git",
     },
   };
 

--- a/packages/convex/convex/analytics.ts
+++ b/packages/convex/convex/analytics.ts
@@ -36,44 +36,47 @@ export const getDashboardStats = authQuery({
 
     const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
-    // Fetch tasks for this user/team
-    const allTasks = await ctx.db
+    // Tasks created in the past 7 days (exclude workspaces and previews)
+    const recentTasks = await ctx.db
       .query("tasks")
-      .withIndex("by_team_user", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId),
+      .withIndex("by_team_user_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("createdAt", sevenDaysAgo),
+      )
+      .filter((q) =>
+        q.and(
+          q.neq(q.field("isCloudWorkspace"), true),
+          q.neq(q.field("isLocalWorkspace"), true),
+          q.neq(q.field("isPreview"), true),
+        ),
       )
       .collect();
 
-    // Tasks created in the past 7 days (exclude workspaces and previews)
-    const recentTasks = allTasks.filter(
-      (t) =>
-        (t.createdAt ?? t._creationTime) >= sevenDaysAgo &&
-        !t.isCloudWorkspace &&
-        !t.isLocalWorkspace &&
-        !t.isPreview,
-    );
-
     // Tasks merged in the past 7 days
-    const mergedTasks = allTasks.filter(
-      (t) =>
-        t.mergeStatus === "pr_merged" &&
-        (t.updatedAt ?? t._creationTime) >= sevenDaysAgo,
-    );
-
-    // Fetch task runs for this user/team
-    const allRuns = await ctx.db
-      .query("taskRuns")
-      .withIndex("by_team_user", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId),
+    const mergedTasks = await ctx.db
+      .query("tasks")
+      .withIndex("by_team_user_updated", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("updatedAt", sevenDaysAgo),
       )
+      .filter((q) => q.eq(q.field("mergeStatus"), "pr_merged"))
       .collect();
 
     // Completed runs in the past 7 days
-    const completedRuns = allRuns.filter(
-      (r) =>
-        r.status === "completed" &&
-        (r.completedAt ?? r.updatedAt) >= sevenDaysAgo,
-    );
+    const completedRuns = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_team_user_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("createdAt", sevenDaysAgo),
+      )
+      .filter((q) => q.eq(q.field("status"), "completed"))
+      .collect();
 
     return {
       tasksStarted: {

--- a/packages/convex/convex/analytics.ts
+++ b/packages/convex/convex/analytics.ts
@@ -36,47 +36,44 @@ export const getDashboardStats = authQuery({
 
     const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
-    // Tasks created in the past 7 days (exclude workspaces and previews)
-    const recentTasks = await ctx.db
+    // Fetch tasks for this user/team
+    const allTasks = await ctx.db
       .query("tasks")
-      .withIndex("by_team_user_created", (idx) =>
-        idx
-          .eq("teamId", teamId)
-          .eq("userId", userId)
-          .gte("createdAt", sevenDaysAgo),
-      )
-      .filter((q) =>
-        q.and(
-          q.neq(q.field("isCloudWorkspace"), true),
-          q.neq(q.field("isLocalWorkspace"), true),
-          q.neq(q.field("isPreview"), true),
-        ),
+      .withIndex("by_team_user", (idx) =>
+        idx.eq("teamId", teamId).eq("userId", userId),
       )
       .collect();
 
+    // Tasks created in the past 7 days (exclude workspaces and previews)
+    const recentTasks = allTasks.filter(
+      (t) =>
+        (t.createdAt ?? t._creationTime) >= sevenDaysAgo &&
+        !t.isCloudWorkspace &&
+        !t.isLocalWorkspace &&
+        !t.isPreview,
+    );
+
     // Tasks merged in the past 7 days
-    const mergedTasks = await ctx.db
-      .query("tasks")
-      .withIndex("by_team_user_updated", (idx) =>
-        idx
-          .eq("teamId", teamId)
-          .eq("userId", userId)
-          .gte("updatedAt", sevenDaysAgo),
+    const mergedTasks = allTasks.filter(
+      (t) =>
+        t.mergeStatus === "pr_merged" &&
+        (t.updatedAt ?? t._creationTime) >= sevenDaysAgo,
+    );
+
+    // Fetch task runs for this user/team
+    const allRuns = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_team_user", (idx) =>
+        idx.eq("teamId", teamId).eq("userId", userId),
       )
-      .filter((q) => q.eq(q.field("mergeStatus"), "pr_merged"))
       .collect();
 
     // Completed runs in the past 7 days
-    const completedRuns = await ctx.db
-      .query("taskRuns")
-      .withIndex("by_team_user_created", (idx) =>
-        idx
-          .eq("teamId", teamId)
-          .eq("userId", userId)
-          .gte("createdAt", sevenDaysAgo),
-      )
-      .filter((q) => q.eq(q.field("status"), "completed"))
-      .collect();
+    const completedRuns = allRuns.filter(
+      (r) =>
+        r.status === "completed" &&
+        (r.completedAt ?? r.updatedAt) >= sevenDaysAgo,
+    );
 
     return {
       tasksStarted: {

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -171,7 +171,9 @@ const convexSchema = defineSchema({
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
     .index("by_team_preview", ["teamId", "isPreview"])
-    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"]),
+    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"])
+    .index("by_team_user_created", ["teamId", "userId", "createdAt"])
+    .index("by_team_user_updated", ["teamId", "userId", "updatedAt"]),
 
   taskRuns: defineTable({
     taskId: v.id("tasks"),
@@ -328,7 +330,8 @@ const convexSchema = defineSchema({
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
-    .index("by_pull_request_url", ["pullRequestUrl"]),
+    .index("by_pull_request_url", ["pullRequestUrl"])
+    .index("by_team_user_created", ["teamId", "userId", "createdAt"]),
 
   // Junction table linking taskRuns to pull requests by PR identity
   // Enables efficient lookup of taskRuns when a PR webhook fires

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -171,9 +171,7 @@ const convexSchema = defineSchema({
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
     .index("by_team_preview", ["teamId", "isPreview"])
-    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"])
-    .index("by_team_user_created", ["teamId", "userId", "createdAt"])
-    .index("by_team_user_updated", ["teamId", "userId", "updatedAt"]),
+    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"]),
 
   taskRuns: defineTable({
     taskId: v.id("tasks"),
@@ -330,8 +328,7 @@ const convexSchema = defineSchema({
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
-    .index("by_pull_request_url", ["pullRequestUrl"])
-    .index("by_team_user_created", ["teamId", "userId", "createdAt"]),
+    .index("by_pull_request_url", ["pullRequestUrl"]),
 
   // Junction table linking taskRuns to pull requests by PR identity
   // Enables efficient lookup of taskRuns when a PR webhook fires

--- a/packages/convex/scripts/test-github-video-upload.ts
+++ b/packages/convex/scripts/test-github-video-upload.ts
@@ -200,7 +200,7 @@ async function main() {
   console.log("=".repeat(60));
 
   const accessToken = process.env.GITHUB_TOKEN;
-  const repoFullName = process.env.REPO || "manaflow-ai/cmux";
+  const repoFullName = process.env.REPO || "manaflow-ai/manaflow";
   const videoFilePath = process.env.VIDEO_FILE;
   const prNumber = process.env.PR_NUMBER ? parseInt(process.env.PR_NUMBER, 10) : undefined;
 

--- a/scripts/github/fetch-pr-ground-truth.ts
+++ b/scripts/github/fetch-pr-ground-truth.ts
@@ -5,7 +5,7 @@ import { dirname, resolve } from "node:path";
 import process from "node:process";
 
 const API_ROOT = "https://api.github.com";
-const DEFAULT_REPOS: RepoSlug[] = ["manaflow-ai/cmux", "stack-auth/stack-auth"];
+const DEFAULT_REPOS: RepoSlug[] = ["manaflow-ai/manaflow", "stack-auth/stack-auth"];
 const OUTPUT_DIR = resolve(process.cwd(), "data", "github");
 const OUTPUT_FILE = resolve(OUTPUT_DIR, "pr-ground-truth.json");
 const PER_PAGE = 100;

--- a/scripts/local-preview-to-pr.ts
+++ b/scripts/local-preview-to-pr.ts
@@ -124,9 +124,9 @@ Environment Variables:
   ANTHROPIC_API_KEY                   Required for screenshot capture
 
 Examples:
-  bun run scripts/local-preview-to-pr.ts --pr https://github.com/manaflow-ai/cmux/pull/123
-  bun run scripts/local-preview-to-pr.ts --pr https://github.com/manaflow-ai/cmux/pull/123 --skip-capture
-  bun run scripts/local-preview-to-pr.ts --pr https://github.com/manaflow-ai/cmux/pull/123 --dry-run
+  bun run scripts/local-preview-to-pr.ts --pr https://github.com/manaflow-ai/manaflow/pull/123
+  bun run scripts/local-preview-to-pr.ts --pr https://github.com/manaflow-ai/manaflow/pull/123 --skip-capture
+  bun run scripts/local-preview-to-pr.ts --pr https://github.com/manaflow-ai/manaflow/pull/123 --dry-run
 `);
 }
 

--- a/scripts/morph-start-instance.ts
+++ b/scripts/morph-start-instance.ts
@@ -167,7 +167,7 @@ await workerExec({
 //   args: [
 //     "clone",
 //     "--depth=1",
-//     "https://github.com/manaflow-ai/cmux",
+//     "https://github.com/manaflow-ai/manaflow",
 //     "/root/workspace",
 //   ],
 //   cwd: "/root",

--- a/scripts/prune-convex-preview-deployments.ts
+++ b/scripts/prune-convex-preview-deployments.ts
@@ -112,7 +112,7 @@ async function main() {
     options.githubRepo ??
     process.env.GITHUB_REPO ??
     process.env.GITHUB_REPOSITORY ??
-    "manaflow-ai/cmux";
+    "manaflow-ai/manaflow";
 
   const githubBranchPrefix = options.githubBranchPrefix ?? "";
   const githubToken =


### PR DESCRIPTION
## Summary
- Updates all GitHub repo references from `manaflow-ai/cmux` to `manaflow-ai/manaflow` across 40 files
- Fixes the broken macOS download link on cmux.dev — the GitHub releases API and star count fetcher were hitting the old repo name and returning 404
- Updates npm package.json repo URLs, CLI skills URL, site header/footer links, demo component refs, internal scripts, and tests

## Test plan
- [ ] Verify cmux.dev macOS download button resolves to a valid `.dmg` URL
- [ ] Verify GitHub star count loads on the landing page
- [ ] Verify "GitHub release page" link in the footer and hero points to the new repo
- [ ] Spot-check that `bun check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily string/URL updates for repo links and API endpoints; risk is limited to potential missed references causing broken links or tests/scripts pointing at the wrong repo.
> 
> **Overview**
> Updates hard-coded GitHub references throughout the codebase from `manaflow-ai/cmux` to `manaflow-ai/manaflow`, including website links, release/download URLs, star-count fetching, and various test fixtures/scripts that operate on a default repo.
> 
> Also tweaks tooling metadata (npm `repository` URLs, nfpm homepage, CLI skills raw-content URL) and expands ESLint global ignores to exclude `.vscode-test` artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9207dc812ceb00c63c7cda679a3ad11eb52912d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->