### PR TITLE
Fade in Manaflow landing screenshot

### DIFF
--- a/apps/www/app/manaflow/fade-in-image.tsx
+++ b/apps/www/app/manaflow/fade-in-image.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  useCallback,
+  useState,
+  type ImgHTMLAttributes,
+  type SyntheticEvent,
+} from "react";
+
+type FadeInImageProps = ImgHTMLAttributes<HTMLImageElement>;
+
+export function FadeInImage({
+  className,
+  onLoad,
+  ...props
+}: FadeInImageProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  const imageRef = useCallback((node: HTMLImageElement | null) => {
+    if (node?.complete && node.naturalWidth > 0) {
+      setLoaded(true);
+    }
+  }, []);
+
+  const handleLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    setLoaded(true);
+    onLoad?.(event);
+  };
+
+  return (
+    <img
+      {...props}
+      ref={imageRef}
+      onLoad={handleLoad}
+      className={clsx(
+        className,
+        "transition-opacity duration-500 ease-out motion-reduce:transition-none",
+        loaded ? "opacity-100" : "opacity-[0.01]"
+      )}
+    />
+  );
+}

--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+import { FadeInImage } from "./fade-in-image";
+
 export const metadata: Metadata = {
   title: "Manaflow - Open Source Applied AI Lab",
   description:
@@ -46,7 +48,7 @@ export default function ManaflowPage() {
         <p className="mt-1 text-xs text-neutral-600 sm:text-sm">
           The open source terminal built for coding agents.
         </p>
-        <img
+        <FadeInImage
           src="/cmux-screenshot.webp"
           alt="cmux — the terminal built for coding agents"
           width={3840}


### PR DESCRIPTION
## Summary
- Add a small client wrapper for the Manaflow landing screenshot
- Fade the screenshot from transparent to opaque when the image loads
- Preserve intrinsic width/height so the previous CLS fix remains intact

## Checks
- bun run typecheck:www
- bun --env-file /Users/lawrence/fun/manaflow/.env check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784780312&installation_id=133855650&pr_number=1861&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1861&signature=232fb51f3cac6b67350db7b344221967406c0c489632e6d0ab2ea8f4b504b872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fade in the Manaflow landing screenshot on load using a lightweight client image component, improving perceived load while keeping layout stable.

- **New Features**
  - Added `FadeInImage` with a 500ms opacity transition and reduced-motion fallback.
  - Handles cached images via `complete`/`naturalWidth` to avoid a flash.
  - Replaced the hero image on `/manaflow` and kept explicit width/height to prevent CLS.

<sup>Written for commit 64f86f18ae28f21d42df14b8548ee13b7a38e26a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable `FadeInImage` component that fades images in once they finish loading for a smoother visual experience.
  * Automatically handles images that are already loaded and respects reduced-motion preferences by disabling the fade transition.
  * Updated the manaflow page screenshot to use `FadeInImage` while preserving the existing image sizing, loading, and layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->