### PR TITLE
Fix SSH password prompt on Linux (cloudrouter ssh)

### DIFF
--- a/packages/cloudrouter/internal/cli/computer.go
+++ b/packages/cloudrouter/internal/cli/computer.go
@@ -38,6 +38,8 @@ func shellQuote(s string) string {
 
 // runSSHCommand runs a command inside the sandbox via SSH over WebSocket tunnel.
 // Uses cloudrouter's built-in __ssh-proxy as SSH ProxyCommand.
+// Handles non-interactive password auth via sshpass or SSH_ASKPASS to avoid
+// password prompts on Linux where SSH opens /dev/tty directly.
 // Returns stdout, stderr, and exit code.
 func runSSHCommand(workerURL, token, command string) (string, string, int, error) {
 	wsURL := toWebSocketURL(workerURL, token)
@@ -58,7 +60,14 @@ func runSSHCommand(workerURL, token, command string) (string, string, int, error
 		command,
 	}
 
-	cmd := exec.Command("ssh", sshArgs...)
+	cmd, cleanup, buildErr := buildSSHCmd(sshArgs)
+	if buildErr != nil {
+		return "", "", -1, buildErr
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -75,6 +84,42 @@ func runSSHCommand(workerURL, token, command string) (string, string, int, error
 
 	stderrStr := filterSSHWarnings(stderr.String())
 	return stdout.String(), stderrStr, exitCode, nil
+}
+
+// buildSSHCmd wraps SSH args with non-interactive password authentication.
+// Uses sshpass when available; otherwise sets up SSH_ASKPASS with a temp
+// script so SSH doesn't open /dev/tty for password prompts on Linux.
+// Returns the command, an optional cleanup function, and any error.
+func buildSSHCmd(sshArgs []string) (*exec.Cmd, func(), error) {
+	if _, lookErr := exec.LookPath("sshpass"); lookErr == nil {
+		// Preferred: use sshpass for non-interactive empty-password auth
+		cmd := exec.Command("sshpass", append([]string{"-p", "", "ssh"}, sshArgs...)...)
+		return cmd, nil, nil
+	}
+
+	// Fallback: use SSH_ASKPASS to provide the empty password.
+	// SSH opens /dev/tty directly for password prompts (bypassing stdin),
+	// so we must force it to use SSH_ASKPASS instead.
+	askpassFile, err := os.CreateTemp("", "cmux-askpass-*.sh")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create askpass script: %w", err)
+	}
+	if _, wErr := askpassFile.WriteString("#!/bin/sh\necho ''\n"); wErr != nil {
+		askpassFile.Close()
+		os.Remove(askpassFile.Name())
+		return nil, nil, fmt.Errorf("failed to write askpass script: %w", wErr)
+	}
+	askpassFile.Close()
+	os.Chmod(askpassFile.Name(), 0700)
+	cleanup := func() { os.Remove(askpassFile.Name()) }
+
+	cmd := exec.Command("ssh", sshArgs...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("SSH_ASKPASS=%s", askpassFile.Name()),
+		"SSH_ASKPASS_REQUIRE=force",
+		"DISPLAY=dummy",
+	)
+	return cmd, cleanup, nil
 }
 
 // filterSSHWarnings removes common SSH warning lines from stderr.

--- a/packages/cloudrouter/internal/cli/ssh_password_test.go
+++ b/packages/cloudrouter/internal/cli/ssh_password_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestBuildSSHCmdPasswordAuth verifies that buildSSHCmd sets up non-interactive
+// password authentication so SSH doesn't prompt via /dev/tty on Linux.
+//
+// Regression test for https://github.com/manaflow-ai/manaflow/issues/1711
+func TestBuildSSHCmdPasswordAuth(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SSH_ASKPASS test not applicable on Windows")
+	}
+
+	sshArgs := []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "PubkeyAuthentication=no",
+		"user@host",
+		"echo hello",
+	}
+
+	cmd, cleanup, err := buildSSHCmd(sshArgs)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("buildSSHCmd failed: %v", err)
+	}
+
+	hasSshpass, _ := exec.LookPath("sshpass")
+
+	if hasSshpass != "" {
+		// When sshpass is available, it should be the command
+		if cmd.Path != hasSshpass {
+			t.Errorf("expected sshpass binary at %s, got %s", hasSshpass, cmd.Path)
+		}
+		// First three args should be: sshpass -p '' ssh
+		args := cmd.Args
+		if len(args) < 4 || args[1] != "-p" || args[2] != "" || args[3] != "ssh" {
+			t.Errorf("expected sshpass -p '' ssh ..., got %v", args[:min(4, len(args))])
+		}
+	} else {
+		// When sshpass is NOT available, SSH_ASKPASS must be configured
+		var hasAskpass, hasAskpassRequire, hasDisplay bool
+		for _, env := range cmd.Env {
+			if strings.HasPrefix(env, "SSH_ASKPASS=") {
+				hasAskpass = true
+				askpassPath := strings.TrimPrefix(env, "SSH_ASKPASS=")
+				// Verify the askpass script exists and is executable
+				info, err := os.Stat(askpassPath)
+				if err != nil {
+					t.Errorf("SSH_ASKPASS script does not exist: %s", askpassPath)
+				} else if info.Mode()&0100 == 0 {
+					t.Errorf("SSH_ASKPASS script is not executable: %s", askpassPath)
+				}
+				// Verify script content echoes empty string
+				content, err := os.ReadFile(askpassPath)
+				if err != nil {
+					t.Errorf("failed to read askpass script: %v", err)
+				} else if !strings.Contains(string(content), "echo ''") {
+					t.Errorf("askpass script should echo empty string, got: %s", content)
+				}
+			}
+			if env == "SSH_ASKPASS_REQUIRE=force" {
+				hasAskpassRequire = true
+			}
+			if env == "DISPLAY=dummy" {
+				hasDisplay = true
+			}
+		}
+
+		if !hasAskpass {
+			t.Error("SSH_ASKPASS not set in command environment")
+		}
+		if !hasAskpassRequire {
+			t.Error("SSH_ASKPASS_REQUIRE=force not set in command environment")
+		}
+		if !hasDisplay {
+			t.Error("DISPLAY=dummy not set in command environment")
+		}
+	}
+}
+
+// TestBuildSSHCmdCleanup verifies that the cleanup function removes temp files.
+func TestBuildSSHCmdCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SSH_ASKPASS test not applicable on Windows")
+	}
+	if _, err := exec.LookPath("sshpass"); err == nil {
+		t.Skip("sshpass is installed; SSH_ASKPASS path not exercised")
+	}
+
+	sshArgs := []string{"user@host", "echo hello"}
+	cmd, cleanup, err := buildSSHCmd(sshArgs)
+	if err != nil {
+		t.Fatalf("buildSSHCmd failed: %v", err)
+	}
+
+	// Find the askpass file path
+	var askpassPath string
+	for _, env := range cmd.Env {
+		if strings.HasPrefix(env, "SSH_ASKPASS=") {
+			askpassPath = strings.TrimPrefix(env, "SSH_ASKPASS=")
+			break
+		}
+	}
+	if askpassPath == "" {
+		t.Fatal("SSH_ASKPASS not found in env")
+	}
+
+	// File should exist before cleanup
+	if _, err := os.Stat(askpassPath); err != nil {
+		t.Fatalf("askpass file should exist before cleanup: %v", err)
+	}
+
+	// Run cleanup
+	if cleanup != nil {
+		cleanup()
+	}
+
+	// File should be gone after cleanup
+	if _, err := os.Stat(askpassPath); !os.IsNotExist(err) {
+		t.Errorf("askpass file should be removed after cleanup, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes `cloudrouter ssh` hanging with a password prompt on Linux when `sshpass` is not installed
- Extracts password auth setup into `buildSSHCmd()` helper, which tries `sshpass` first, then falls back to `SSH_ASKPASS` with `SSH_ASKPASS_REQUIRE=force` — the same approach already used by `buildSSHProxyCommand()` for rsync
- Adds regression tests for `buildSSHCmd` (password auth setup and temp file cleanup)

## Root cause

SSH opens `/dev/tty` directly for password prompts, bypassing Go's `cmd.Stdin`. On Linux, when a user runs `cloudrouter ssh` from a terminal, the Go process inherits the controlling terminal, and SSH accesses it via `/dev/tty` to prompt for a password — causing the command to hang indefinitely.

`buildSSHProxyCommand()` (used by rsync/upload) already handled this correctly. `runSSHCommand()` (used by `cloudrouter ssh` and browser commands) did not.

## Reproduction

Reproduced on an E2B Linux sandbox (Ubuntu 22.04, OpenSSH 8.9p1, x86_64, no sshpass):

```
Test 1: With TTY, NO sshpass, NO SSH_ASKPASS → TIMED OUT (password prompt)
Test 2: Without TTY (stdin=/dev/null)        → SUCCESS
Test 3: With TTY + SSH_ASKPASS fix           → SUCCESS
```

## Test plan

- [x] `go build` compiles
- [x] `go test ./internal/cli/ -run TestBuildSSHCmd` passes
- [ ] Manual verification on Linux (cmux VM) with the built binary

Fixes #1711