### PR TITLE
Set Claude Haiku 4.5 as default; update cmux diff heatmaps

### DIFF
--- a/apps/client/src/lib/heatmap-settings.ts
+++ b/apps/client/src/lib/heatmap-settings.ts
@@ -5,19 +5,22 @@ import {
   type HeatmapColorSettings,
 } from "@/components/heatmap-diff-viewer/heatmap-gradient";
 
+const HEATMAP_MODEL_ANTHROPIC_HAIKU_45 = "anthropic-haiku-4-5";
+const LEGACY_HEATMAP_MODEL_ANTHROPIC_OPUS_45 = "anthropic-opus-4-5";
+const LEGACY_HEATMAP_MODEL_ANTHROPIC = "anthropic";
+
 export const HEATMAP_MODEL_OPTIONS = [
-  { value: "anthropic-opus-4-5", label: "Claude Opus 4.5" },
+  { value: HEATMAP_MODEL_ANTHROPIC_HAIKU_45, label: "Claude Haiku 4.5" },
   { value: "cmux-heatmap-2", label: "cmux-heatmap-2" },
   { value: "cmux-heatmap-0", label: "cmux-heatmap-0" },
   { value: "cmux-heatmap-1", label: "cmux-heatmap-1" },
-  { value: "anthropic", label: "Claude Opus 4.1" },
 ] as const;
 
 export type HeatmapModelOptionValue =
   (typeof HEATMAP_MODEL_OPTIONS)[number]["value"];
 
 export const DEFAULT_HEATMAP_MODEL: HeatmapModelOptionValue =
