### PR TITLE
Add E2B lifecycle webhook ingestion in Convex

### DIFF
--- a/apps/www/app/cloudrouter/terminal-demo.tsx
+++ b/apps/www/app/cloudrouter/terminal-demo.tsx
@@ -459,10 +459,14 @@ export function TerminalDemo() {
           addLine(outputLine);
         }
 
+        // Show next prompt immediately, then pause before typing
+        const nextPrompt = STEPS[stepIdx + 1]?.prompt ?? "~/my-app";
+        setCurrentPrompt(nextPrompt);
+        setShowCursor(true);
+
         // Pause between steps
         const pause = step.pauseAfter ?? STEP_PAUSE;
         await sleep(pause + 400, signal);
-        setShowCursor(true);
       }
 
       // Demo complete

--- a/packages/convex/_shared/convex-env.ts
+++ b/packages/convex/_shared/convex-env.ts
@@ -21,6 +21,7 @@ export const env = createEnv({
     AWS_BEARER_TOKEN_BEDROCK: z.string().min(1).optional(),
     MORPH_API_KEY: z.string().min(1).optional(),
     E2B_API_KEY: z.string().min(1).optional(),
+    E2B_WEBHOOK_SECRET: z.string().min(1).optional(),
     MODAL_TOKEN_ID: z.string().min(1),
     MODAL_TOKEN_SECRET: z.string().min(1),
     CMUX_IS_STAGING: z.string().optional(),

--- a/packages/convex/_shared/e2b-webhook.test.ts
+++ b/packages/convex/_shared/e2b-webhook.test.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  E2BWebhookEventSchema,
+  computeE2BWebhookSignature,
+  mapE2BWebhookEventType,
+  verifyE2BWebhookSignature,
+} from "./e2b-webhook";
+
+describe("e2b webhook helpers", () => {
+  it("computes the documented signature format", async () => {
+    const secret = "test-secret";
+    const payload = '{"id":"evt_123","type":"sandbox.lifecycle.created","sandboxId":"sbx_123"}';
+    const expected = createHash("sha256")
+      .update(`${secret}${payload}`, "utf8")
+      .digest("base64")
+      .replace(/=+$/g, "");
+
+    const actual = await computeE2BWebhookSignature(secret, payload);
+    expect(actual).toBe(expected);
+  });
+
+  it("verifies a valid signature header", async () => {
+    const secret = "test-secret";
+    const payload = '{"id":"evt_123","type":"sandbox.lifecycle.created","sandboxId":"sbx_123"}';
+    const signatureHeader = await computeE2BWebhookSignature(secret, payload);
+
+    const ok = await verifyE2BWebhookSignature({
+      secret,
+      payload,
+      signatureHeader,
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a tampered payload", async () => {
+    const secret = "test-secret";
+    const signedPayload = '{"id":"evt_123","type":"sandbox.lifecycle.created","sandboxId":"sbx_123"}';
+    const tamperedPayload = '{"id":"evt_123","type":"sandbox.lifecycle.killed","sandboxId":"sbx_123"}';
+    const signatureHeader = await computeE2BWebhookSignature(secret, signedPayload);
+
+    const ok = await verifyE2BWebhookSignature({
+      secret,
+      payload: tamperedPayload,
+      signatureHeader,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("maps lifecycle events to instance state transitions", () => {
+    expect(mapE2BWebhookEventType("sandbox.lifecycle.created")).toEqual({
+      status: "running",
+      activity: "resume",
+    });
+    expect(mapE2BWebhookEventType("sandbox.lifecycle.resumed")).toEqual({
+      status: "running",
+      activity: "resume",
+    });
+    expect(mapE2BWebhookEventType("sandbox.lifecycle.paused")).toEqual({
+      status: "paused",
+      activity: "pause",
+    });
+    expect(mapE2BWebhookEventType("sandbox.lifecycle.killed")).toEqual({
+      status: "stopped",
+      activity: "stop",
+    });
+    expect(mapE2BWebhookEventType("sandbox.lifecycle.timeout")).toEqual({
+      status: "stopped",
+      activity: "stop",
+    });
+    expect(mapE2BWebhookEventType("sandbox.lifecycle.updated")).toEqual({
+      status: null,
+      activity: null,
+    });
+    expect(mapE2BWebhookEventType("ping")).toBeNull();
+  });
+
+  it("parses a valid E2B lifecycle payload", () => {
+    const event = E2BWebhookEventSchema.parse({
+      id: "evt_123",
+      timestamp: "2026-02-13T11:12:13.456Z",
+      type: "sandbox.lifecycle.created",
+      sandboxId: "sbx_123",
+      eventData: {
+        metadata: {
+          app: "cmux-devbox-v2",
+        },
+      },
+    });
+    expect(event.sandboxId).toBe("sbx_123");
+  });
+
+  it("allows ping payloads without sandboxId", () => {
+    const event = E2BWebhookEventSchema.parse({
+      id: "evt_ping",
+      timestamp: "2026-02-13T11:12:13.456Z",
+      type: "ping",
+    });
+    expect(event.type).toBe("ping");
+    expect(event.sandboxId).toBeUndefined();
+  });
+});

--- a/packages/convex/_shared/e2b-webhook.ts
+++ b/packages/convex/_shared/e2b-webhook.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { base64FromBytes } from "./encoding";
+
+const E2B_LIFECYCLE_TO_STATE = {
+  "sandbox.lifecycle.created": {
+    status: "running",
+    activity: "resume",
+  },
+  "sandbox.lifecycle.resumed": {
+    status: "running",
+    activity: "resume",
+  },
+  "sandbox.lifecycle.paused": {
+    status: "paused",
+    activity: "pause",
+  },
+  "sandbox.lifecycle.killed": {
+    status: "stopped",
+    activity: "stop",
+  },
+  "sandbox.lifecycle.timeout": {
+    status: "stopped",
+    activity: "stop",
+  },
+  "sandbox.lifecycle.updated": {
+    status: null,
+    activity: null,
+  },
+} as const;
+
+export const E2BWebhookEventSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  type: z.string(),
+  sandboxId: z.string().optional(),
+  eventData: z.record(z.string(), z.unknown()).nullable().optional(),
+});
+
+export type E2BWebhookEvent = z.infer<typeof E2BWebhookEventSchema>;
+export type E2BWebhookLifecycleType = keyof typeof E2B_LIFECYCLE_TO_STATE;
+export type E2BWebhookMappedState =
+  (typeof E2B_LIFECYCLE_TO_STATE)[E2BWebhookLifecycleType];
+
+function safeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    result |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  }
+  return result === 0;
+}
+
+export async function computeE2BWebhookSignature(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const bytes = new TextEncoder().encode(`${secret}${payload}`);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return base64FromBytes(digest).replace(/=+$/g, "");
+}
+
+export async function verifyE2BWebhookSignature(args: {
+  secret: string;
+  payload: string;
+  signatureHeader: string | null;
+}): Promise<boolean> {
+  const signature = args.signatureHeader?.trim();
+  if (!signature) return false;
+  const expected = await computeE2BWebhookSignature(args.secret, args.payload);
+  return safeEqualString(expected, signature);
+}
+
+export function mapE2BWebhookEventType(
+  eventType: string,
+): E2BWebhookMappedState | null {
+  switch (eventType) {
+    case "sandbox.lifecycle.created":
+      return E2B_LIFECYCLE_TO_STATE["sandbox.lifecycle.created"];
+    case "sandbox.lifecycle.resumed":
+      return E2B_LIFECYCLE_TO_STATE["sandbox.lifecycle.resumed"];
+    case "sandbox.lifecycle.paused":
+      return E2B_LIFECYCLE_TO_STATE["sandbox.lifecycle.paused"];
+    case "sandbox.lifecycle.killed":
+      return E2B_LIFECYCLE_TO_STATE["sandbox.lifecycle.killed"];
+    case "sandbox.lifecycle.timeout":
+      return E2B_LIFECYCLE_TO_STATE["sandbox.lifecycle.timeout"];
+    case "sandbox.lifecycle.updated":
+      return E2B_LIFECYCLE_TO_STATE["sandbox.lifecycle.updated"];
+    default:
+      return null;
+  }
+}

--- a/packages/convex/convex/e2b_webhook.ts
+++ b/packages/convex/convex/e2b_webhook.ts
@@ -1,0 +1,81 @@
+import { sha256Hex } from "../_shared/crypto";
+import {
+  type E2BWebhookEvent,
+  E2BWebhookEventSchema,
+  mapE2BWebhookEventType,
+  verifyE2BWebhookSignature,
+} from "../_shared/e2b-webhook";
+import { env } from "../_shared/convex-env";
+import { internal } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+
+export const e2bWebhook = httpAction(async (ctx, req) => {
+  if (!env.E2B_WEBHOOK_SECRET) {
+    return new Response("webhook not configured", { status: 501 });
+  }
+
+  const payload = await req.text();
+  const signature = req.headers.get("e2b-signature");
+
+  const isValidSignature = await verifyE2BWebhookSignature({
+    secret: env.E2B_WEBHOOK_SECRET,
+    payload,
+    signatureHeader: signature,
+  });
+  if (!isValidSignature) {
+    return new Response("invalid signature", { status: 400 });
+  }
+
+  let event: E2BWebhookEvent;
+  try {
+    event = E2BWebhookEventSchema.parse(JSON.parse(payload));
+  } catch {
+    return new Response("invalid payload", { status: 400 });
+  }
+
+  const deliveryId = req.headers.get("e2b-delivery-id") ?? event.id;
+  if (deliveryId) {
+    const payloadHash = await sha256Hex(payload);
+    const result = await ctx.runMutation(internal.github_app.recordWebhookDelivery, {
+      provider: "e2b",
+      deliveryId: `e2b:${deliveryId}`,
+      payloadHash,
+    });
+    if (!result.created) {
+      return new Response("ok (duplicate)", { status: 200 });
+    }
+  }
+
+  const mappedState = mapE2BWebhookEventType(event.type);
+  if (!mappedState) {
+    return new Response("ok (ignored)", { status: 200 });
+  }
+
+  if (!event.sandboxId) {
+    return new Response("invalid payload", { status: 400 });
+  }
+  const sandboxId = event.sandboxId;
+
+  if (mappedState.status) {
+    await ctx.runMutation(internal.devboxInstances.updateStatusInternal, {
+      providerInstanceId: sandboxId,
+      status: mappedState.status,
+    });
+  }
+
+  if (mappedState.activity === "resume") {
+    await ctx.runMutation(internal.e2bInstances.recordResumeInternal, {
+      instanceId: sandboxId,
+    });
+  } else if (mappedState.activity === "pause") {
+    await ctx.runMutation(internal.e2bInstances.recordPauseInternal, {
+      instanceId: sandboxId,
+    });
+  } else if (mappedState.activity === "stop") {
+    await ctx.runMutation(internal.e2bInstances.recordStopInternal, {
+      instanceId: sandboxId,
+    });
+  }
+
+  return new Response("ok", { status: 200 });
+});

--- a/packages/convex/convex/http.ts
+++ b/packages/convex/convex/http.ts
@@ -16,6 +16,7 @@ import { githubSetup } from "./github_setup";
 import { githubWebhook } from "./github_webhook";
 import { reportEnvironmentError } from "./taskRuns_http";
 import { stackWebhook } from "./stack_webhook";
+import { e2bWebhook } from "./e2b_webhook";
 import {
   updatePreviewStatus,
   createScreenshotSet,
@@ -72,6 +73,12 @@ http.route({
   path: "/stack_webhook",
   method: "POST",
   handler: stackWebhook,
+});
+
+http.route({
+  path: "/e2b_webhook",
+  method: "POST",
+  handler: e2bWebhook,
 });
 
 http.route({


### PR DESCRIPTION
## Scope
This PR only adds E2B webhook ingestion + lifecycle state tracking.
It does **not** implement billing ledgering, metering, invoicing, or limits.

## In Scope
- add Convex HTTP webhook endpoint at `/e2b_webhook`
- verify E2B webhook signatures (`sha256(secret + payload)` base64, no padding)
- parse lifecycle payloads and map to internal devbox/e2b status/activity updates
- dedupe webhook deliveries using existing `webhookDeliveries`
- add shared helper tests for signature/mapping/ping payload compatibility
- add `E2B_WEBHOOK_SECRET` to Convex env schema

## Out Of Scope
- billing tables or credit ledger
- Stripe/Stack payment integration
- usage pricing/invoice generation
- Modal lifecycle reconciliation

## Testing
- `cd packages/convex && bun test`
- `bun check` (lint/typecheck pass; existing openapi generation warning in this repo setup)
