### PR TITLE
Wrap long diff lines in Monaco viewer

### DIFF
--- a/apps/client/src/components/monaco/monaco-git-diff-viewer-with-sidebar.tsx
+++ b/apps/client/src/components/monaco/monaco-git-diff-viewer-with-sidebar.tsx
@@ -507,6 +507,12 @@ function createDiffEditorMount({
       return;
     }
 
+    // Explicitly enable word wrap on both sub-editors so long lines never
+    // overflow horizontally.  The top-level diffOptions.wordWrap doesn't
+    // always propagate reliably to both panes.
+    originalEditor.updateOptions({ wordWrap: "on" });
+    modifiedEditor.updateOptions({ wordWrap: "on" });
+
     const disposables: Array<{ dispose: () => void }> = [];
     const originalVisibility = container.style.visibility;
     const originalTransform = container.style.transform;

--- a/apps/client/src/components/monaco/monaco-git-diff-viewer.tsx
+++ b/apps/client/src/components/monaco/monaco-git-diff-viewer.tsx
@@ -498,6 +498,12 @@ function createDiffEditorMount({
       return;
     }
 
+    // Explicitly enable word wrap on both sub-editors so long lines never
+    // overflow horizontally.  The top-level diffOptions.wordWrap doesn't
+    // always propagate reliably to both panes.
+    originalEditor.updateOptions({ wordWrap: "on" });
+    modifiedEditor.updateOptions({ wordWrap: "on" });
+
     const disposables: Array<{ dispose: () => void }> = [];
     const originalVisibility = container.style.visibility;
     const originalTransform = container.style.transform;


### PR DESCRIPTION
it seems that in the git diff viewer (monaco view) sometimes the diff view lines overflow and we can drag it left and right... we dont want that we want it to be fixed (just use a new line if needed)...