### PR TITLE
Update Discord links to new invite URL

### DIFF
--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -124,7 +124,7 @@ export default function ManaflowPage() {
             github
           </a>
           <a
-            href="https://discord.gg/FVevu78A"
+            href="https://discord.gg/SDbQmzQhRK"
             target="_blank"
             className="text-neutral-500 hover:text-black hover:underline"
           >


### PR DESCRIPTION
update my discord links with https://discord.gg/SDbQmzQhRK everywhere instead of the old one