### PR TITLE
Fix Manaflow landing image layout shift

### DIFF
--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -49,7 +49,11 @@ export default function ManaflowPage() {
         <img
           src="/cmux-screenshot.webp"
           alt="cmux — the terminal built for coding agents"
-          className="mt-3 w-full rounded-lg -ml-[11px] sm:-ml-4"
+          width={3840}
+          height={2224}
+          decoding="async"
+          fetchPriority="high"
+          className="mt-3 h-auto w-full rounded-lg -ml-[11px] sm:-ml-4"
         />
 
         <div className="mt-5 flex gap-3 text-xs sm:mt-6 sm:gap-4 sm:text-sm">


### PR DESCRIPTION
## Summary
- Add intrinsic dimensions to the Manaflow landing page cmux screenshot
- Keep the image responsive while reserving its aspect-ratio box before decode

## Checks
- bun run typecheck:www
- bun --env-file /Users/lawrence/fun/manaflow/.env check
- Chrome delayed-image check: CLS 0, marker top delta 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784534483&installation_id=133855650&pr_number=1857&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1857&signature=f7c76899938928d2a55429975ba28290a59157cd03f028c16633e5dacacc92e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the image layout shift on the Manaflow landing page by adding intrinsic dimensions and keeping the screenshot responsive. This reserves space before decode and eliminates CLS.

- **Bug Fixes**
  - Set width 3840 and height 2224 to reserve aspect ratio.
  - Added decoding="async" and fetchPriority="high" to improve load behavior.
  - Applied h-auto w-full to maintain responsive aspect ratio.
  - Verified CLS is 0 in delayed-image testing.

<sup>Written for commit bc92120810fadb82c39dcb76127b852b2f9b3f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized hero image loading with explicit sizing and enhanced rendering attributes for improved page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->