### PR TITLE
Gate high-end GPUs behind approval

### DIFF
--- a/packages/cloudrouter/internal/cli/root.go
+++ b/packages/cloudrouter/internal/cli/root.go
@@ -54,6 +54,8 @@ GPU options (--gpu, auto-selects Modal provider):
   T4          16GB VRAM  - inference, fine-tuning small models
   L4          24GB VRAM  - inference, image generation
   A10G        24GB VRAM  - training medium models
+
+  The following GPUs require approval (contact founders@manaflow.ai):
   L40S        48GB VRAM  - inference, video generation
   A100        40GB VRAM  - training large models (7B-70B)
   A100-80GB   80GB VRAM  - very large models

--- a/packages/cloudrouter/internal/cli/start.go
+++ b/packages/cloudrouter/internal/cli/start.go
@@ -78,6 +78,8 @@ GPU options (--gpu):
   T4          16GB VRAM  - inference, fine-tuning small models
   L4          24GB VRAM  - inference, image generation
   A10G        24GB VRAM  - training medium models
+
+  The following GPUs require approval (contact founders@manaflow.ai):
   L40S        48GB VRAM  - inference, video generation
   A100        40GB VRAM  - training large models (7B-70B)
   A100-80GB   80GB VRAM  - very large models
@@ -161,6 +163,18 @@ Examples:
 				if name == "" {
 					name = filepath.Base(absPath)
 				}
+			}
+		}
+
+		// Gate expensive GPUs client-side
+		if startFlagGPU != "" {
+			baseGPU := strings.ToUpper(strings.Split(startFlagGPU, ":")[0])
+			gatedGPUs := map[string]bool{
+				"L40S": true, "A100": true, "A100-80GB": true,
+				"H100": true, "H200": true, "B200": true,
+			}
+			if gatedGPUs[baseGPU] {
+				return fmt.Errorf("GPU type %q requires approval. Contact founders@manaflow.ai to get this GPU enabled for your account", startFlagGPU)
 			}
 		}
 

--- a/packages/convex/convex/devbox_v2_http.ts
+++ b/packages/convex/convex/devbox_v2_http.ts
@@ -207,7 +207,7 @@ export const createInstance = httpAction(async (ctx, req) => {
         return jsonResponse(
           {
             code: 403,
-            message: `GPU type "${body.gpu}" requires approval. Please contact the Manaflow team at founders@manaflow.com for inquiry.`,
+            message: `GPU type "${body.gpu}" requires approval. Please contact founders@manaflow.ai to get this GPU enabled for your account.`,
           },
           403,
         );

--- a/packages/shared/src/modal-templates.ts
+++ b/packages/shared/src/modal-templates.ts
@@ -147,18 +147,13 @@ export const getModalGpuTemplates = (): readonly ModalTemplatePreset[] => {
 };
 
 /**
- * All GPUs are now available without approval.
+ * GPUs available without approval. Higher-end GPUs (L40S, A100, H100, H200, B200)
+ * require contacting founders@manaflow.ai for enablement.
  */
 export const MODAL_AVAILABLE_GPUS = new Set([
   "T4",
   "L4",
   "A10G",
-  "L40S",
-  "A100",
-  "A100-80GB",
-  "H100",
-  "H200",
-  "B200",
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Gates L40S, A100, A100-80GB, H100, H200, and B200 GPUs behind approval — only T4, L4, and A10G are freely available
- Adds client-side guardrail in the CLI to reject gated GPUs with a clear error before hitting the API
- Updates `--help` text in both `start` and root commands to indicate which GPUs require approval
- Directs users to contact founders@manaflow.ai for enablement

## Test plan
- [ ] Run `cloudrouter start --gpu T4` — should succeed
- [ ] Run `cloudrouter start --gpu H100` — should fail with approval message
- [ ] Run `cloudrouter start --help` — should show gated GPU section
- [ ] Verify API returns 403 for gated GPUs with correct message