### PR TITLE
Change sandbox ID prefix from cmux_ to cr_

### DIFF
--- a/packages/convex/convex/cmux_http.ts
+++ b/packages/convex/convex/cmux_http.ts
@@ -19,8 +19,8 @@ const JSON_HEADERS = {
 };
 
 // Security: Validate instance ID format to prevent injection attacks
-// IDs should be cmux_ followed by 8+ alphanumeric characters
-const INSTANCE_ID_REGEX = /^cmux_[a-zA-Z0-9]{8,}$/;
+// IDs should be cr_ or cmux_ followed by 8+ alphanumeric characters
+const INSTANCE_ID_REGEX = /^(cr|cmux)_[a-zA-Z0-9]{8,}$/;
 
 function isValidInstanceId(id: string): boolean {
   return INSTANCE_ID_REGEX.test(id);

--- a/packages/convex/convex/cmux_http.ts
+++ b/packages/convex/convex/cmux_http.ts
@@ -19,8 +19,8 @@ const JSON_HEADERS = {
 };
 
 // Security: Validate instance ID format to prevent injection attacks
-// IDs should be cr_ or cmux_ followed by 8+ alphanumeric characters
-const INSTANCE_ID_REGEX = /^(cr|cmux)_[a-zA-Z0-9]{8,}$/;
+// IDs should be cmux_ followed by 8+ alphanumeric characters
+const INSTANCE_ID_REGEX = /^cmux_[a-zA-Z0-9]{8,}$/;
 
 function isValidInstanceId(id: string): boolean {
   return INSTANCE_ID_REGEX.test(id);

--- a/packages/convex/convex/devboxInstances.ts
+++ b/packages/convex/convex/devboxInstances.ts
@@ -11,11 +11,11 @@ const instanceStatusValidator = v.union(
 );
 
 /**
- * Generate a friendly ID for CLI users (cmux_xxxxxxxx)
+ * Generate a friendly ID for CLI users (cr_xxxxxxxx)
  */
 function generateDevboxId(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-  let result = "cmux_";
+  let result = "cr_";
   const array = new Uint8Array(8);
   crypto.getRandomValues(array);
   for (let i = 0; i < 8; i++) {
@@ -79,12 +79,12 @@ export const list = authQuery({
 });
 
 /**
- * Get a specific devbox instance by ID (cmux_xxxxxxxx).
+ * Get a specific devbox instance by ID (cr_xxxxxxxx).
  */
 export const getById = authQuery({
   args: {
     teamSlugOrId: v.string(),
-    id: v.string(), // The devboxId (cmux_xxx)
+    id: v.string(), // The devboxId (cr_xxx)
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;

--- a/packages/convex/convex/devbox_http.ts
+++ b/packages/convex/convex/devbox_http.ts
@@ -10,8 +10,8 @@ const JSON_HEADERS = {
 };
 
 // Security: Validate instance ID format to prevent injection attacks
-// IDs should be cmux_ followed by 8+ alphanumeric characters
-const INSTANCE_ID_REGEX = /^cmux_[a-zA-Z0-9]{8,}$/;
+// IDs should be cr_ or cmux_ followed by 8+ alphanumeric characters
+const INSTANCE_ID_REGEX = /^(cr|cmux)_[a-zA-Z0-9]{8,}$/;
 
 function isValidInstanceId(id: string): boolean {
   return INSTANCE_ID_REGEX.test(id);

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1188,7 +1188,7 @@ const convexSchema = defineSchema({
 
   // User-owned devbox instances (standalone sandboxes not tied to task runs)
   devboxInstances: defineTable({
-    devboxId: v.string(), // Friendly ID (cmux_xxxxxxxx) for CLI users
+    devboxId: v.string(), // Friendly ID (cr_xxxxxxxx) for CLI users
     userId: v.string(), // Owner user ID
     teamId: v.string(), // Team scope
     name: v.optional(v.string()), // User-friendly name
@@ -1214,7 +1214,7 @@ const convexSchema = defineSchema({
 
   // Provider-specific info for devbox instances (maps our ID to provider details)
   devboxInfo: defineTable({
-    devboxId: v.string(), // Our friendly ID (cmux_xxxxxxxx)
+    devboxId: v.string(), // Our friendly ID (cr_xxxxxxxx)
     provider: v.union(v.literal("morph"), v.literal("e2b"), v.literal("modal"), v.literal("daytona")), // Provider name (extensible for future providers)
     providerInstanceId: v.string(), // Provider's instance ID (e.g., morphvm_xxx)
     snapshotId: v.optional(v.string()), // Snapshot ID used to create the instance


### PR DESCRIPTION
## Summary
- New devbox instances now generate IDs with `cr_` prefix instead of `cmux_`
- Validation regex updated to accept both `cr_` and `cmux_` prefixes for backward compatibility with existing instances

## Test plan
- [ ] Verify new instances get `cr_xxxxxxxx` IDs
- [ ] Verify existing `cmux_xxxxxxxx` instances still work