-  "anthropic-opus-4-5";
+  HEATMAP_MODEL_ANTHROPIC_HAIKU_45;
 
 export const TOOLTIP_LANGUAGE_OPTIONS = [
   { value: "en", label: "English" },
@@ -53,6 +56,12 @@ export const DEFAULT_TOOLTIP_LANGUAGE: TooltipLanguageValue = "en";
 export function normalizeHeatmapModel(
   value: string | null | undefined
 ): HeatmapModelOptionValue {
+  if (
+    value === LEGACY_HEATMAP_MODEL_ANTHROPIC_OPUS_45 ||
+    value === LEGACY_HEATMAP_MODEL_ANTHROPIC
+  ) {
+    return DEFAULT_HEATMAP_MODEL;
+  }
   const match = HEATMAP_MODEL_OPTIONS.find((option) => option.value === value);
   return match ? match.value : DEFAULT_HEATMAP_MODEL;
 }

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -19,6 +19,10 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useConvex } from "convex/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isElectron } from "@/lib/electron";
+import {
+  DEFAULT_HEATMAP_MODEL,
+  normalizeHeatmapModel,
+} from "@/lib/heatmap-settings";
 import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -302,9 +306,9 @@ function SettingsComponent() {
 
   // Heatmap settings state
   const [heatmapModel, setHeatmapModel] =
-    useState<string>("anthropic-opus-4-5");
+    useState<string>(DEFAULT_HEATMAP_MODEL);
   const [originalHeatmapModel, setOriginalHeatmapModel] =
-    useState<string>("anthropic-opus-4-5");
+    useState<string>(DEFAULT_HEATMAP_MODEL);
   const [heatmapThreshold, setHeatmapThreshold] = useState<number>(0);
   const [originalHeatmapThreshold, setOriginalHeatmapThreshold] =
     useState<number>(0);
@@ -320,8 +324,7 @@ function SettingsComponent() {
 
   // Heatmap model options from model-config.ts
   const HEATMAP_MODEL_OPTIONS = [
-    { value: "anthropic-opus-4-5", label: "Claude Opus 4.5" },
-    { value: "anthropic", label: "Claude Opus 4.1" },
+    { value: "anthropic-haiku-4-5", label: "Claude Haiku 4.5" },
     { value: "cmux-heatmap-2", label: "cmux-heatmap-2" },
     { value: "cmux-heatmap-1", label: "cmux-heatmap-1" },
   ];
@@ -439,13 +442,9 @@ function SettingsComponent() {
       prev === nextAutoPrEnabled ? prev : nextAutoPrEnabled
     );
 
-    if (workspaceSettings?.heatmapModel) {
-      const nextModel = workspaceSettings.heatmapModel;
-      setHeatmapModel((prev) => (prev === nextModel ? prev : nextModel));
-      setOriginalHeatmapModel((prev) =>
-        prev === nextModel ? prev : nextModel
-      );
-    }
+    const nextModel = normalizeHeatmapModel(workspaceSettings?.heatmapModel ?? null);
+    setHeatmapModel((prev) => (prev === nextModel ? prev : nextModel));
+    setOriginalHeatmapModel((prev) => (prev === nextModel ? prev : nextModel));
     if (workspaceSettings?.heatmapThreshold !== undefined) {
       const nextThreshold = workspaceSettings.heatmapThreshold;
       setHeatmapThreshold((prev) =>

--- a/apps/www/lib/routes/code-review.route.ts
+++ b/apps/www/lib/routes/code-review.route.ts
@@ -88,7 +88,7 @@ const StartBodySchema = z
       .optional(),
     /** Pre-fetched diffs from the client to avoid re-fetching from GitHub API */
     fileDiffs: z.array(FileDiffSchema).optional(),
-    /** Model selection for heatmap review (e.g., "anthropic-opus-4-5", "cmux-heatmap-2") */
+    /** Model selection for heatmap review (e.g., "anthropic-haiku-4-5", "cmux-heatmap-2") */
     heatmapModel: z.string().optional(),
     /** Language for tooltip text (e.g., "en", "zh-Hant", "ja") */
     tooltipLanguage: z.string().optional(),

--- a/apps/www/lib/services/code-review/model-config.ts
+++ b/apps/www/lib/services/code-review/model-config.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC_MODEL_OPUS_45 } from "@cmux/shared/utils/anthropic";
+import { ANTHROPIC_MODEL_HAIKU_45 } from "@cmux/shared/utils/anthropic";
 import type { ModelConfig } from "./run-simple-anthropic-review";
 
 type SearchParamsRecord = {
@@ -171,12 +171,14 @@ export function parseTooltipLanguageFromUrlSearchParams(
 export const HEATMAP_MODEL_FINETUNE_QUERY_VALUE = "finetune";
 export const HEATMAP_MODEL_DENSE_FINETUNE_QUERY_VALUE = "cmux-heatmap-1";
 export const HEATMAP_MODEL_DENSE_V2_FINETUNE_QUERY_VALUE = "cmux-heatmap-2";
+export const HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE = "anthropic-haiku-4-5";
 export const HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE = "anthropic-opus-4-5";
 export const HEATMAP_MODEL_ANTHROPIC_QUERY_VALUE = "anthropic";
 export type HeatmapModelQueryValue =
   | typeof HEATMAP_MODEL_FINETUNE_QUERY_VALUE
   | typeof HEATMAP_MODEL_DENSE_FINETUNE_QUERY_VALUE
   | typeof HEATMAP_MODEL_DENSE_V2_FINETUNE_QUERY_VALUE
+  | typeof HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE
   | typeof HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE
   | typeof HEATMAP_MODEL_ANTHROPIC_QUERY_VALUE;
 
@@ -213,31 +215,33 @@ function createFineTunedDenseV2OpenAiConfig(): ModelConfig {
   };
 }
 
-function createAnthropicOpus45Config(): ModelConfig {
+function createAnthropicHaiku45Config(): ModelConfig {
   return {
     provider: "anthropic",
-    model: ANTHROPIC_MODEL_OPUS_45,
+    model: ANTHROPIC_MODEL_HAIKU_45,
   };
 }
 
 export function getDefaultHeatmapModelConfig(): ModelConfig {
-  return createAnthropicOpus45Config();
+  return createAnthropicHaiku45Config();
 }
 
 export function getHeatmapModelConfigForSelection(
   selection: HeatmapModelQueryValue
 ): ModelConfig {
-  if (selection === HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE) {
-    return createAnthropicOpus45Config();
-  }
   if (selection === HEATMAP_MODEL_DENSE_V2_FINETUNE_QUERY_VALUE) {
     return createFineTunedDenseV2OpenAiConfig();
   }
-  if (selection === HEATMAP_MODEL_ANTHROPIC_QUERY_VALUE) {
-    return createAnthropicOpus45Config();
-  }
   if (selection === HEATMAP_MODEL_DENSE_FINETUNE_QUERY_VALUE) {
     return createFineTunedDenseOpenAiConfig();
+  }
+  // Keep legacy anthropic values supported, but always resolve to Haiku 4.5.
+  if (
+    selection === HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE ||
+    selection === HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE ||
+    selection === HEATMAP_MODEL_ANTHROPIC_QUERY_VALUE
+  ) {
+    return createAnthropicHaiku45Config();
   }
   return createFineTunedOpenAiConfig();
 }
@@ -246,17 +250,20 @@ export function normalizeHeatmapModelQueryValue(
   raw: string | null | undefined
 ): HeatmapModelQueryValue {
   if (typeof raw !== "string") {
-    return HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE;
+    return HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE;
   }
   const normalized = raw.trim().toLowerCase();
+  if (normalized === HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE) {
+    return HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE;
+  }
   if (normalized === HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE) {
-    return HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE;
+    return HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE;
   }
   if (normalized === HEATMAP_MODEL_DENSE_V2_FINETUNE_QUERY_VALUE) {
     return HEATMAP_MODEL_DENSE_V2_FINETUNE_QUERY_VALUE;
   }
   if (normalized === HEATMAP_MODEL_ANTHROPIC_QUERY_VALUE) {
-    return HEATMAP_MODEL_ANTHROPIC_QUERY_VALUE;
+    return HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE;
   }
   if (normalized === HEATMAP_MODEL_DENSE_FINETUNE_QUERY_VALUE) {
     return HEATMAP_MODEL_DENSE_FINETUNE_QUERY_VALUE;
@@ -264,7 +271,7 @@ export function normalizeHeatmapModelQueryValue(
   if (normalized === HEATMAP_MODEL_FINETUNE_QUERY_VALUE) {
     return HEATMAP_MODEL_FINETUNE_QUERY_VALUE;
   }
-  return HEATMAP_MODEL_ANTHROPIC_OPUS_45_QUERY_VALUE;
+  return HEATMAP_MODEL_ANTHROPIC_HAIKU_45_QUERY_VALUE;
 }
 
 function extractRecordValue(

--- a/apps/www/lib/services/code-review/run-heatmap-review.ts
+++ b/apps/www/lib/services/code-review/run-heatmap-review.ts
@@ -70,7 +70,7 @@ export async function runHeatmapReview(
     prUrl: config.prUrl,
   });
 
-  // Determine the effective model configuration (defaults to Anthropic Opus 4.5)
+  // Determine the effective model configuration (defaults to Anthropic Haiku 4.5)
   const effectiveModelConfig: ModelConfig =
     config.modelConfig ?? getDefaultHeatmapModelConfig();
 

--- a/apps/www/lib/services/code-review/start-code-review.ts
+++ b/apps/www/lib/services/code-review/start-code-review.ts
@@ -36,7 +36,7 @@ type StartCodeReviewPayload = {
   modelConfig?: ModelConfig;
   /** Pre-fetched diffs from the client to avoid re-fetching from GitHub API */
   fileDiffs?: FileDiff[];
-  /** Model selection for heatmap review (e.g., "anthropic-opus-4-5", "cmux-heatmap-2") */
+  /** Model selection for heatmap review (e.g., "anthropic-haiku-4-5", "cmux-heatmap-2") */
   heatmapModel?: string;
   /** Language for tooltip text (e.g., "en", "zh-Hant", "ja") */
   tooltipLanguage?: string;

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -607,7 +607,7 @@ const convexSchema = defineSchema({
     autoSyncEnabled: v.optional(v.boolean()), // Auto-sync local workspace to cloud (default: true)
     nextLocalWorkspaceSequence: v.optional(v.number()), // Counter for local workspace naming
     // Heatmap review settings
-    heatmapModel: v.optional(v.string()), // Model to use for heatmap review (e.g., "anthropic-opus-4-5", "cmux-heatmap-2")
+    heatmapModel: v.optional(v.string()), // Model to use for heatmap review (e.g., "anthropic-haiku-4-5", "cmux-heatmap-2")
     heatmapThreshold: v.optional(v.number()), // Score threshold for filtering (0-1, default: 0)
     heatmapTooltipLanguage: v.optional(v.string()), // Language for tooltip text (e.g., "en", "zh-Hant", "ja")
     heatmapColors: v.optional(


### PR DESCRIPTION
we have ancan we make sure 0github.com is not using claude code 4.5 and 4.1 ... instead swap them to use the claude haiku 4.5 model as default. same thing for the heatmaps in the git diff viewers in the cmux app as wel