### PR TITLE
Keep company information page low key

### DIFF
--- a/apps/www/app/company-information/page.test.tsx
+++ b/apps/www/app/company-information/page.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import CompanyInformationPage, { metadata } from "./page";
+import ManaflowPage from "../manaflow/page";
 
 describe("company information", () => {
   it("publishes the legal entity, contact, address, and both domains", () => {
@@ -21,5 +22,15 @@ describe("company information", () => {
     expect(metadata.alternates?.canonical).toBe(
       "https://manaflow.com/company-information",
     );
+  });
+
+  it("keeps the direct page out of search indexes", () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("does not link the direct page from the public Manaflow page", () => {
+    const html = renderToStaticMarkup(<ManaflowPage />);
+
+    expect(html).not.toContain('href="/company-information"');
   });
 });

--- a/apps/www/app/company-information/page.tsx
+++ b/apps/www/app/company-information/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
   title: "Company information — Manaflow",
   description:
     "Legal entity, address, contact, and domain information for Manaflow and cmux",
+  robots: {
+    index: false,
+    follow: false,
+  },
   alternates: {
     canonical: "https://manaflow.com/company-information",
   },

--- a/apps/www/app/manaflow/page.tsx
+++ b/apps/www/app/manaflow/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import { FadeInImage } from "./fade-in-image";
 
@@ -90,15 +89,6 @@ export default function ManaflowPage() {
           </a>
         </div>
         <div className="mt-5 border-t border-neutral-200 pt-4 text-xs sm:mt-6 sm:text-sm">
-          <Link
-            href="/company-information"
-            className="text-neutral-500 hover:text-black hover:underline"
-          >
-            company information
-          </Link>
-          <span className="mx-2 text-neutral-300" aria-hidden>
-            ·
-          </span>
           <a
             href="mailto:founders@manaflow.com"
             className="text-neutral-500 hover:text-black hover:underline"


### PR DESCRIPTION
Keeps the direct company-information URL live for Artifact Signing validation while removing the public Manaflow link and setting noindex metadata.\n\nVerification:\n- bunx vitest run apps/www/app/company-information/page.test.tsx\n- bun run typecheck in apps/www\n- Prettier check on changed files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788145850&installation_model_id=21920&pr_number=1902&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1902&signature=3d46767ab44b4d206f4847495a378eb0e355401f95ef3cabb94733d0af1dd256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the company information page accessible via direct URL for Artifact Signing validation, while making it low profile. Removed the link from the public Manaflow page and set `metadata.robots` to `{ index: false, follow: false }` on `/company-information`.

<sup>Written for commit 0d6f5ba1e375a324ab751eb880c7aa5b6c62442d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the Company Information link from the public Manaflow page.
  * Company Information pages are now excluded from search engine indexing and link crawling.
  * Retained the contact email link in the page footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->