### PR TITLE
perf: optimize getDashboardStats with compound timestamp indexes

### DIFF
--- a/packages/convex/convex/analytics.ts
+++ b/packages/convex/convex/analytics.ts
@@ -36,44 +36,47 @@ export const getDashboardStats = authQuery({
 
     const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
-    // Fetch tasks for this user/team
-    const allTasks = await ctx.db
+    // Tasks created in the past 7 days (exclude workspaces and previews)
+    const recentTasks = await ctx.db
       .query("tasks")
-      .withIndex("by_team_user", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId),
+      .withIndex("by_team_user_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("createdAt", sevenDaysAgo),
+      )
+      .filter((q) =>
+        q.and(
+          q.neq(q.field("isCloudWorkspace"), true),
+          q.neq(q.field("isLocalWorkspace"), true),
+          q.neq(q.field("isPreview"), true),
+        ),
       )
       .collect();
 
-    // Tasks created in the past 7 days (exclude workspaces and previews)
-    const recentTasks = allTasks.filter(
-      (t) =>
-        (t.createdAt ?? t._creationTime) >= sevenDaysAgo &&
-        !t.isCloudWorkspace &&
-        !t.isLocalWorkspace &&
-        !t.isPreview,
-    );
-
     // Tasks merged in the past 7 days
-    const mergedTasks = allTasks.filter(
-      (t) =>
-        t.mergeStatus === "pr_merged" &&
-        (t.updatedAt ?? t._creationTime) >= sevenDaysAgo,
-    );
-
-    // Fetch task runs for this user/team
-    const allRuns = await ctx.db
-      .query("taskRuns")
-      .withIndex("by_team_user", (idx) =>
-        idx.eq("teamId", teamId).eq("userId", userId),
+    const mergedTasks = await ctx.db
+      .query("tasks")
+      .withIndex("by_team_user_updated", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("updatedAt", sevenDaysAgo),
       )
+      .filter((q) => q.eq(q.field("mergeStatus"), "pr_merged"))
       .collect();
 
     // Completed runs in the past 7 days
-    const completedRuns = allRuns.filter(
-      (r) =>
-        r.status === "completed" &&
-        (r.completedAt ?? r.updatedAt) >= sevenDaysAgo,
-    );
+    const completedRuns = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_team_user_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .gte("createdAt", sevenDaysAgo),
+      )
+      .filter((q) => q.eq(q.field("status"), "completed"))
+      .collect();
 
     return {
       tasksStarted: {

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -171,7 +171,9 @@ const convexSchema = defineSchema({
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])
     .index("by_team_preview", ["teamId", "isPreview"])
-    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"]),
+    .index("by_linked_cloud_task_run", ["linkedFromCloudTaskRunId"])
+    .index("by_team_user_created", ["teamId", "userId", "createdAt"])
+    .index("by_team_user_updated", ["teamId", "userId", "updatedAt"]),
 
   taskRuns: defineTable({
     taskId: v.id("tasks"),
@@ -328,7 +330,8 @@ const convexSchema = defineSchema({
     .index("by_vscode_container_name", ["vscode.containerName"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
-    .index("by_pull_request_url", ["pullRequestUrl"]),
+    .index("by_pull_request_url", ["pullRequestUrl"])
+    .index("by_team_user_created", ["teamId", "userId", "createdAt"]),
 
   // Junction table linking taskRuns to pull requests by PR identity
   // Enables efficient lookup of taskRuns when a PR webhook fires


### PR DESCRIPTION
## Summary
- Adds compound indexes `by_team_user_created` and `by_team_user_updated` on `tasks`, and `by_team_user_created` on `taskRuns`
- Replaces two `.collect()`-everything queries with three targeted index range queries using `.gte()` on the timestamp field
- Only fetches documents within the 7-day window at the DB level instead of fetching all user history and filtering in JS

## Test plan
- [x] `bun check` passes (no type errors in changed files; pre-existing lint issues in vendored vscode-extension code are unrelated)
- [ ] Verify dashboard analytics cards still render correctly with same data