### PR TITLE
Prevent horizontal overflow on landing, wrap lines

### DIFF
--- a/apps/www/app/cloudrouter/code-block-styles.ts
+++ b/apps/www/app/cloudrouter/code-block-styles.ts
@@ -2,4 +2,4 @@ export const CLOUDROUTER_CODE_BLOCK_CLASS =
   "overflow-x-auto rounded-lg border border-neutral-200 text-sm leading-relaxed dark:border-neutral-800 [&_pre]:!m-0 [&_pre]:!rounded-lg [&_pre]:!p-4 [&_pre]:!pr-12";
 
 export const CLOUDROUTER_SKILL_CONTENT_CLASS =
-  "max-h-[600px] overflow-y-auto overflow-x-auto rounded-lg border border-neutral-200 text-sm leading-relaxed dark:border-neutral-800 [&_pre]:!m-0 [&_pre]:!rounded-lg [&_pre]:!p-4 [&_pre]:!pr-12";
+  "max-h-[600px] overflow-y-auto rounded-lg border border-neutral-200 text-sm leading-relaxed dark:border-neutral-800 [&_pre]:!m-0 [&_pre]:!rounded-lg [&_pre]:!p-4 [&_pre]:!pr-12 [&_pre]:![white-space:pre-wrap] [&_pre]:![overflow-wrap:break-word]";


### PR DESCRIPTION
image.png fix this random horizontal scroll that is happening in the cloudrouter landing page. it shoudl not tlook this we want to just extend to new lines if possible and not overflow like that...