### PR TITLE
Add configurable sandbox timeouts and lifecycle primitives

### DIFF
--- a/packages/cloudrouter/internal/api/client.go
+++ b/packages/cloudrouter/internal/api/client.go
@@ -162,6 +162,27 @@ func (c *Client) StopInstance(teamSlug, id string) error {
 	return err
 }
 
+// PauseInstance pauses a sandbox (preserves state)
+func (c *Client) PauseInstance(teamSlug, id string) error {
+	path := fmt.Sprintf("/api/v2/devbox/instances/%s/pause", id)
+	_, err := c.doRequest("POST", path, map[string]string{"teamSlugOrId": teamSlug})
+	return err
+}
+
+// ResumeInstance resumes a paused sandbox
+func (c *Client) ResumeInstance(teamSlug, id string) error {
+	path := fmt.Sprintf("/api/v2/devbox/instances/%s/resume", id)
+	_, err := c.doRequest("POST", path, map[string]string{"teamSlugOrId": teamSlug})
+	return err
+}
+
+// DeleteInstance terminates a sandbox and removes its record
+func (c *Client) DeleteInstance(teamSlug, id string) error {
+	path := fmt.Sprintf("/api/v2/devbox/instances/%s/delete", id)
+	_, err := c.doRequest("POST", path, map[string]string{"teamSlugOrId": teamSlug})
+	return err
+}
+
 // ExtendTimeout extends the sandbox timeout
 func (c *Client) ExtendTimeout(teamSlug, id string, timeoutMs int) error {
 	path := fmt.Sprintf("/api/v2/devbox/instances/%s/extend", id)

--- a/packages/cloudrouter/internal/cli/lifecycle.go
+++ b/packages/cloudrouter/internal/cli/lifecycle.go
@@ -9,7 +9,8 @@ import (
 
 var stopCmd = &cobra.Command{
 	Use:   "stop <id>",
-	Short: "Stop a sandbox",
+	Short: "Pause a sandbox (preserves state)",
+	Long:  "Pause a sandbox. The sandbox state is preserved and can be resumed later with 'resume'.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		teamSlug, err := getTeamSlug()
@@ -18,10 +19,50 @@ var stopCmd = &cobra.Command{
 		}
 
 		client := api.NewClient()
-		if err := client.StopInstance(teamSlug, args[0]); err != nil {
+		if err := client.PauseInstance(teamSlug, args[0]); err != nil {
 			return err
 		}
-		fmt.Printf("Stopped: %s\n", args[0])
+		fmt.Printf("Paused: %s\n", args[0])
+		return nil
+	},
+}
+
+var pauseCmd = &cobra.Command{
+	Use:   "pause <id>",
+	Short: "Pause a sandbox (preserves state)",
+	Long:  "Pause a sandbox. The sandbox state is preserved and can be resumed later with 'resume'.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		teamSlug, err := getTeamSlug()
+		if err != nil {
+			return fmt.Errorf("failed to get team: %w", err)
+		}
+
+		client := api.NewClient()
+		if err := client.PauseInstance(teamSlug, args[0]); err != nil {
+			return err
+		}
+		fmt.Printf("Paused: %s\n", args[0])
+		return nil
+	},
+}
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume <id>",
+	Short: "Resume a paused sandbox",
+	Long:  "Resume a previously paused sandbox so it becomes active again.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		teamSlug, err := getTeamSlug()
+		if err != nil {
+			return fmt.Errorf("failed to get team: %w", err)
+		}
+
+		client := api.NewClient()
+		if err := client.ResumeInstance(teamSlug, args[0]); err != nil {
+			return err
+		}
+		fmt.Printf("Resumed: %s\n", args[0])
 		return nil
 	},
 }
