### PR TITLE
Set default agents to Claude 4.6 and Codex XHigh

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -82,7 +82,7 @@ export const Route = createFileRoute("/_layout/$teamSlugOrId/dashboard")({
 });
 
 // Default agents (not persisted to localStorage)
-const DEFAULT_AGENTS = ["claude/opus-4.5"];
+const DEFAULT_AGENTS = ["claude/opus-4.6", "codex/gpt-5.3-codex-xhigh"];
 const KNOWN_AGENT_NAMES = new Set(AGENT_CONFIGS.map((agent) => agent.name));
 const DISABLED_AGENT_NAMES = new Set(
   AGENT_CONFIGS.filter((agent) => agent.disabled).map((agent) => agent.name)

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -2814,10 +2814,10 @@ Please address the issue mentioned in the comment above.`;
             taskDescription: formattedPrompt,
             isCloudMode: true,
             theme: "dark",
-            // Use provided selectedAgents or default to claude/sonnet-4 and codex/gpt-5.1-codex-high
+            // Use provided selectedAgents or default to claude/opus-4.6 and codex/gpt-5.3-codex-xhigh
             selectedAgents: selectedAgents || [
-              "claude/sonnet-4",
-              "codex/gpt-5.1-codex-high",
+              "claude/opus-4.6",
+              "codex/gpt-5.3-codex-xhigh",
             ],
           },
           safeTeam


### PR DESCRIPTION
can you make the default agents claude/opus-4.6 and codex/gpt-5.3-codex-xhigh