### PR TITLE
Apply date index filter before in-memory analytics

### DIFF
--- a/packages/convex/convex/analytics.ts
+++ b/packages/convex/convex/analytics.ts
@@ -36,40 +36,50 @@ export const getDashboardStats = authQuery({
 
     const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
-    // Fetch tasks for this user/team
-    const allTasks = await ctx.db
+    // Fetch tasks created in the past 7 days (filter by date at index level)
+    const recentTasksRaw = await ctx.db
       .query("tasks")
-      .withIndex("by_team_user", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId),
+      .withIndex("by_team_user_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("createdAt", sevenDaysAgo),
       )
       .collect();
 
-    // Tasks created in the past 7 days (exclude workspaces and previews)
-    const recentTasks = allTasks.filter(
-      (t) =>
-        (t.createdAt ?? t._creationTime) >= sevenDaysAgo &&
-        !t.isCloudWorkspace &&
-        !t.isLocalWorkspace &&
-        !t.isPreview,
+    // Exclude workspaces and previews in memory
+    const recentTasks = recentTasksRaw.filter(
+      (t) => !t.isCloudWorkspace && !t.isLocalWorkspace && !t.isPreview,
     );
 
-    // Tasks merged in the past 7 days
-    const mergedTasks = allTasks.filter(
-      (t) =>
-        t.mergeStatus === "pr_merged" &&
-        (t.updatedAt ?? t._creationTime) >= sevenDaysAgo,
+    // Fetch tasks updated in the past 7 days, then filter to merged
+    const recentlyUpdatedTasks = await ctx.db
+      .query("tasks")
+      .withIndex("by_team_user_updated", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("updatedAt", sevenDaysAgo),
+      )
+      .collect();
+
+    const mergedTasks = recentlyUpdatedTasks.filter(
+      (t) => t.mergeStatus === "pr_merged",
     );
 
-    // Fetch task runs for this user/team
-    const allRuns = await ctx.db
+    // Fetch task runs created in the past 7 days (filter by date at index level)
+    const recentRuns = await ctx.db
       .query("taskRuns")
-      .withIndex("by_team_user", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId),
+      .withIndex("by_team_user_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("createdAt", sevenDaysAgo),
       )
       .collect();
 
-    // Completed runs in the past 7 days
-    const completedRuns = allRuns.filter(
+    // Filter to completed runs in memory
+    const completedRuns = recentRuns.filter(
       (r) =>
         r.status === "completed" &&
         (r.completedAt ?? r.updatedAt) >= sevenDaysAgo,

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -167,6 +167,8 @@ const convexSchema = defineSchema({
     .index("by_created", ["createdAt"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
+    .index("by_team_user_created", ["teamId", "userId", "createdAt"])
+    .index("by_team_user_updated", ["teamId", "userId", "updatedAt"])
     .index("by_team_user_activity", ["teamId", "userId", "lastActivityAt"])
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
@@ -328,6 +330,7 @@ const convexSchema = defineSchema({
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
+    .index("by_team_user_created", ["teamId", "userId", "createdAt"])
     .index("by_pull_request_url", ["pullRequestUrl"]),
 
   // Junction table linking taskRuns to pull requests by PR identity

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -168,7 +168,7 @@ const convexSchema = defineSchema({
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
     .index("by_team_user_created", ["teamId", "userId", "createdAt"])
-    .index("by_team_user_updated", ["teamId", "userId", "updatedAt"])
+    .index("by_team_user_merge_updated", ["teamId", "userId", "mergeStatus", "updatedAt"])
     .index("by_team_user_activity", ["teamId", "userId", "lastActivityAt"])
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
@@ -330,7 +330,7 @@ const convexSchema = defineSchema({
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
-    .index("by_team_user_created", ["teamId", "userId", "createdAt"])
+    .index("by_team_user_status_created", ["teamId", "userId", "status", "createdAt"])
     .index("by_pull_request_url", ["pullRequestUrl"]),
 
   // Junction table linking taskRuns to pull requests by PR identity


### PR DESCRIPTION
in the query for analytics on the dashboard page, we actually want to do withIndex or you can do the convex gte for date before storing it in memory the query. currently we are storing the query in memory first and then filtering, but we can filter it with index by date first before doing that.. its more efficient that way