### PR TITLE
Fix active Electron, web, and Convex Sentry errors

### DIFF
--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -58,6 +58,7 @@ import {
 } from "./stack-auth-cookies";
 import { computeSetAsDefaultProtocolClientCall } from "./protocol-registration";
 import { getMobileMachineInfo } from "./mobile-machine-info";
+import { isProtocolWindowUsable } from "./protocol-window-lifecycle";
 
 // Use a cookieable HTTPS origin intercepted locally instead of a custom scheme.
 const PARTITION = "persist:manaflow";
@@ -91,13 +92,17 @@ const LOG_ROTATION: LogRotationOptions = {
   maxBackups: 3,
 };
 
-
 let rendererLoaded = false;
 let pendingProtocolUrl: string | null = null;
 let mainWindow: BrowserWindow | null = null;
 let previewReloadMenuItem: MenuItem | null = null;
 let previewBackMenuItem: MenuItem | null = null;
 let previewForwardMenuItem: MenuItem | null = null;
+
+function getUsableMainWindow(): BrowserWindow | null {
+  const window = mainWindow;
+  return isProtocolWindowUsable(window) ? window : null;
+}
 let previewFocusAddressMenuItem: MenuItem | null = null;
 let previewReloadMenuVisible = false;
 let historyBackMenuItem: MenuItem | null = null;
@@ -125,20 +130,20 @@ function writeMainLogLine(level: "LOG" | "WARN" | "ERROR", line: string): void {
   appendLogWithRotation(
     mainLogPath,
     `[${getTimestamp()}] [MAIN] [${level}] ${line}\n`,
-    LOG_ROTATION
+    LOG_ROTATION,
   );
 }
 
 function writeRendererLogLine(
   level: "info" | "warning" | "error" | "debug",
-  line: string
+  line: string,
 ): void {
   if (!rendererLogPath) ensureLogFiles();
   if (!rendererLogPath) return;
   appendLogWithRotation(
     rendererLogPath,
     `[${getTimestamp()}] [RENDERER] [${level.toUpperCase()}] ${line}\n`,
-    LOG_ROTATION
+    LOG_ROTATION,
   );
 }
 
@@ -242,7 +247,7 @@ function setupPreviewProxyCertificateTrust(): void {
   // Actually, let's just do it here and hope it works for new requests, or move it out.
   // Documentation says "This switch must be set before the app is ready".
   // So we should call a separate function for it.
-  
+
   app.on(
     "certificate-error",
     (event, _webContents, url, error, certificate, callback) => {
@@ -257,7 +262,7 @@ function setupPreviewProxyCertificateTrust(): void {
       } else {
         callback(false);
       }
-    }
+    },
   );
 }
 
