### PR TITLE
Redirect www.cmux.sh to manaflow.com (307)

### DIFF
--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -1,8 +1,9 @@
 {
-  "rewrites": [
+  "redirects": [
     {
       "source": "/(.*)",
-      "destination": "/index.html"
+      "destination": "https://manaflow.com",
+      "statusCode": 307
     }
   ],
   "relatedProjects": ["prj_2WNSLqIZWRGIIRMQLQrDom5DhivV"]


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/manaflow/pull/1779. The cmux-client Vercel project serves www.cmux.sh and wasn't covered by the proxy.ts deprecation guard (which only affects cmux-www).

Replaces the SPA rewrite with a 307 temporary redirect to manaflow.com.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect all www.cmux.sh traffic to https://manaflow.com with a 307 Temporary Redirect, replacing the SPA rewrite. Ensures the cmux-client Vercel project follows the deprecation redirect already applied to cmux-www.

- **Migration**
  - To revert, change `redirects` back to `rewrites` with destination `/index.html`.

<sup>Written for commit d779cdbf21f92589a3e999ccb3293c4215ca0327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment routing configuration to redirect application traffic to an external URL using HTTP 307 temporary redirects, replacing the previous internal routing rewrite strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->