### PR TITLE
feat: Modal VNC auth, Jupyter CLI, Chrome defaults

### DIFF
--- a/packages/cmux-devbox-2/internal/cli/root.go
+++ b/packages/cmux-devbox-2/internal/cli/root.go
@@ -101,6 +101,7 @@ func init() {
 	// Open commands
 	rootCmd.AddCommand(codeCmd)
 	rootCmd.AddCommand(vncCmd)
+	rootCmd.AddCommand(jupyterCmd)
 
 	// Lifecycle commands
 	rootCmd.AddCommand(stopCmd)

--- a/packages/convex/convex/devbox_v2_http.ts
+++ b/packages/convex/convex/devbox_v2_http.ts
@@ -406,6 +406,7 @@ async function handleGetInstance(
     })) as {
       instanceId: string;
       status: string;
+      jupyterUrl?: string | null;
       vscodeUrl?: string | null;
       workerUrl?: string | null;
       vncUrl?: string | null;
@@ -426,6 +427,7 @@ async function handleGetInstance(
       provider,
       status,
       name: instance.name,
+      jupyterUrl: providerResult.jupyterUrl ?? undefined,
       vscodeUrl: providerResult.vscodeUrl ?? undefined,
       workerUrl: providerResult.workerUrl ?? undefined,
       vncUrl: providerResult.vncUrl ?? undefined,

--- a/packages/convex/convex/modal_actions.ts
+++ b/packages/convex/convex/modal_actions.ts
@@ -10,6 +10,7 @@ import {
 import { ModalClient, type ModalInstance } from "@cmux/modal-client";
 
 const CMUX_CODE_VERSION = "0.9.0";
+const MODAL_SNAPSHOT_IMAGE_ID = "im-W8QiRWb9p6Iut03EbPVSWj";
 
 /**
  * Get Modal client with credentials from env
@@ -139,13 +140,19 @@ sleep 1
 # XFCE desktop
 export DISPLAY=:1
 export HOME=/root
+export BROWSER=/usr/bin/google-chrome-stable
 export XDG_RUNTIME_DIR=/tmp/runtime-root
 mkdir -p /tmp/runtime-root
 eval \$(dbus-launch --sh-syntax) 2>/dev/null || true
 nohup startxfce4 > /tmp/xfce.log 2>&1 &
 sleep 2
 
-# Chrome
+# Set Chrome as XFCE default browser (must be after startxfce4 creates config)
+mkdir -p /root/.config/xfce4
+echo 'WebBrowser=google-chrome' > /root/.config/xfce4/helpers.rc
+xfconf-query -c xfce4-session -p /compat/LaunchGNOME -s false 2>/dev/null || true
+
+# Chrome (with CDP enabled for cloudrouter computer commands)
 mkdir -p /root/.config/chrome
 nohup google-chrome \\
   --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer \\
@@ -155,10 +162,13 @@ nohup google-chrome \\
   --start-maximized --window-position=0,0 --window-size=1920,1080 \\
   --remote-debugging-port=9222 --remote-debugging-address=127.0.0.1 \\
   --user-data-dir=/root/.config/chrome --password-store=basic \\
+  --remote-debugging-port=9222 \\
+  --remote-debugging-address=127.0.0.1 \\
   about:blank > /tmp/chrome.log 2>&1 &
+sleep 1
 
-# noVNC + websockify on port 39380
-nohup websockify --web /usr/share/novnc --heartbeat 1 0.0.0.0:39380 localhost:5901 > /tmp/novnc.log 2>&1 &
+# noVNC + auth-websockify on port 39380 (validates tkn/token param)
+nohup auth-websockify --web /usr/share/novnc --heartbeat 1 0.0.0.0:39380 localhost:5901 > /tmp/novnc.log 2>&1 &
 
 # cmux-code on port 39378
 nohup /app/cmux-code/bin/code-server-oss \\
@@ -224,9 +234,7 @@ export const buildSnapshot = internalAction({
 });
 
 /**
- * Start a new Modal sandbox instance.
- * Uses MODAL_SNAPSHOT_IMAGE_ID env var for fast startup if available,
- * otherwise falls back to installing everything from scratch.
+ * Start a new Modal sandbox instance from a pre-built snapshot.
  */
 export const startInstance = internalAction({
   args: {
@@ -246,18 +254,10 @@ export const startInstance = internalAction({
     const presetId = args.templateId ?? DEFAULT_MODAL_TEMPLATE_ID;
     const preset = getModalTemplateByPresetId(presetId);
     const gpu = args.gpu ?? preset?.gpu;
-    const baseImage = args.image ?? preset?.image ?? "python:3.11-slim";
-
-    // Check for pre-built snapshot
-    const snapshotImageId = env.MODAL_SNAPSHOT_IMAGE_ID;
-    const useSnapshot = !!snapshotImageId;
+    const snapshotImageId = MODAL_SNAPSHOT_IMAGE_ID;
 
     try {
-      console.log(
-        useSnapshot
-          ? `[modal_actions] Starting from snapshot ${snapshotImageId}`
-          : `[modal_actions] Starting from base image ${baseImage} (no snapshot)`,
-      );
+      console.log(`[modal_actions] Starting from snapshot ${snapshotImageId}`);
 
       const instance = await client.instances.start({
         gpu,
@@ -266,32 +266,16 @@ export const startInstance = internalAction({
         timeoutSeconds: args.ttlSeconds ?? 60 * 60,
         metadata: args.metadata,
         envs: args.envs,
-        ...(useSnapshot
-          ? { snapshotImageId }
-          : { image: baseImage }),
+        snapshotImageId,
         encryptedPorts: [8888, 39377, 39378, 39380],
       });
 
       const authToken = generateAuthToken();
 
-      if (useSnapshot) {
-        // Snapshot has everything installed — just start services
-        console.log("[modal_actions] Running lightweight startup script...");
-        const result = await instance.exec(buildStartupScript(authToken));
-        if (result.exit_code !== 0) {
-          console.error("[modal_actions] Startup script failed:", result.stderr);
-        }
-      } else {
-        // No snapshot — run the full install + startup (slow path)
-        console.log("[modal_actions] No snapshot, running full setup...");
-        const installResult = await instance.exec(buildInstallScript());
-        if (installResult.exit_code !== 0) {
-          console.error("[modal_actions] Install failed:", installResult.stderr);
-        }
-        const startResult = await instance.exec(buildStartupScript(authToken));
-        if (startResult.exit_code !== 0) {
-          console.error("[modal_actions] Startup failed:", startResult.stderr);
-        }
+      console.log("[modal_actions] Running startup script...");
+      const result = await instance.exec(buildStartupScript(authToken));
+      if (result.exit_code !== 0) {
+        console.error("[modal_actions] Startup script failed:", result.stderr);
       }
 
       // Refresh tunnel URLs
@@ -312,7 +296,7 @@ export const startInstance = internalAction({
           : undefined,
         workerUrl: workerUrl ?? undefined,
         vncUrl: vncUrl
-          ? `${vncUrl}/vnc.html?autoconnect=true&resize=scale&quality=9&compression=0&show_dot=true&reconnect=true&reconnect_delay=1000`
+          ? `${vncUrl}/viewer.html?autoconnect=true&resize=scale&quality=9&compression=0&show_dot=true&reconnect=true&reconnect_delay=1000`
           : undefined,
       };
     } finally {
@@ -348,7 +332,7 @@ export const getInstance = internalAction({
         vscodeUrl,
         workerUrl: workerUrl ?? null,
         vncUrl: vncUrl
-          ? `${vncUrl}/vnc.html?autoconnect=true&resize=scale`
+          ? `${vncUrl}/viewer.html?autoconnect=true&resize=scale`
           : null,
       };
     } catch {

--- a/scripts/build-modal-snapshot.ts
+++ b/scripts/build-modal-snapshot.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env bun
+/**
+ * Local script to build a Modal snapshot with all deps pre-installed.
+ * Reads MODAL_TOKEN_ID and MODAL_TOKEN_SECRET from .env.
+ *
+ * Usage:
+ *   bun scripts/build-modal-snapshot.ts
+ */
+
+import { ModalClient } from "@cmux/modal-client";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Load .env
+const envPath = resolve(import.meta.dirname!, "../.env");
+const envContent = readFileSync(envPath, "utf-8");
+const env: Record<string, string> = {};
+for (const line of envContent.split("\n")) {
+  const match = line.match(/^([^#=]+)=(.*)$/);
+  if (match) {
+    const key = match[1].trim();
+    let value = match[2].trim();
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+}
+
+const tokenId = env.MODAL_TOKEN_ID;
+const tokenSecret = env.MODAL_TOKEN_SECRET;
+
+if (!tokenId || !tokenSecret) {
+  console.error(
+    "Missing MODAL_TOKEN_ID or MODAL_TOKEN_SECRET in .env",
+  );
+  process.exit(1);
+}
+
+const CMUX_CODE_VERSION = "0.9.0";
+
+const INSTALL_SCRIPT = `#!/bin/bash
+set -e
+
+# Create workspace directory
+mkdir -p /home/user/workspace
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq > /dev/null 2>&1
+apt-get install -y -qq \\
+  curl procps jq wget gnupg pip \\
+  tigervnc-standalone-server tigervnc-common \\
+  xfce4 xfce4-terminal dbus-x11 \\
+  novnc python3-websockify \\
+  fonts-liberation fonts-dejavu \\
+  > /dev/null 2>&1
+
+# Install Google Chrome
+curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/chrome.deb
+apt-get install -y -qq /tmp/chrome.deb > /dev/null 2>&1 || apt-get install -y -qq -f > /dev/null 2>&1
+rm -f /tmp/chrome.deb
+
+# Install cmux-code (VSCode fork)
+mkdir -p /app/cmux-code
+curl -fSL --retry 3 --retry-delay 2 -o /tmp/cmux-code.tar.gz \\
+  "https://github.com/manaflow-ai/vscode-1/releases/download/v${CMUX_CODE_VERSION}/vscode-server-linux-x64-web.tar.gz"
+tar xf /tmp/cmux-code.tar.gz -C /app/cmux-code/ --strip-components=1
+rm -f /tmp/cmux-code.tar.gz
+
+# Install worker daemon (Go binary for PTY/SSH)
+curl -fSL --retry 3 --retry-delay 2 -o /usr/local/bin/worker-daemon \\
+  "https://github.com/manaflow-ai/vscode-1/releases/download/v${CMUX_CODE_VERSION}/worker-daemon"
+chmod +x /usr/local/bin/worker-daemon
+
+# Install JupyterLab
+pip install -q jupyterlab 2>/dev/null || true
+
+# Set Google Chrome as the default browser (system-level)
+update-alternatives --set x-www-browser /usr/bin/google-chrome-stable 2>/dev/null || true
+update-alternatives --set gnome-www-browser /usr/bin/google-chrome-stable 2>/dev/null || true
+# Note: XFCE helpers.rc is set in the startup script since startxfce4 recreates config
+
+# Create VNC viewer wrapper that strips auth token from visible URL
+cat > /usr/share/novnc/viewer.html << 'VIEWER_EOF'
+<!DOCTYPE html>
+<html style="margin:0;padding:0;height:100%;overflow:hidden">
+<head><meta charset="utf-8"><title>VNC</title></head>
+<body style="margin:0;padding:0;height:100%;overflow:hidden">
+<iframe id="vnc" style="width:100%;height:100%;border:none"></iframe>
+<script>
+(function(){
+  var params = new URLSearchParams(location.search);
+  // Copy tkn to token so noVNC passes it on WebSocket connections
+  if (params.has('tkn') && !params.has('token')) {
+    params.set('token', params.get('tkn'));
+  }
+  document.getElementById('vnc').src = 'vnc.html?' + params.toString();
+  // Strip secrets from visible URL
+  params.delete('tkn');
+  params.delete('token');
+  var clean = location.pathname + (params.toString() ? '?' + params.toString() : '');
+  history.replaceState(null, '', clean);
+})();
+</script>
+</body>
+</html>
+VIEWER_EOF
+
+# auth-websockify is created as a separate step after install
+
+# Clean apt cache to reduce snapshot size
+apt-get clean > /dev/null 2>&1
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+echo "INSTALL_COMPLETE"
+`;
+
+async function main() {
+  const client = new ModalClient({ tokenId, tokenSecret });
+
+  try {
+    console.log("[build-snapshot] Creating sandbox from python:3.11-slim...");
+    const startTime = Date.now();
+
+    const instance = await client.instances.start({
+      image: "python:3.11-slim",
+      timeoutSeconds: 30 * 60,
+      encryptedPorts: [8888, 39377, 39378, 39380],
+    });
+
+    console.log(
+      `[build-snapshot] Sandbox created: ${instance.id} (${((Date.now() - startTime) / 1000).toFixed(1)}s)`,
+    );
+
+    console.log("[build-snapshot] Running install script...");
+    const installStart = Date.now();
+    const result = await instance.exec(INSTALL_SCRIPT);
+
+    if (result.exit_code !== 0) {
+      console.error("[build-snapshot] Install failed:");
+      console.error("stdout:", result.stdout);
+      console.error("stderr:", result.stderr);
+      process.exit(1);
+    }
+
+    console.log(
+      `[build-snapshot] Install complete (${((Date.now() - installStart) / 1000).toFixed(1)}s)`,
+    );
+
+    // Upload locally-built worker-daemon if available (overrides the release binary)
+    const localWorkerDaemon = resolve(import.meta.dirname!, "/tmp/worker-daemon-linux");
+    if (existsSync(localWorkerDaemon)) {
+      console.log("[build-snapshot] Uploading local worker-daemon binary...");
+      const binary = readFileSync(localWorkerDaemon);
+      const b64 = binary.toString("base64");
+      // Write base64 chunks to avoid shell arg limits
+      const chunkSize = 65536;
+      const chunks = Math.ceil(b64.length / chunkSize);
+      await instance.exec("rm -f /tmp/worker-daemon.b64");
+      for (let i = 0; i < chunks; i++) {
+        const chunk = b64.slice(i * chunkSize, (i + 1) * chunkSize);
+        await instance.exec(`printf '%s' '${chunk}' >> /tmp/worker-daemon.b64`);
+      }
+      const uploadResult = await instance.exec(
+        "base64 -d /tmp/worker-daemon.b64 > /usr/local/bin/worker-daemon && chmod +x /usr/local/bin/worker-daemon && rm /tmp/worker-daemon.b64 && echo UPLOAD_OK",
+      );
+      if (uploadResult.stdout.includes("UPLOAD_OK")) {
+        console.log("[build-snapshot] Local worker-daemon uploaded successfully");
+      } else {
+        console.error("[build-snapshot] Failed to upload worker-daemon:", uploadResult.stderr);
+      }
+    }
+
+    // Create auth-websockify script (separate exec to avoid heredoc issues in main script)
+    console.log("[build-snapshot] Installing auth-websockify...");
+    const authWsScript = [
+      "#!/usr/bin/python3",
+      "import sys, os, urllib.parse",
+      "from websockify import websocketproxy",
+      "",
+      "TOKEN_FILE = '/home/user/.worker-auth-token'",
+      "",
+      "def _read_token():",
+      "    try:",
+      "        with open(TOKEN_FILE) as f:",
+      "            return f.read().strip()",
+      "    except Exception:",
+      "        return None",
+      "",
+      "def _validate_token(handler):",
+      "    parsed = urllib.parse.urlparse(handler.path)",
+      "    params = urllib.parse.parse_qs(parsed.query)",
+      "    tkn = params.get('tkn', params.get('token', [None]))[0]",
+      "    expected = _read_token()",
+      "    return tkn is not None and expected is not None and tkn == expected",
+      "",
+      "class AuthRequestHandler(websocketproxy.ProxyRequestHandler):",
+      "    def do_GET(self):",
+      "        if not _validate_token(self):",
+      "            self.send_error(403, 'Forbidden: missing or invalid token')",
+      "            return",
+      "        return super().do_GET()",
+      "",
+      "    def do_proxy(self):",
+      "        if not _validate_token(self):",
+      "            self.send_error(403, 'Forbidden: missing or invalid token')",
+      "            return",
+      "        return super().do_proxy()",
+      "",
+      "# Override WebSocketProxy to always use AuthRequestHandler",
+      "# (default param is evaluated at define time, so monkey-patching module attr won't work)",
+      "OrigWebSocketProxy = websocketproxy.WebSocketProxy",
+      "class AuthWebSocketProxy(OrigWebSocketProxy):",
+      "    def __init__(self, RequestHandlerClass=AuthRequestHandler, *args, **kwargs):",
+      "        super().__init__(RequestHandlerClass=RequestHandlerClass, *args, **kwargs)",
+      "websocketproxy.WebSocketProxy = AuthWebSocketProxy",
+      "",
+      "if __name__ == '__main__':",
+      "    websocketproxy.websockify_init()",
+    ].join("\n");
+    const authWsB64 = Buffer.from(authWsScript).toString("base64");
+    const authResult = await instance.exec(
+      `echo '${authWsB64}' | base64 -d > /usr/local/bin/auth-websockify && chmod +x /usr/local/bin/auth-websockify && echo AUTH_WS_OK`,
+    );
+    if (authResult.stdout.includes("AUTH_WS_OK")) {
+      console.log("[build-snapshot] auth-websockify installed successfully");
+    } else {
+      console.error("[build-snapshot] Failed to install auth-websockify:", authResult.stderr);
+    }
+
+    console.log("[build-snapshot] Snapshotting filesystem...");
+    const snapStart = Date.now();
+    const snapshotImageId = await instance.snapshotFilesystem(5 * 60 * 1000);
+    console.log(
+      `[build-snapshot] Snapshot created: ${snapshotImageId} (${((Date.now() - snapStart) / 1000).toFixed(1)}s)`,
+    );
+
+    await instance.stop();
+
+    const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(`\n[build-snapshot] Done in ${totalTime}s`);
+    console.log(`\nSnapshot ID: ${snapshotImageId}`);
+    console.log(
+      `\nTo use this snapshot, update Convex env:\n  cd packages/convex && bunx convex env set MODAL_SNAPSHOT_IMAGE_ID "${snapshotImageId}"`,
+    );
+  } finally {
+    client.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **VNC auth**: Added `auth-websockify` that validates `tkn`/`token` query params before serving VNC content or proxying WebSocket connections. Without a valid token, requests return 403.
- **Token stripping**: Added `viewer.html` wrapper that loads noVNC in an iframe while stripping the auth token from the visible URL bar.
- **Jupyter CLI**: Added `cloudrouter jupyter <id>` command and Jupyter URL to `status` output. Also added `jupyterUrl` to the `GetInstance` API response.
- **Chrome as default browser**: Set Chrome as XFCE default browser in Modal startup script (written after `startxfce4` since XFCE recreates config on boot).
- **Snapshot build script**: Added `scripts/build-modal-snapshot.ts` for building Modal snapshots locally with optional local worker-daemon binary upload.

## Files changed
- `packages/cmux-devbox-2/internal/cli/open.go` — Added `jupyterCmd`, Jupyter URL in `statusCmd`
- `packages/cmux-devbox-2/internal/cli/root.go` — Registered `jupyterCmd`
- `packages/convex/convex/devbox_v2_http.ts` — Added `jupyterUrl` to GetInstance response
- `packages/convex/convex/modal_actions.ts` — Chrome defaults, auth-websockify, viewer.html URL
- `scripts/build-modal-snapshot.ts` — New snapshot build script with auth-websockify + viewer.html

## Test plan
- [x] VNC without token returns 403
- [x] VNC with wrong token returns 403
- [x] VNC with correct token returns 200
- [x] Snapshot built and deployed (`im-Pzh3knU1Lgmf6tdlg3XN1F`)
- [ ] Verify `cloudrouter jupyter` opens Jupyter in browser
- [ ] Verify Chrome is default browser in XFCE VNC desktop