@@ -265,7 +270,10 @@ function setupSpkiWhitelist() {
   try {
     const certManager = new CertificateManager();
     const fingerprint = certManager.getCaSpkiFingerprint();
-    app.commandLine.appendSwitch("ignore-certificate-errors-spki-list", fingerprint);
+    app.commandLine.appendSwitch(
+      "ignore-certificate-errors-spki-list",
+      fingerprint,
+    );
     console.log("[MAIN] Added SPKI whitelist for proxy CA:", fingerprint);
   } catch (error) {
     console.error("[MAIN] Failed to setup SPKI whitelist", error);
@@ -298,7 +306,7 @@ function formatArgs(args: unknown[]): string {
   const ts = new Date().toISOString();
   const body = args
     .map((a) =>
-      typeof a === "string" ? a : util.inspect(a, { depth: 3, colors: false })
+      typeof a === "string" ? a : util.inspect(a, { depth: 3, colors: false }),
     )
     .join(" ");
   return `[${ts}] ${body}`;
@@ -327,7 +335,7 @@ export function mainError(...args: unknown[]) {
 
 function sendShortcutToFocusedWindow(
   eventName: string,
-  payload?: unknown
+  payload?: unknown,
 ): boolean {
   try {
     const target = getActiveBrowserWindow();
@@ -364,7 +372,7 @@ ipcMain.handle(
   async (_event, visible: unknown) => {
     setPreviewReloadMenuVisibility(Boolean(visible));
     return { ok: true };
-  }
+  },
 );
 
 function emitAutoUpdateToastIfPossible(): void {
@@ -373,7 +381,7 @@ function emitAutoUpdateToastIfPossible(): void {
   try {
     mainWindow.webContents.send(
       "cmux:event:auto-update:ready",
-      queuedAutoUpdateToast
+      queuedAutoUpdateToast,
     );
     queuedAutoUpdateToast = null;
   } catch (error) {
@@ -395,7 +403,7 @@ function resolveSemverVersion(value: string | null | undefined): string | null {
 }
 
 function isUpdateNewerThanCurrent(
-  info: UpdateInfo | null | undefined
+  info: UpdateInfo | null | undefined,
 ): boolean {
   if (!info) return false;
 
@@ -433,7 +441,7 @@ function isUpdateNewerThanCurrent(
 
 function logUpdateCheckResult(
   context: string,
-  result: UpdateCheckResult | null | undefined
+  result: UpdateCheckResult | null | undefined,
 ): void {
   if (!result) {
     mainLog(`${context} completed`, { updateAvailable: false });
@@ -483,7 +491,7 @@ function registerAutoUpdateIpcHandlers(): void {
   ipcMain.handle("cmux:auto-update:check", async () => {
     if (!app.isPackaged) {
       mainLog(
-        "Auto-update check requested while app is not packaged; ignoring request"
+        "Auto-update check requested while app is not packaged; ignoring request",
       );
       return { ok: false, reason: "not-packaged" as const };
     }
@@ -514,7 +522,7 @@ function registerAutoUpdateIpcHandlers(): void {
   ipcMain.handle("cmux:auto-update:install", async () => {
     if (!app.isPackaged) {
       mainLog(
-        "Auto-update install requested while app is not packaged; ignoring request"
+        "Auto-update install requested while app is not packaged; ignoring request",
       );
       return { ok: false, reason: "not-packaged" as const };
     }
@@ -569,7 +577,6 @@ function registerAppIpcHandlers(): void {
   });
 }
 
-
 function setupAutoUpdates(): void {
   if (!app.isPackaged) {
     mainLog("Skipping auto-updates in development");
@@ -618,15 +625,15 @@ function setupAutoUpdates(): void {
 
   autoUpdater.on("checking-for-update", () => mainLog("Checking for update…"));
   autoUpdater.on("update-available", (info) =>
-    mainLog("Update available", info?.version)
+    mainLog("Update available", info?.version),
   );
   autoUpdater.on("update-not-available", () => mainLog("No updates available"));
   autoUpdater.on("error", (err) => mainWarn("Updater error", err));
   autoUpdater.on("download-progress", (p) =>
     mainLog(
       "Update download progress",
-      `${p.percent?.toFixed?.(1) ?? 0}% (${p.transferred}/${p.total})`
-    )
+      `${p.percent?.toFixed?.(1) ?? 0}% (${p.transferred}/${p.total})`,
+    ),
   );
   autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
     const version =
@@ -643,7 +650,7 @@ function setupAutoUpdates(): void {
         {
           version,
           currentVersion: app.getVersion(),
-        }
+        },
       );
       return;
     }
@@ -657,7 +664,7 @@ function setupAutoUpdates(): void {
   autoUpdater
     .checkForUpdatesAndNotify()
     .then((result) =>
-      logUpdateCheckResult("Initial checkForUpdatesAndNotify", result)
+      logUpdateCheckResult("Initial checkForUpdatesAndNotify", result),
     )
     .catch((e) => mainWarn("checkForUpdatesAndNotify failed", e));
   const CHECK_INTERVAL_MS = 30 * 60 * 1000;
@@ -667,14 +674,14 @@ function setupAutoUpdates(): void {
     autoUpdater
       .checkForUpdates()
       .then((result) =>
-        logUpdateCheckResult("Scheduled checkForUpdates", result)
+        logUpdateCheckResult("Scheduled checkForUpdates", result),
       )
       .catch((e) => mainWarn("Periodic checkForUpdates failed", e));
   }, CHECK_INTERVAL_MS); // 30 minutes
 }
 
 async function handleOrQueueProtocolUrl(url: string) {
-  if (mainWindow && rendererLoaded) {
+  if (getUsableMainWindow() && rendererLoaded) {
     mainLog("Handling protocol URL immediately", { url });
     await handleProtocolUrl(url);
   } else {
@@ -703,13 +710,21 @@ function createWindow(): void {
 
   // Use only the icon from manaflow-logos iconset.
   const iconPng = resolveResourcePath(
-    "manaflow-logos/manaflow.iconset/icon_512x512.png"
+    "manaflow-logos/manaflow.iconset/icon_512x512.png",
   );
   if (process.platform !== "darwin") {
     windowOptions.icon = iconPng;
   }
 
-  mainWindow = new BrowserWindow(windowOptions);
+  rendererLoaded = false;
+  const createdWindow = new BrowserWindow(windowOptions);
+  mainWindow = createdWindow;
+  createdWindow.on("closed", () => {
+    if (mainWindow === createdWindow) {
+      mainWindow = null;
+      rendererLoaded = false;
+    }
+  });
 
   // Capture renderer console output into renderer.log
   mainWindow.webContents.on(
@@ -720,7 +735,7 @@ function createWindow(): void {
         : "";
       const msg = src ? `${message} (${src})` : message;
       writeRendererLogLine(level, msg);
-    }
+    },
   );
 
   mainWindow.on("ready-to-show", () => {
@@ -754,7 +769,7 @@ function createWindow(): void {
       validatedURL,
       isMainFrame,
       frameProcessId,
-      frameRoutingId
+      frameRoutingId,
     ) => {
       mainWarn("did-fail-load", {
         errorCode,
@@ -764,7 +779,7 @@ function createWindow(): void {
         frameProcessId,
         frameRoutingId,
       });
-    }
+    },
   );
 
   mainWindow.webContents.on("did-navigate", (_e, url) => {
@@ -805,7 +820,7 @@ app.on("browser-window-focus", (_event, window) => {
       { windowId: window.id };
     window.webContents.send(
       `cmux:event:${ELECTRON_WINDOW_FOCUS_EVENT}`,
-      payload
+      payload,
     );
   } catch (error) {
     mainWarn("Failed to emit window focus event to renderer", error);
@@ -1021,7 +1036,7 @@ app.whenReady().then(async () => {
   // Set Dock icon from iconset on macOS.
   if (process.platform === "darwin") {
     const iconPng = resolveResourcePath(
-      "manaflow-logos/manaflow.iconset/icon_512x512.png"
+      "manaflow-logos/manaflow.iconset/icon_512x512.png",
     );
     const img = nativeImage.createFromPath(iconPng);
     if (!img.isEmpty()) app.dock?.setIcon(img);
@@ -1047,9 +1062,10 @@ app.whenReady().then(async () => {
       return net.fetch(request);
     }
 
-    const pathname = url.pathname === "/" ? "/index-electron.html" : url.pathname;
+    const pathname =
+      url.pathname === "/" ? "/index-electron.html" : url.pathname;
     const fsPath = path.normalize(
-      path.join(baseDir, decodeURIComponent(pathname))
+      path.join(baseDir, decodeURIComponent(pathname)),
     );
     const rel = path.relative(baseDir, fsPath);
     if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
@@ -1092,7 +1108,7 @@ app.whenReady().then(async () => {
             const dispatched = sendShortcutToFocusedWindow("preview-reload");
             if (!dispatched) {
               mainWarn(
-                "Reload Preview shortcut triggered with no active renderer"
+                "Reload Preview shortcut triggered with no active renderer",
               );
             }
           },
@@ -1190,7 +1206,7 @@ app.whenReady().then(async () => {
         ],
       },
       viewMenu,
-      { role: "windowMenu" }
+      { role: "windowMenu" },
     );
     template.push({
       role: "help",
@@ -1276,7 +1292,7 @@ function jwksForIssuer(issuer: string) {
 }
 
 async function verifyJwtAndGetPayload(
-  token: string
+  token: string,
 ): Promise<JWTPayload | null> {
   try {
     const decoded = decodeJwt(token);
@@ -1292,7 +1308,7 @@ async function verifyJwtAndGetPayload(
 }
 
 async function handleProtocolUrl(url: string): Promise<void> {
-  if (!mainWindow) {
+  if (!getUsableMainWindow()) {
     // Should not happen due to queuing, but guard anyway
     mainWarn("handleProtocolUrl called with no window; queueing", { url });
     pendingProtocolUrl = url;
@@ -1321,19 +1337,24 @@ async function handleProtocolUrl(url: string): Promise<void> {
     // may be a JSON array string (`["refresh","access"]`) so skip verification.
     const refreshPayload = await verifyJwtAndGetPayload(stackRefresh);
     if (!refreshPayload) {
-      mainWarn("JWT verification failed - refresh token may be opaque/malformed", {
-        refreshLength: stackRefresh.length,
-      });
+      mainWarn(
+        "JWT verification failed - refresh token may be opaque/malformed",
+        {
+          refreshLength: stackRefresh.length,
+        },
+      );
     }
 
     // Stack Auth SDK expects structured refresh cookies and a paired access cookie
     // value. Using these formats avoids refresh-token rotation issues on Electron.
-    const win = mainWindow;
+    const win = getUsableMainWindow();
     if (!win) {
-      mainWarn("Aborting cookie set due to missing window");
+      mainWarn("Deferring cookie set until a live window is available");
+      pendingProtocolUrl = url;
       return;
     }
     const currentUrl = new URL(win.webContents.getURL());
+    const cookieSession = win.webContents.session;
     const cookieOrigin = `${currentUrl.origin}/`;
     const cookieHost = currentUrl.hostname;
     const isSecure = currentUrl.protocol === "https:";
@@ -1348,7 +1369,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
     // migrates away from legacy cookie paths (e.g. /index-electron.html) that
     // can prevent Stack Auth from deleting rotated refresh tokens.
     try {
-      const allCookies = await win.webContents.session.cookies.get({});
+      const allCookies = await cookieSession.cookies.get({});
       const relevantCookies = allCookies.filter((cookie) => {
         if (!cookie.domain) return false;
         const domain = cookie.domain?.startsWith(".")
@@ -1379,7 +1400,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
             : currentUrl.protocol.replace(":", "");
           const removalUrl = `${scheme}://${domain}${cookie.path}`;
           try {
-            await win.webContents.session.cookies.remove(removalUrl, cookie.name);
+            await cookieSession.cookies.remove(removalUrl, cookie.name);
           } catch (removeError) {
             // Best-effort cleanup; don't block login.
             mainWarn("Failed to remove cookie", {
@@ -1388,7 +1409,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
               error: removeError,
             });
           }
-        })
+        }),
       );
     } catch (clearError) {
       mainWarn("Failed to enumerate/clear Stack Auth cookies", clearError);
@@ -1406,7 +1427,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
     const nowSeconds = Math.floor(Date.now() / 1000);
     try {
       await Promise.all([
-        win.webContents.session.cookies.set({
+        cookieSession.cookies.set({
           url: cookieOrigin,
           name: cookieSpecs.refresh.name,
           value: cookieSpecs.refresh.value,
@@ -1416,7 +1437,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
           httpOnly: cookieSpecs.refresh.httpOnly,
           path: cookieSpecs.refresh.path,
         }),
-        win.webContents.session.cookies.set({
+        cookieSession.cookies.set({
           url: cookieOrigin,
           name: cookieSpecs.access.name,
           value: cookieSpecs.access.value,
@@ -1426,7 +1447,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
           httpOnly: cookieSpecs.access.httpOnly,
           path: cookieSpecs.access.path,
         }),
-        win.webContents.session.cookies.set({
+        cookieSession.cookies.set({
           url: cookieOrigin,
           name: cookieSpecs.isHttps.name,
           value: cookieSpecs.isHttps.value,
@@ -1444,7 +1465,7 @@ async function handleProtocolUrl(url: string): Promise<void> {
     }
 
     mainLog("Reloading renderer to apply auth cookies");
-    win.webContents.reload();
+    getUsableMainWindow()?.webContents.reload();
     return;
   }
 
@@ -1454,12 +1475,20 @@ async function handleProtocolUrl(url: string): Promise<void> {
         team: urlObj.searchParams.get("team"),
       });
       // Bring app to front and refresh to pick up new connections
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.show();
-      mainWindow.focus();
+      const win = getUsableMainWindow();
+      if (!win) {
+        mainWarn(
+          "Deferring GitHub completion until a live window is available",
+        );
+        pendingProtocolUrl = url;
+        return;
+      }
+      if (win.isMinimized()) win.restore();
+      win.show();
+      win.focus();
       const team = urlObj.searchParams.get("team");
       try {
-        mainWindow.webContents.send("cmux:event:github-connect-complete", {
+        win.webContents.send("cmux:event:github-connect-complete", {
           team,
         });
       } catch (emitErr) {

--- a/apps/client/electron/main/protocol-window-lifecycle.test.ts
+++ b/apps/client/electron/main/protocol-window-lifecycle.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isProtocolWindowUsable } from "./protocol-window-lifecycle";
+
+describe("isProtocolWindowUsable", () => {
+  it("rejects a destroyed browser window before reading its web contents", () => {
+    let webContentsRead = false;
+    const window = {
+      isDestroyed: () => true,
+      get webContents() {
+        webContentsRead = true;
+        return { isDestroyed: () => false };
+      },
+    };
+
+    expect(isProtocolWindowUsable(window)).toBe(false);
+    expect(webContentsRead).toBe(false);
+  });
+
+  it("rejects destroyed web contents", () => {
+    const window = {
+      isDestroyed: () => false,
+      webContents: { isDestroyed: () => true },
+    };
+
+    expect(isProtocolWindowUsable(window)).toBe(false);
+  });
+
+  it("accepts a live window with live web contents", () => {
+    const window = {
+      isDestroyed: () => false,
+      webContents: { isDestroyed: () => false },
+    };
+
+    expect(isProtocolWindowUsable(window)).toBe(true);
+  });
+});

--- a/apps/client/electron/main/protocol-window-lifecycle.ts
+++ b/apps/client/electron/main/protocol-window-lifecycle.ts
@@ -1,0 +1,15 @@
+export type ProtocolWindowLike = {
+  isDestroyed: () => boolean;
+  readonly webContents: {
+    isDestroyed: () => boolean;
+  };
+};
+
+export function isProtocolWindowUsable<T extends ProtocolWindowLike>(
+  window: T | null,
+): window is T {
+  if (!window || window.isDestroyed()) {
+    return false;
+  }
+  return !window.webContents.isDestroyed();
+}

--- a/apps/client/src/components/theme/theme-provider.tsx
+++ b/apps/client/src/components/theme/theme-provider.tsx
@@ -5,11 +5,13 @@ import {
   type ResolvedTheme,
   ThemeProviderContext,
 } from "./theme-context";
+import {
+  settleThemeViewTransition,
+  shouldStartThemeViewTransition,
+} from "./theme-transition";
 
 type DocumentWithStartViewTransition = Document & {
-  startViewTransition?: (
-    callback: () => void
-  ) => ViewTransition;
+  startViewTransition?: (callback: () => void) => ViewTransition;
 };
 
 type ThemeProviderProps = {
@@ -22,9 +24,7 @@ const getInitialResolvedTheme = (): ResolvedTheme => {
   if (typeof document === "undefined") {
     return "light";
   }
-  return document.documentElement.classList.contains("dark")
-    ? "dark"
-    : "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
 };
 
 export function ThemeProvider({
@@ -34,11 +34,11 @@ export function ThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
   );
   const resolvedThemeRef = useRef<ResolvedTheme>(getInitialResolvedTheme());
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(
-    resolvedThemeRef.current
+    resolvedThemeRef.current,
   );
   const isInitialRenderRef = useRef(true);
 
@@ -46,14 +46,15 @@ export function ThemeProvider({
     const root = window.document.documentElement;
 
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const computeSystem = (): ResolvedTheme => (mediaQuery.matches ? "dark" : "light");
-    const prefersReducedMotion = window
-      .matchMedia("(prefers-reduced-motion: reduce)")
-      .matches;
+    const computeSystem = (): ResolvedTheme =>
+      mediaQuery.matches ? "dark" : "light";
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
 
     const applyTheme = (
       next: ResolvedTheme,
-      { withTransition }: { withTransition: boolean }
+      { withTransition }: { withTransition: boolean },
     ) => {
       const updateTheme = () => {
         root.classList.remove("light", "dark");
@@ -65,21 +66,31 @@ export function ThemeProvider({
         }
       };
 
-      const documentWithTransition = document as DocumentWithStartViewTransition;
-      const startViewTransition = documentWithTransition.startViewTransition?.bind(
-        documentWithTransition
-      );
-      const shouldAnimate =
-        withTransition &&
-        !prefersReducedMotion &&
-        typeof startViewTransition === "function";
+      const documentWithTransition =
+        document as DocumentWithStartViewTransition;
+      const startViewTransition =
+        documentWithTransition.startViewTransition?.bind(
+          documentWithTransition,
+        );
+      const shouldAnimate = shouldStartThemeViewTransition({
+        withTransition,
+        prefersReducedMotion,
+        visibilityState: document.visibilityState,
+        hasViewTransitionAPI: typeof startViewTransition === "function",
+      });
 
-      if (shouldAnimate) {
-        startViewTransition(() => {
-          flushSync(() => {
-            updateTheme();
+      if (shouldAnimate && startViewTransition) {
+        try {
+          const transition = startViewTransition(() => {
+            flushSync(() => {
+              updateTheme();
+            });
           });
-        });
+          void settleThemeViewTransition(transition);
+        } catch (error) {
+          console.error("Failed to start theme view transition", error);
+          updateTheme();
+        }
         return;
       }
 

--- a/apps/client/src/components/theme/theme-transition.test.ts
+++ b/apps/client/src/components/theme/theme-transition.test.ts
@@ -13,13 +13,16 @@ describe("theme view transitions", () => {
         prefersReducedMotion: false,
         visibilityState: "hidden",
         hasViewTransitionAPI: true,
-      })
+      }),
     ).toBe(false);
   });
 
   it("observes rejected transition promises without rethrowing", async () => {
     const rejected = Promise.reject(
-      new DOMException("Transition was aborted because of invalid state", "InvalidStateError")
+      new DOMException(
+        "Transition was aborted because of invalid state",
+        "InvalidStateError",
+      ),
     );
 
     await expect(
@@ -27,7 +30,7 @@ describe("theme view transitions", () => {
         ready: rejected,
         updateCallbackDone: Promise.resolve(),
         finished: Promise.resolve(),
-      })
+      }),
     ).resolves.toBeUndefined();
   });
 });

--- a/apps/client/src/components/theme/theme-transition.test.ts
+++ b/apps/client/src/components/theme/theme-transition.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  settleThemeViewTransition,
+  shouldStartThemeViewTransition,
+} from "./theme-transition";
+
+describe("theme view transitions", () => {
+  it("does not start a transition while the document is hidden", () => {
+    expect(
+      shouldStartThemeViewTransition({
+        withTransition: true,
+        prefersReducedMotion: false,
+        visibilityState: "hidden",
+        hasViewTransitionAPI: true,
+      })
+    ).toBe(false);
+  });
+
+  it("observes rejected transition promises without rethrowing", async () => {
+    const rejected = Promise.reject(
+      new DOMException("Transition was aborted because of invalid state", "InvalidStateError")
+    );
+
+    await expect(
+      settleThemeViewTransition({
+        ready: rejected,
+        updateCallbackDone: Promise.resolve(),
+        finished: Promise.resolve(),
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/client/src/components/theme/theme-transition.ts
+++ b/apps/client/src/components/theme/theme-transition.ts
@@ -1,0 +1,40 @@
+type ThemeViewTransition = Pick<
+  ViewTransition,
+  "ready" | "updateCallbackDone" | "finished"
+>;
+
+type ThemeViewTransitionPolicy = {
+  withTransition: boolean;
+  prefersReducedMotion: boolean;
+  visibilityState: DocumentVisibilityState;
+  hasViewTransitionAPI: boolean;
+};
+
+export function shouldStartThemeViewTransition({
+  withTransition,
+  prefersReducedMotion,
+  visibilityState,
+  hasViewTransitionAPI,
+}: ThemeViewTransitionPolicy): boolean {
+  return (
+    withTransition &&
+    !prefersReducedMotion &&
+    visibilityState === "visible" &&
+    hasViewTransitionAPI
+  );
+}
+
+export async function settleThemeViewTransition(
+  transition: ThemeViewTransition,
+): Promise<void> {
+  const results = await Promise.allSettled([
+    transition.ready,
+    transition.updateCallbackDone,
+    transition.finished,
+  ]);
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.error("Theme view transition failed", result.reason);
+    }
+  }
+}

--- a/packages/convex/convex/containerSettings.test.ts
+++ b/packages/convex/convex/containerSettings.test.ts
@@ -9,7 +9,7 @@ describe("buildContainerSettingsUpdatePayload", () => {
         teamSlugOrId: "team-slug",
         maxRunningContainers: 7,
         autoCleanupEnabled: false,
-      })
+      }),
     ).toEqual({
       maxRunningContainers: 7,
       autoCleanupEnabled: false,

--- a/packages/convex/convex/containerSettings.test.ts
+++ b/packages/convex/convex/containerSettings.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContainerSettingsUpdatePayload } from "./containerSettings";
+
+describe("buildContainerSettingsUpdatePayload", () => {
+  it("excludes the routing-only team slug from persisted settings", () => {
+    expect(
+      buildContainerSettingsUpdatePayload({
+        teamSlugOrId: "team-slug",
+        maxRunningContainers: 7,
+        autoCleanupEnabled: false,
+      })
+    ).toEqual({
+      maxRunningContainers: 7,
+      autoCleanupEnabled: false,
+    });
+  });
+});

--- a/packages/convex/convex/containerSettings.ts
+++ b/packages/convex/convex/containerSettings.ts
@@ -12,6 +12,22 @@ const DEFAULT_SETTINGS = {
   minContainersToKeep: 0,
 };
 
+type ContainerSettingsUpdatePayload = {
+  teamSlugOrId: string;
+  maxRunningContainers?: number;
+  reviewPeriodMinutes?: number;
+  autoCleanupEnabled?: boolean;
+  stopImmediatelyOnCompletion?: boolean;
+  minContainersToKeep?: number;
+};
+
+export function buildContainerSettingsUpdatePayload({
+  teamSlugOrId: _teamSlugOrId,
+  ...settings
+}: ContainerSettingsUpdatePayload) {
+  return settings;
+}
+
 // Get container settings
 export const get = authQuery({
   args: { teamSlugOrId: v.string() },
@@ -53,6 +69,7 @@ export const update = authMutation({
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const settings = buildContainerSettingsUpdatePayload(args);
     const existing = await ctx.db
       .query("containerSettings")
       .withIndex("by_team_user", (q) =>
@@ -63,14 +80,14 @@ export const update = authMutation({
 
     if (existing) {
       await ctx.db.patch(existing._id, {
-        ...args,
+        ...settings,
         userId,
         teamId,
         updatedAt: now,
       });
     } else {
       await ctx.db.insert("containerSettings", {
-        ...args,
+        ...settings,
         userId,
         teamId,
         createdAt: now,


### PR DESCRIPTION
Fixes four active app-owned Sentry groups:

- https://manaflow.sentry.io/issues/7528578247/ guards destroyed Electron windows and reacquires live state after async work.
- https://manaflow.sentry.io/issues/7611606699/ and https://manaflow.sentry.io/issues/7535183509/ gate theme view transitions and observe all transition promises.
- https://manaflow.sentry.io/issues/7466908752/ removes the routing-only team slug before strict Convex writes.

Regression tests are split into a test-only commit followed by the fix.

Verified with focused Vitest suites, lint, typecheck, the Electron production build, the browser production build with non-secret test environment values, and the Convex typecheck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787457401&installation_model_id=21920&pr_number=1892&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1892&signature=2eb97386280e57c7fbfa899e19bf42b88c91306e17fa90ff6252dd424fd7faa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four Sentry errors across Electron, web, and Convex by guarding destroyed windows, gating theme view transitions, and stripping routing-only fields from Convex writes. Adds focused regression tests.

- **Bug Fixes**
  - Electron: Added `isProtocolWindowUsable` and used it across protocol handling and cookie flows; queue protocol URLs and cookie sets until a live window exists; reset window refs on close; reload only when a usable window is present.
  - Web: Start theme view transitions only when visible and not reduced-motion; added `settleThemeViewTransition` to await `ready/updateCallbackDone/finished` without throwing on rejections.
  - Convex: New `buildContainerSettingsUpdatePayload` removes `teamSlugOrId` before `update/insert` to avoid strict-write errors.
  - Tests: Vitest suites for protocol window lifecycle, theme transitions, and container settings.

<sup>Written for commit e8cb6e16c002e166a22881102f7cbc2517139dc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