@@ -29,7 +70,8 @@ var stopCmd = &cobra.Command{
 var deleteCmd = &cobra.Command{
 	Use:     "delete <id>",
 	Aliases: []string{"rm", "kill"},
-	Short:   "Delete a sandbox",
+	Short:   "Delete a sandbox (terminates and removes)",
+	Long:    "Permanently delete a sandbox. This terminates the sandbox and removes all records.",
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		teamSlug, err := getTeamSlug()
@@ -38,7 +80,7 @@ var deleteCmd = &cobra.Command{
 		}
 
 		client := api.NewClient()
-		if err := client.StopInstance(teamSlug, args[0]); err != nil {
+		if err := client.DeleteInstance(teamSlug, args[0]); err != nil {
 			return err
 		}
 		fmt.Printf("Deleted: %s\n", args[0])
@@ -65,29 +107,6 @@ var extendCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Extended timeout by %d seconds: %s\n", extendFlagTimeout, args[0])
-		return nil
-	},
-}
-
-// These are no-ops for E2B (included for CLI compatibility)
-var pauseCmd = &cobra.Command{
-	Use:    "pause <id>",
-	Short:  "Extend sandbox timeout (pause not supported)",
-	Args:   cobra.ExactArgs(1),
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Note: Pause is not supported. Use 'extend' to keep sandbox running longer.")
-		return extendCmd.RunE(cmd, args)
-	},
-}
-
-var resumeCmd = &cobra.Command{
-	Use:    "resume <id>",
-	Short:  "No-op (sandboxes don't pause)",
-	Args:   cobra.ExactArgs(1),
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Note: Sandboxes don't pause. If stopped, create a new one.")
 		return nil
 	},
 }

--- a/packages/cloudrouter/internal/cli/root.go
+++ b/packages/cloudrouter/internal/cli/root.go
@@ -31,7 +31,9 @@ Quick start:
   cloudrouter start ./my-project         # Create sandbox + upload directory
   cloudrouter code <id>                  # Open VS Code
   cloudrouter pty <id>                   # Open terminal session
-  cloudrouter stop <id>                  # Stop sandbox
+  cloudrouter stop <id>                  # Pause sandbox
+  cloudrouter resume <id>                # Resume paused sandbox
+  cloudrouter delete <id>                # Delete sandbox permanently
   cloudrouter ls                         # List all sandboxes
 
 GPU options (--gpu):

--- a/packages/cloudrouter/internal/cli/start.go
+++ b/packages/cloudrouter/internal/cli/start.go
@@ -33,6 +33,7 @@ var (
 	startFlagCPU      float64
 	startFlagMemory   int
 	startFlagImage    string
+	startFlagTimeout  int
 )
 
 // availableGpus are GPUs that can be used without special approval
@@ -218,6 +219,7 @@ Examples:
 			TeamSlugOrID: teamSlug,
 			TemplateID:   templateID,
 			Name:         name,
+			TTLSeconds:   startFlagTimeout,
 		}
 		if provider != "" {
 			createReq.Provider = provider
@@ -355,4 +357,5 @@ func init() {
 	startCmd.Flags().Float64Var(&startFlagCPU, "cpu", 0, "CPU cores (e.g., 4, 8)")
 	startCmd.Flags().IntVar(&startFlagMemory, "memory", 0, "Memory in MiB (e.g., 8192, 65536)")
 	startCmd.Flags().StringVar(&startFlagImage, "image", "", "Container image (e.g., ubuntu:22.04)")
+	startCmd.Flags().IntVar(&startFlagTimeout, "timeout", 600, "Sandbox timeout in seconds (default: 10 minutes)")
 }


### PR DESCRIPTION
## Summary
- Add `--timeout` flag to `cloudrouter start` (default 10 minutes instead of 1 hour)
- Remap `stop` command to **pause** sandbox (preserves state, resumable)
- Unhide `pause` and `resume` as first-class CLI commands
- `delete`/`rm`/`kill` now properly **terminates** the sandbox and removes DB records
- Add backend delete endpoint that stops provider instance + cleans up records
- Change default TTL from 1 hour → 10 minutes for both E2B and Modal providers

## Test plan
- [ ] `cloudrouter start --timeout 300` creates sandbox with 5 min timeout
- [ ] `cloudrouter stop <id>` pauses (not terminates) the sandbox
- [ ] `cloudrouter resume <id>` resumes a paused sandbox
- [ ] `cloudrouter pause <id>` also pauses (alias behavior)
- [ ] `cloudrouter delete <id>` terminates and removes the sandbox
- [ ] `cloudrouter extend <id>` extends timeout as before
- [ ] `cloudrouter --help` shows updated descriptions for lifecycle commands