### PR TITLE
Make /manaflow cmux link underline on hover only

### DIFF
--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -31,7 +31,7 @@ export default function ManaflowPage() {
           <a
             href="https://cmux.com"
             target="_blank"
-            className="text-sm text-black underline hover:text-neutral-600 sm:text-base"
+            className="text-sm text-black hover:text-neutral-600 hover:underline sm:text-base"
           >
             cmux
           </a>


### PR DESCRIPTION
## Summary
- remove default underline from the `cmux` link on `/manaflow`
- keep underline on hover for the `cmux` link

## Testing
- `bun check` *(fails in this environment: Bun panic in `scripts/watch-openapi.ts`, missing `@eslint/js`, and npm 404 on `tsgo`)*

## Issues
- Related: manaflow.com `/manaflow` cmux link hover-only underline request


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `cmux` link on /manaflow underline only on hover instead of always. Aligns with the request for hover-only underline behavior.

<sup>Written for commit 5325326f5eb11e0d1cef7da3d826d377a5ff374c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated external link styling to display underline only on hover rather than always visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->