### PR TITLE
Add public company information page

### DIFF
--- a/apps/www/app/company-information/page.test.tsx
+++ b/apps/www/app/company-information/page.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import CompanyInformationPage, { metadata } from "./page";
+
+describe("company information", () => {
+  it("publishes the legal entity, contact, address, and both domains", () => {
+    const html = renderToStaticMarkup(<CompanyInformationPage />);
+
+    expect(html).toContain("Manaflow, Inc.");
+    expect(html).toContain("18428 Vantage Pointe Dr");
+    expect(html).toContain("Rowland Heights");
+    expect(html).toContain("91748-5142");
+    expect(html).toContain("founders@manaflow.com");
+    expect(html).toContain("manaflow.com");
+    expect(html).toContain("cmux.com");
+    expect(html).toContain("application/ld+json");
+  });
+
+  it("uses the public manaflow.com URL as its canonical URL", () => {
+    expect(metadata.alternates?.canonical).toBe(
+      "https://manaflow.com/company-information",
+    );
+  });
+});

--- a/apps/www/app/company-information/page.tsx
+++ b/apps/www/app/company-information/page.tsx
@@ -52,7 +52,7 @@ export default function CompanyInformationPage() {
 
   return (
     <div
-      className="min-h-dvh bg-white px-4 py-10 text-black sm:min-h-screen sm:py-16 print:px-0 print:py-0"
+      className="min-h-dvh bg-white px-4 py-10 text-black dark:bg-neutral-950 dark:text-neutral-100 sm:min-h-screen sm:py-16 print:!bg-white print:!text-black print:px-0 print:py-0"
       style={{ fontFamily: "var(--font-geist-sans), sans-serif" }}
     >
       <main className="mx-auto max-w-xl">
@@ -62,18 +62,18 @@ export default function CompanyInformationPage() {
         />
         <Link
           href="/"
-          className="text-sm text-neutral-500 hover:text-black hover:underline print:hidden"
+          className="text-sm text-neutral-500 hover:text-black hover:underline dark:text-neutral-400 dark:hover:text-white print:hidden"
         >
           ← Manaflow
         </Link>
         <h1 className="mt-6 text-2xl font-bold sm:text-3xl print:mt-0">
           Company information
         </h1>
-        <p className="mt-3 text-sm leading-6 text-neutral-600 sm:text-base">
+        <p className="mt-3 text-sm leading-6 text-neutral-600 dark:text-neutral-400 sm:text-base print:!text-black">
           Official legal entity and domain information for Manaflow and cmux.
         </p>
 
-        <dl className="mt-8 overflow-hidden rounded-lg border border-neutral-200">
+        <dl className="mt-8 overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800 print:!border-neutral-200">
           <CompanyDetail term="Legal entity">{legalName}</CompanyDetail>
           <CompanyDetail term="Business address">
             <address className="not-italic">
@@ -87,7 +87,7 @@ export default function CompanyInformationPage() {
           <CompanyDetail term="Contact">
             <a
               href={`mailto:${contactEmail}`}
-              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black dark:decoration-neutral-600 dark:hover:decoration-white print:!decoration-neutral-300"
             >
               {contactEmail}
             </a>
@@ -95,7 +95,7 @@ export default function CompanyInformationPage() {
           <CompanyDetail term="Company domain">
             <a
               href="https://manaflow.com"
-              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black dark:decoration-neutral-600 dark:hover:decoration-white print:!decoration-neutral-300"
             >
               manaflow.com
             </a>
@@ -103,7 +103,7 @@ export default function CompanyInformationPage() {
           <CompanyDetail term="Product domain">
             <a
               href="https://cmux.com"
-              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black dark:decoration-neutral-600 dark:hover:decoration-white print:!decoration-neutral-300"
             >
               cmux.com
             </a>
@@ -114,18 +114,18 @@ export default function CompanyInformationPage() {
           <h2 className="text-lg font-semibold">
             Domain ownership and operation
           </h2>
-          <p className="mt-3 text-sm leading-6 text-neutral-700 sm:text-base">
+          <p className="mt-3 text-sm leading-6 text-neutral-700 dark:text-neutral-300 sm:text-base print:!text-black">
             {legalName} owns and operates{" "}
             <a
               href="https://manaflow.com"
-              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black dark:decoration-neutral-600 dark:hover:decoration-white print:!decoration-neutral-300"
             >
               manaflow.com
             </a>{" "}
             and{" "}
             <a
               href="https://cmux.com"
-              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black dark:decoration-neutral-600 dark:hover:decoration-white print:!decoration-neutral-300"
             >
               cmux.com
             </a>
@@ -133,7 +133,7 @@ export default function CompanyInformationPage() {
           </p>
         </section>
 
-        <p className="mt-8 text-xs text-neutral-500">
+        <p className="mt-8 text-xs text-neutral-500 dark:text-neutral-500 print:!text-black">
           Last updated: July 30, 2026
         </p>
       </main>
@@ -149,9 +149,13 @@ function CompanyDetail({
   readonly children: React.ReactNode;
 }) {
   return (
-    <div className="grid gap-1 border-b border-neutral-200 px-5 py-4 last:border-b-0 sm:grid-cols-[10rem_1fr] sm:gap-6">
-      <dt className="text-sm font-medium text-neutral-600">{term}</dt>
-      <dd className="text-sm leading-6 text-black">{children}</dd>
+    <div className="grid gap-1 border-b border-neutral-200 px-5 py-4 last:border-b-0 dark:border-neutral-800 sm:grid-cols-[10rem_1fr] sm:gap-6 print:!border-neutral-200">
+      <dt className="text-sm font-medium text-neutral-600 dark:text-neutral-400 print:!text-black">
+        {term}
+      </dt>
+      <dd className="text-sm leading-6 text-black dark:text-neutral-100 print:!text-black">
+        {children}
+      </dd>
     </div>
   );
 }

--- a/apps/www/app/company-information/page.tsx
+++ b/apps/www/app/company-information/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const legalName = "Manaflow, Inc.";
+const contactEmail = "founders@manaflow.com";
+const streetAddress = "18428 Vantage Pointe Dr";
+const locality = "Rowland Heights";
+const region = "CA";
+const postalCode = "91748-5142";
+
+export const metadata: Metadata = {
+  title: "Company information — Manaflow",
+  description:
+    "Legal entity, address, contact, and domain information for Manaflow and cmux",
+  alternates: {
+    canonical: "https://manaflow.com/company-information",
+  },
+  openGraph: {
+    title: "Company information — Manaflow",
+    description:
+      "Legal entity, address, contact, and domain information for Manaflow and cmux",
+    type: "website",
+    url: "https://manaflow.com/company-information",
+  },
+};
+
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Manaflow",
+  legalName,
+  url: "https://manaflow.com",
+  email: contactEmail,
+  address: {
+    "@type": "PostalAddress",
+    streetAddress,
+    addressLocality: locality,
+    addressRegion: region,
+    postalCode,
+    addressCountry: "US",
+  },
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "general inquiries",
+    email: contactEmail,
+  },
+  sameAs: ["https://manaflow.com", "https://cmux.com"],
+};
+
+export default function CompanyInformationPage() {
+  const jsonLd = JSON.stringify(organizationJsonLd).replace(/</g, "\\u003c");
+
+  return (
+    <div
+      className="min-h-dvh bg-white px-4 py-10 text-black sm:min-h-screen sm:py-16 print:px-0 print:py-0"
+      style={{ fontFamily: "var(--font-geist-sans), sans-serif" }}
+    >
+      <main className="mx-auto max-w-xl">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLd }}
+        />
+        <Link
+          href="/"
+          className="text-sm text-neutral-500 hover:text-black hover:underline print:hidden"
+        >
+          ← Manaflow
+        </Link>
+        <h1 className="mt-6 text-2xl font-bold sm:text-3xl print:mt-0">
+          Company information
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-neutral-600 sm:text-base">
+          Official legal entity and domain information for Manaflow and cmux.
+        </p>
+
+        <dl className="mt-8 overflow-hidden rounded-lg border border-neutral-200">
+          <CompanyDetail term="Legal entity">{legalName}</CompanyDetail>
+          <CompanyDetail term="Business address">
+            <address className="not-italic">
+              {streetAddress}
+              <br />
+              {locality}, {region} {postalCode}
+              <br />
+              United States
+            </address>
+          </CompanyDetail>
+          <CompanyDetail term="Contact">
+            <a
+              href={`mailto:${contactEmail}`}
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+            >
+              {contactEmail}
+            </a>
+          </CompanyDetail>
+          <CompanyDetail term="Company domain">
+            <a
+              href="https://manaflow.com"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+            >
+              manaflow.com
+            </a>
+          </CompanyDetail>
+          <CompanyDetail term="Product domain">
+            <a
+              href="https://cmux.com"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+            >
+              cmux.com
+            </a>
+          </CompanyDetail>
+        </dl>
+
+        <section className="mt-8">
+          <h2 className="text-lg font-semibold">
+            Domain ownership and operation
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-neutral-700 sm:text-base">
+            {legalName} owns and operates{" "}
+            <a
+              href="https://manaflow.com"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+            >
+              manaflow.com
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://cmux.com"
+              className="underline decoration-neutral-300 underline-offset-2 hover:decoration-black"
+            >
+              cmux.com
+            </a>
+            . cmux is developed and operated by {legalName}.
+          </p>
+        </section>
+
+        <p className="mt-8 text-xs text-neutral-500">
+          Last updated: July 30, 2026
+        </p>
+      </main>
+    </div>
+  );
+}
+
+function CompanyDetail({
+  term,
+  children,
+}: {
+  readonly term: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="grid gap-1 border-b border-neutral-200 px-5 py-4 last:border-b-0 sm:grid-cols-[10rem_1fr] sm:gap-6">
+      <dt className="text-sm font-medium text-neutral-600">{term}</dt>
+      <dd className="text-sm leading-6 text-black">{children}</dd>
+    </div>
+  );
+}

--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -1,28 +1,29 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { FadeInImage } from "./fade-in-image";
 
 export const metadata: Metadata = {
   title: "Manaflow - Open Source Applied AI Lab",
-  description:
-    "Open source applied AI lab building next-gen devtools",
+  description: "Open source applied AI lab building next-gen devtools",
   openGraph: {
     title: "Manaflow - Open Source Applied AI Lab",
-    description:
-      "Open source applied AI lab building next-gen devtools",
+    description: "Open source applied AI lab building next-gen devtools",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "Manaflow - Open Source Applied AI Lab",
-    description:
-      "Open source applied AI lab building next-gen devtools",
+    description: "Open source applied AI lab building next-gen devtools",
   },
 };
 
 export default function ManaflowPage() {
   return (
-    <div className="min-h-dvh overscroll-none bg-white px-4 py-10 text-black sm:min-h-screen sm:py-16" style={{ fontFamily: "var(--font-geist-sans), sans-serif" }}>
+    <div
+      className="min-h-dvh overscroll-none bg-white px-4 py-10 text-black sm:min-h-screen sm:py-16"
+      style={{ fontFamily: "var(--font-geist-sans), sans-serif" }}
+    >
       <div className="mx-auto max-w-xl">
         <h1 className="mb-2 text-2xl font-bold sm:text-3xl">Manaflow</h1>
         <p className="mb-5 text-sm text-neutral-600 sm:mb-6 sm:text-base">
@@ -86,6 +87,23 @@ export default function ManaflowPage() {
             className="text-neutral-500 hover:text-black hover:underline"
           >
             linkedin
+          </a>
+        </div>
+        <div className="mt-5 border-t border-neutral-200 pt-4 text-xs sm:mt-6 sm:text-sm">
+          <Link
+            href="/company-information"
+            className="text-neutral-500 hover:text-black hover:underline"
+          >
+            company information
+          </Link>
+          <span className="mx-2 text-neutral-300" aria-hidden>
+            ·
+          </span>
+          <a
+            href="mailto:founders@manaflow.com"
+            className="text-neutral-500 hover:text-black hover:underline"
+          >
+            contact
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a public company-information page with Manaflow legal identity, address, contact, and both domains
- link it from the manaflow.com landing page
- add Organization structured data, print-friendly styling, and focused tests

## Verification
- bun run --cwd apps/www test app/company-information/page.test.tsx
- bun run typecheck:www
- bunx eslint on changed TypeScript files
- bun check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788045488&installation_model_id=21920&pr_number=1900&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1900&signature=a5e04df4ca46612102e617d0300b09b4c9e15bb57168073def14ecad78153ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public company information page listing Manaflow’s legal entity, address, contact email, and domains. Links it from the manaflow.com landing page and adds Organization structured data for better SEO.

- **New Features**
  - New route at /company-information with canonical https://manaflow.com/company-information and print-friendly + dark mode styles
  - Organization JSON-LD with legal name, postal address, and contact
  - Footer link from the Manaflow landing page plus a mailto contact link
  - Tests covering published content and canonical metadata

<sup>Written for commit f8a9b30fc2c39894859cc15edd7985e981ee2c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a company information page with legal details, contact information, domains, ownership details, and update date.
  * Added responsive, dark-mode, and print-friendly layouts.
  * Added structured organization information and improved search metadata.
  * Added footer links to company information and contact details on the Manaflow page.

* **Tests**
  * Added coverage for company details, domains, structured data, and canonical URL metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->