### PR TITLE
Switch preview.new model from Opus 4.5 to Sonnet 4.6

### DIFF
--- a/packages/convex/convex/bedrock_utils.ts
+++ b/packages/convex/convex/bedrock_utils.ts
@@ -35,6 +35,7 @@ export const BEDROCK_INFERENCE_PROFILE: "us" | "global" = "us";
 const BASE_MODELS = {
   // Claude 4.6 models
   "opus-4-6": "anthropic.claude-opus-4-6-v1",
+  "sonnet-4-6": "anthropic.claude-sonnet-4-6",
   // Claude 4.5 models
   "sonnet-4-5": "anthropic.claude-sonnet-4-5-20250929-v1:0",
   "opus-4-5": "anthropic.claude-opus-4-5-20251101-v1:0",
@@ -67,6 +68,9 @@ export const MODEL_MAP: Record<string, string> = {
   // Opus 4.6 variants
   "claude-opus-4-6": withPrefix(BASE_MODELS["opus-4-6"]),
   "claude-4-6-opus": withPrefix(BASE_MODELS["opus-4-6"]),
+  // Sonnet 4.6 variants
+  "claude-sonnet-4-6": withPrefix(BASE_MODELS["sonnet-4-6"]),
+  "claude-4-6-sonnet": withPrefix(BASE_MODELS["sonnet-4-6"]),
   // Sonnet 4.5 variants
   "claude-sonnet-4-5-20250929": withPrefix(BASE_MODELS["sonnet-4-5"]),
   "claude-sonnet-4-5": withPrefix(BASE_MODELS["sonnet-4-5"]),

--- a/packages/host-screenshot-collector/src/index.ts
+++ b/packages/host-screenshot-collector/src/index.ts
@@ -1332,7 +1332,7 @@ After capturing screenshots/videos, briefly state what you captured and leave th
       for await (const message of query({
         prompt,
         options: {
-          model: "claude-opus-4-5-20251101",
+          model: "claude-sonnet-4-6",
           mcpServers: {
             chrome: {
               command: "bunx",


### PR DESCRIPTION
## Summary
- Change preview.new screenshot collector model from `claude-opus-4-5-20251101` to `claude-sonnet-4-6`
- Add Sonnet 4.6 Bedrock model mapping (`claude-sonnet-4-6`, `claude-4-6-sonnet`) to bedrock_utils

## Test plan
- [ ] Verify preview.new test job runs successfully with Sonnet 4.6
- [ ] Confirm Bedrock proxy resolves `claude-sonnet-4-6` correctly