### PR TITLE
fix: use auth token as SSH username in curl-based transport

### DIFF
--- a/packages/cloudrouter/internal/cli/computer.go
+++ b/packages/cloudrouter/internal/cli/computer.go
@@ -50,7 +50,7 @@ func runSSHCommand(workerURL, token, command string) (string, string, int, error
 	// Try curl-based SSH first (preferred - simpler, no Go bridge needed)
 	curlPath := getCurlWithWebSocket()
 	if curlPath != "" {
-		return runSSHCommandWithCurl(curlPath, wsURL, command)
+		return runSSHCommandWithCurl(curlPath, wsURL, token, command)
 	}
 
 	// Fall back to Go WebSocket bridge
@@ -58,14 +58,14 @@ func runSSHCommand(workerURL, token, command string) (string, string, int, error
 }
 
 // runSSHCommandWithCurl runs a command via SSH using curl as ProxyCommand.
-func runSSHCommandWithCurl(curlPath, wsURL, command string) (string, string, int, error) {
+func runSSHCommandWithCurl(curlPath, wsURL, token, command string) (string, string, int, error) {
 	proxyCmd := fmt.Sprintf("%s --no-progress-meter -N --http1.1 -T . '%s'", curlPath, wsURL)
 	sshArgs := []string{
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=ERROR",
 		"-o", fmt.Sprintf("ProxyCommand=%s", proxyCmd),
-		"user@e2b-sandbox",
+		fmt.Sprintf("%s@e2b-sandbox", token),
 		command,
 	}
 


### PR DESCRIPTION
## Summary
- When curl has WebSocket support (e.g. Homebrew curl on macOS), the curl ProxyCommand transport used hardcoded `user` as the SSH username
- The server-side SSH auth requires `username == auth token`, so this always failed with `user@e2b-sandbox's password:` prompt
- Fixed all 4 affected code paths (`runRsyncWithCurl`, `runRsyncSingleFileWithCurl`, `runRsyncDownloadWithCurl`, `runSSHCommandWithCurl`) to pass the auth token as the SSH username, matching what the bridge fallback already does

Fixes #1711

## Test plan
- [ ] Install Homebrew curl (`brew install curl`) to get WebSocket support
- [ ] Run `cloudrouter start .` — should sync without password prompt
- [ ] Run `cloudrouter upload` — should work without password prompt
- [ ] Run `cloudrouter download` — should work without password prompt
- [ ] Verify bridge fallback still works (uninstall Homebrew curl or use system curl)