### PR TITLE
Add CLA Assistant workflow

### DIFF
--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -86,7 +86,7 @@ elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
   fi
   if [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ||
         ("${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" && ${runs_call_count} -ge 2) ]]; then
-    jq -c '.runs | .workflow_runs += [{
+    runs_json="$(jq -c '.runs | .workflow_runs += [{
       "id": 701,
       "path": ".github/workflows/cla.yml",
       "event": "pull_request_target",
@@ -98,23 +98,45 @@ elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
       "status": "completed",
       "conclusion": "success",
       "created_at": "2026-09-01T11:30:00Z"
-    }]' "${fixture}"
+    }]' "${fixture}")"
   else
-    jq -c '.runs' "${fixture}"
+    runs_json="$(jq -c '.runs' "${fixture}")"
   fi
+  if [[ "${CLA_FIXTURE_POPULATED_EXECUTION:-false}" == "true" ]]; then
+    run_pull_request="$(jq -c '.run_pull_request' "${fixture}")"
+    runs_json="$(jq -c --argjson run_pull_request "${run_pull_request}" \
+      '.workflow_runs[0].pull_requests = [$run_pull_request] | .workflow_runs[0].head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
+      <<<"${runs_json}")"
+  fi
+  printf '%s\n' "${runs_json}"
 elif [[ "${endpoint}" == *"/actions/workflows"* ]]; then
   jq -c '.workflows' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/runs/700/jobs"* ]]; then
-  jq -c --arg generation_marker "${generation_marker}" \
-    '.jobs.jobs[0].steps[0].name = $generation_marker | .jobs' "${fixture}"
+  jobs_json="$(jq -c --arg generation_marker "${generation_marker}" \
+    '.jobs.jobs[0].steps[0].name = $generation_marker | .jobs' "${fixture}")"
+  if [[ "${CLA_FIXTURE_POPULATED_EXECUTION:-false}" == "true" ]]; then
+    jobs_json="$(jq -c '.jobs[0].head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' <<<"${jobs_json}")"
+  fi
+  printf '%s\n' "${jobs_json}"
 elif [[ "${endpoint}" == *"/actions/runs/701/jobs"* ]]; then
   jq -c --arg generation_marker "${generation_marker}" \
     '.success_jobs.jobs[0].steps[0].name = $generation_marker | .success_jobs' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/runs/700"* ]]; then
-  jq -c '.run' "${fixture}"
+  run_json="$(jq -c '.run' "${fixture}")"
+  if [[ "${CLA_FIXTURE_POPULATED_EXECUTION:-false}" == "true" ]]; then
+    run_pull_request="$(jq -c '.run_pull_request' "${fixture}")"
+    run_json="$(jq -c --argjson run_pull_request "${run_pull_request}" \
+      '.pull_requests = [$run_pull_request] | .head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
+      <<<"${run_json}")"
+  fi
+  printf '%s\n' "${run_json}"
 elif [[ "${endpoint}" == *"/actions/jobs/8800"* ]]; then
-  jq -c --arg generation_marker "${generation_marker}" \
-    '.job.steps[0].name = $generation_marker | .job' "${fixture}"
+  job_json="$(jq -c --arg generation_marker "${generation_marker}" \
+    '.job.steps[0].name = $generation_marker | .job' "${fixture}")"
+  if [[ "${CLA_FIXTURE_POPULATED_EXECUTION:-false}" == "true" ]]; then
+    job_json="$(jq -c '.head_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' <<<"${job_json}")"
+  fi
+  printf '%s\n' "${job_json}"
 else
   echo "unmatched fixture endpoint: ${endpoint}" >&2
   exit 2

--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -10,6 +10,12 @@ fixture="${CLA_FIXTURE:?CLA_FIXTURE is required}"
 endpoint=""
 method="GET"
 previous=""
+workflow_sha="${CLA_FIXTURE_WORKFLOW_SHA:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+[[ "${workflow_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "fixture workflow SHA is invalid" >&2
+  exit 2
+}
+generation_marker="CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-workflow-${workflow_sha}"
 for argument in "$@"; do
   if [[ "${previous}" == "--method" ]]; then
     method="${argument}"
@@ -22,6 +28,13 @@ done
   echo "fixture endpoint is missing" >&2
   exit 2
 }
+
+if [[ "${CLA_FIXTURE_OVERSIZE_ENDPOINT:-}" == "${endpoint}" ]]; then
+  printf '{"oversized":"'
+  head -c 8000001 /dev/zero | tr '\0' x
+  printf '"}\n'
+  exit 0
+fi
 
 if [[ "${method}" == "POST" ]]; then
   printf '%s\n' "${endpoint}" >"${CLA_POST_LOG:?CLA_POST_LOG is required}"
@@ -52,11 +65,13 @@ elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
 elif [[ "${endpoint}" == *"/actions/workflows"* ]]; then
   jq -c '.workflows' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/runs/700/jobs"* ]]; then
-  jq -c '.jobs' "${fixture}"
+  jq -c --arg generation_marker "${generation_marker}" \
+    '.jobs.jobs[0].steps[0].name = $generation_marker | .jobs' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/runs/700"* ]]; then
   jq -c '.run' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/jobs/8800"* ]]; then
-  jq -c '.job' "${fixture}"
+  jq -c --arg generation_marker "${generation_marker}" \
+    '.job.steps[0].name = $generation_marker | .job' "${fixture}"
 else
   echo "unmatched fixture endpoint: ${endpoint}" >&2
   exit 2

--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -57,11 +57,36 @@ elif [[ "${endpoint}" == *"/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/che
     printf '%s\n' '{"check_runs":[]}'
   elif [[ "${CLA_FIXTURE_WRONG_SOURCE_JOB:-false}" == "true" ]]; then
     jq -c '.source_check_runs | .check_runs[0].details_url = "https://github.com/manaflow-ai/manaflow/actions/runs/700/job/8801"' "${fixture}"
+  elif [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ]]; then
+    jq -c '.source_check_runs | .check_runs += [{
+      "id": 8810,
+      "name": "CLA Assistant v3",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "conclusion": "success",
+      "app": {"slug": "github-actions"},
+      "details_url": "https://github.com/manaflow-ai/manaflow/actions/runs/701/job/8810"
+    }]' "${fixture}"
   else
     jq -c '.source_check_runs' "${fixture}"
   fi
 elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
-  jq -c '.runs' "${fixture}"
+  if [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ]]; then
+    jq -c '.runs | .workflow_runs += [{
+      "id": 701,
+      "path": ".github/workflows/cla.yml",
+      "event": "pull_request_target",
+      "workflow_id": 9000,
+      "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+      "head_branch": "feature",
+      "head_repository": {"full_name": "fork-user/manaflow", "id": 987654},
+      "pull_requests": [],
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-01T11:30:00Z"
+    }]' "${fixture}"
+  else
+    jq -c '.runs' "${fixture}"
+  fi
 elif [[ "${endpoint}" == *"/actions/workflows"* ]]; then
   jq -c '.workflows' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/runs/700/jobs"* ]]; then

--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -123,6 +123,21 @@ elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
   else
     runs_json="$(jq -c '.runs' "${fixture}")"
   fi
+  if [[ "${CLA_FIXTURE_DEFAULT_SHA_COMMENT_RUN:-false}" == "true" ]]; then
+    runs_json="$(jq -c '.workflow_runs += [{
+      "id": 702,
+      "path": ".github/workflows/cla.yml",
+      "event": "issue_comment",
+      "workflow_id": 9000,
+      "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+      "head_branch": "main",
+      "head_repository": {"full_name": "manaflow-ai/manaflow", "id": 1026429198},
+      "pull_requests": [],
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-09-01T12:30:00Z"
+    }]' <<<"${runs_json}")"
+  fi
   if [[ "${CLA_FIXTURE_POPULATED_EXECUTION:-false}" == "true" ]]; then
     run_pull_request="$(jq -c '.run_pull_request' "${fixture}")"
     runs_json="$(jq -c --argjson run_pull_request "${run_pull_request}" \

--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -58,21 +58,28 @@ elif [[ "${endpoint}" == *"/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/che
   elif [[ "${CLA_FIXTURE_WRONG_SOURCE_JOB:-false}" == "true" ]]; then
     jq -c '.source_check_runs | .check_runs[0].details_url = "https://github.com/manaflow-ai/manaflow/actions/runs/700/job/8801"' "${fixture}"
   elif [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ||
-          "${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" ]]; then
+          "${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" ||
+          "${CLA_FIXTURE_ACTIVE_SOURCE_RUN:-false}" == "true" ]]; then
     jq -c '.source_check_runs | .check_runs += [{
       "id": 8810,
       "name": "CLA Assistant v3",
       "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "completed",
       "conclusion": "success",
       "app": {"slug": "github-actions"},
       "details_url": "https://github.com/manaflow-ai/manaflow/actions/runs/701/job/8810"
-    }]' "${fixture}"
+    }]' "${fixture}" | if [[ "${CLA_FIXTURE_ACTIVE_SOURCE_RUN:-false}" == "true" ]]; then
+      jq -c '.check_runs[-1].status = "in_progress" | .check_runs[-1].conclusion = null'
+    else
+      cat
+    fi
   else
     jq -c '.source_check_runs' "${fixture}"
   fi
 elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
   runs_call_count=1
-  if [[ "${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" ]]; then
+  if [[ "${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" ||
+        "${CLA_FIXTURE_ACTIVE_SOURCE_RUN:-false}" == "true" ]]; then
     runs_call_log="${CLA_FIXTURE_RUNS_CALL_LOG:?CLA_FIXTURE_RUNS_CALL_LOG is required}"
     if [[ -f "${runs_call_log}" ]]; then
       runs_call_count="$(<"${runs_call_log}")"
@@ -97,6 +104,20 @@ elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
       "pull_requests": [],
       "status": "completed",
       "conclusion": "success",
+      "created_at": "2026-09-01T11:30:00Z"
+    }]' "${fixture}")"
+  elif [[ "${CLA_FIXTURE_ACTIVE_SOURCE_RUN:-false}" == "true" && ${runs_call_count} -ge 2 ]]; then
+    runs_json="$(jq -c '.runs | .workflow_runs += [{
+      "id": 701,
+      "path": ".github/workflows/cla.yml",
+      "event": "pull_request_target",
+      "workflow_id": 9000,
+      "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+      "head_branch": "feature",
+      "head_repository": {"full_name": "fork-user/manaflow", "id": 987654},
+      "pull_requests": [],
+      "status": "in_progress",
+      "conclusion": null,
       "created_at": "2026-09-01T11:30:00Z"
     }]' "${fixture}")"
   else

--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:-}" == "api" ]] || {
+  echo "fixture only supports gh api" >&2
+  exit 2
+}
+
+fixture="${CLA_FIXTURE:?CLA_FIXTURE is required}"
+endpoint=""
+method="GET"
+previous=""
+for argument in "$@"; do
+  if [[ "${previous}" == "--method" ]]; then
+    method="${argument}"
+  elif [[ "${argument}" == repos/* ]]; then
+    endpoint="${argument}"
+  fi
+  previous="${argument}"
+done
+[[ -n "${endpoint}" ]] || {
+  echo "fixture endpoint is missing" >&2
+  exit 2
+}
+
+if [[ "${method}" == "POST" ]]; then
+  printf '%s\n' "${endpoint}" >"${CLA_POST_LOG:?CLA_POST_LOG is required}"
+  printf '%s\n' '{}'
+  exit 0
+fi
+
+if [[ "${endpoint}" == *"/issues/comments/9001"* ]]; then
+  jq -c '.comment' "${fixture}"
+elif [[ "${endpoint}" == *"/issues/42"* ]]; then
+  jq -c '.issue' "${fixture}"
+elif [[ "${endpoint}" == *"/pulls/42"* ]]; then
+  jq -c '.pull_request' "${fixture}"
+elif [[ "${endpoint}" == *"/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/pulls"* ]]; then
+  printf '%s\n' '[]'
+elif [[ "${endpoint}" == *"/pulls"* ]]; then
+  printf '%s\n' '[{"number":42,"state":"open","base":{"ref":"main","repo":{"full_name":"manaflow-ai/manaflow","id":1026429198}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"full_name":"fork-user/manaflow","id":987654}}}]'
+elif [[ "${endpoint}" == *"/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs"* ]]; then
+  if [[ "${CLA_FIXTURE_NO_SOURCE_CHECK:-false}" == "true" ]]; then
+    printf '%s\n' '{"check_runs":[]}'
+  elif [[ "${CLA_FIXTURE_WRONG_SOURCE_JOB:-false}" == "true" ]]; then
+    jq -c '.source_check_runs | .check_runs[0].details_url = "https://github.com/manaflow-ai/manaflow/actions/runs/700/job/8801"' "${fixture}"
+  else
+    jq -c '.source_check_runs' "${fixture}"
+  fi
+elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
+  jq -c '.runs' "${fixture}"
+elif [[ "${endpoint}" == *"/actions/workflows"* ]]; then
+  jq -c '.workflows' "${fixture}"
+elif [[ "${endpoint}" == *"/actions/runs/700/jobs"* ]]; then
+  jq -c '.jobs' "${fixture}"
+elif [[ "${endpoint}" == *"/actions/runs/700"* ]]; then
+  jq -c '.run' "${fixture}"
+elif [[ "${endpoint}" == *"/actions/jobs/8800"* ]]; then
+  jq -c '.job' "${fixture}"
+else
+  echo "unmatched fixture endpoint: ${endpoint}" >&2
+  exit 2
+fi

--- a/.github/scripts/fixtures/cla-rerun-fake-gh
+++ b/.github/scripts/fixtures/cla-rerun-fake-gh
@@ -57,7 +57,8 @@ elif [[ "${endpoint}" == *"/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/che
     printf '%s\n' '{"check_runs":[]}'
   elif [[ "${CLA_FIXTURE_WRONG_SOURCE_JOB:-false}" == "true" ]]; then
     jq -c '.source_check_runs | .check_runs[0].details_url = "https://github.com/manaflow-ai/manaflow/actions/runs/700/job/8801"' "${fixture}"
-  elif [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ]]; then
+  elif [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ||
+          "${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" ]]; then
     jq -c '.source_check_runs | .check_runs += [{
       "id": 8810,
       "name": "CLA Assistant v3",
@@ -70,7 +71,21 @@ elif [[ "${endpoint}" == *"/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/che
     jq -c '.source_check_runs' "${fixture}"
   fi
 elif [[ "${endpoint}" == *"/actions/workflows/9000/runs"* ]]; then
-  if [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ]]; then
+  runs_call_count=1
+  if [[ "${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" ]]; then
+    runs_call_log="${CLA_FIXTURE_RUNS_CALL_LOG:?CLA_FIXTURE_RUNS_CALL_LOG is required}"
+    if [[ -f "${runs_call_log}" ]]; then
+      runs_call_count="$(<"${runs_call_log}")"
+      [[ "${runs_call_count}" =~ ^[0-9]+$ ]] || {
+        echo "fixture workflow run call count is invalid" >&2
+        exit 2
+      }
+      runs_call_count=$((runs_call_count + 1))
+    fi
+    printf '%s\n' "${runs_call_count}" >"${runs_call_log}"
+  fi
+  if [[ "${CLA_FIXTURE_NEWER_SUCCESS:-false}" == "true" ||
+        ("${CLA_FIXTURE_FINAL_NEWER_SUCCESS:-false}" == "true" && ${runs_call_count} -ge 2) ]]; then
     jq -c '.runs | .workflow_runs += [{
       "id": 701,
       "path": ".github/workflows/cla.yml",
@@ -92,6 +107,9 @@ elif [[ "${endpoint}" == *"/actions/workflows"* ]]; then
 elif [[ "${endpoint}" == *"/actions/runs/700/jobs"* ]]; then
   jq -c --arg generation_marker "${generation_marker}" \
     '.jobs.jobs[0].steps[0].name = $generation_marker | .jobs' "${fixture}"
+elif [[ "${endpoint}" == *"/actions/runs/701/jobs"* ]]; then
+  jq -c --arg generation_marker "${generation_marker}" \
+    '.success_jobs.jobs[0].steps[0].name = $generation_marker | .success_jobs' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/runs/700"* ]]; then
   jq -c '.run' "${fixture}"
 elif [[ "${endpoint}" == *"/actions/jobs/8800"* ]]; then

--- a/.github/scripts/fixtures/fork-rerun.json
+++ b/.github/scripts/fixtures/fork-rerun.json
@@ -128,6 +128,25 @@
       }
     ]
   },
+  "success_jobs": {
+    "total_count": 1,
+    "jobs": [
+      {
+        "id": 8810,
+        "run_id": 701,
+        "name": "CLA Assistant v3",
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "steps": [
+          {
+            "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-workflow-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "status": "completed"
+          }
+        ]
+      }
+    ]
+  },
   "job": {
     "id": 8800,
     "run_id": 700,

--- a/.github/scripts/fixtures/fork-rerun.json
+++ b/.github/scripts/fixtures/fork-rerun.json
@@ -41,6 +41,24 @@
       "id": 1234
     }
   },
+  "run_pull_request": {
+    "number": 42,
+    "base": {
+      "ref": "main",
+      "repo": {
+        "full_name": "manaflow-ai/manaflow",
+        "id": 1026429198
+      }
+    },
+    "head": {
+      "ref": "feature",
+      "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "repo": {
+        "full_name": "fork-user/manaflow",
+        "id": 987654
+      }
+    }
+  },
   "source_check_runs": {
     "total_count": 1,
     "check_runs": [

--- a/.github/scripts/fixtures/fork-rerun.json
+++ b/.github/scripts/fixtures/fork-rerun.json
@@ -1,0 +1,150 @@
+{
+  "issue": {
+    "state": "open",
+    "pull_request": {
+      "url": "https://api.github.com/repos/manaflow-ai/manaflow/pulls/42"
+    }
+  },
+  "comment": {
+    "id": 9001,
+    "issue_url": "https://api.github.com/repos/manaflow-ai/manaflow/issues/42",
+    "body": "recheck",
+    "user": {
+      "id": 1234,
+      "login": "contributor",
+      "type": "User"
+    },
+    "created_at": "2026-09-01T12:00:00Z",
+    "updated_at": "2026-09-01T12:00:00Z",
+    "author_association": "NONE"
+  },
+  "pull_request": {
+    "number": 42,
+    "state": "open",
+    "base": {
+      "ref": "main",
+      "repo": {
+        "full_name": "manaflow-ai/manaflow",
+        "id": 1026429198
+      }
+    },
+    "head": {
+      "ref": "feature",
+      "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "repo": {
+        "full_name": "fork-user/manaflow",
+        "id": 987654
+      }
+    },
+    "user": {
+      "login": "contributor",
+      "id": 1234
+    }
+  },
+  "source_check_runs": {
+    "total_count": 1,
+    "check_runs": [
+      {
+        "id": 8800,
+        "name": "CLA Assistant v3",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "conclusion": "failure",
+        "app": {
+          "slug": "github-actions"
+        },
+        "details_url": "https://github.com/manaflow-ai/manaflow/actions/runs/700/job/8800"
+      }
+    ]
+  },
+  "workflows": {
+    "total_count": 1,
+    "workflows": [
+      {
+        "id": 9000,
+        "path": ".github/workflows/cla.yml",
+        "state": "active"
+      }
+    ]
+  },
+  "runs": {
+    "total_count": 1,
+    "workflow_runs": [
+      {
+        "id": 700,
+        "path": ".github/workflows/cla.yml",
+        "event": "pull_request_target",
+        "workflow_id": 9000,
+        "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "head_branch": "feature",
+        "head_repository": {
+          "full_name": "fork-user/manaflow",
+          "id": 987654
+        },
+        "pull_requests": [],
+        "status": "completed",
+        "conclusion": "failure",
+        "created_at": "2026-09-01T11:00:00Z",
+        "head_commit": {
+          "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      }
+    ]
+  },
+  "run": {
+    "id": 700,
+    "path": ".github/workflows/cla.yml",
+    "event": "pull_request_target",
+    "workflow_id": 9000,
+    "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "head_branch": "feature",
+    "head_repository": {
+      "full_name": "fork-user/manaflow",
+      "id": 987654
+    },
+    "pull_requests": [],
+    "status": "completed",
+    "conclusion": "failure",
+    "created_at": "2026-09-01T11:00:00Z",
+    "head_commit": {
+      "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  },
+  "jobs": {
+    "total_count": 1,
+    "jobs": [
+      {
+        "id": 8800,
+        "run_id": 700,
+        "name": "CLA Assistant v3",
+        "status": "completed",
+        "conclusion": "failure",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "steps": [
+          {
+            "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaa",
+            "status": "completed"
+          }
+        ]
+      }
+    ]
+  },
+  "job": {
+    "id": 8800,
+    "run_id": 700,
+    "name": "CLA Assistant v3",
+    "status": "completed",
+    "conclusion": "failure",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "steps": [
+      {
+        "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaa",
+        "status": "completed"
+      }
+    ]
+  },
+  "ledger": {
+    "type": "file",
+    "encoding": "base64",
+    "content": "e30="
+  }
+}

--- a/.github/scripts/fixtures/fork-rerun.json
+++ b/.github/scripts/fixtures/fork-rerun.json
@@ -121,7 +121,7 @@
         "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "steps": [
           {
-            "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-workflow-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "status": "completed"
           }
         ]
@@ -137,7 +137,7 @@
     "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "steps": [
       {
-        "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-workflow-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "status": "completed"
       }
     ]

--- a/.github/scripts/fixtures/fork-rerun.json
+++ b/.github/scripts/fixtures/fork-rerun.json
@@ -121,7 +121,7 @@
         "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "steps": [
           {
-            "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaa",
+            "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "status": "completed"
           }
         ]
@@ -137,7 +137,7 @@
     "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "steps": [
       {
-        "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaa",
+        "name": "CLA generation v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "status": "completed"
       }
     ]

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -9,6 +9,31 @@ fail() {
 readonly MAX_SAFE_INTEGER=9007199254740991
 readonly MAX_COMMENT_BYTES=65536
 readonly EXPECTED_REPOSITORY='manaflow-ai/manaflow'
+readonly MAX_API_RESPONSE_BYTES=8000000
+
+# Every GitHub API response is bounded before a caller parses it. The helper
+# still applies endpoint-specific page and object limits below; this shared
+# cap prevents a malformed response from consuming unbounded shell memory.
+gh() {
+  local response response_bytes
+  if [[ "${1:-}" != "api" ]]; then
+    command gh "$@"
+    return
+  fi
+  if ! response="$(command gh "$@")"; then
+    return 1
+  fi
+  response_bytes="$(printf '%s' "${response}" | wc -c | tr -d '[:space:]')" || return 1
+  [[ "${response_bytes}" =~ ^[0-9]+$ ]] || {
+    echo "GitHub API response size is invalid" >&2
+    return 1
+  }
+  (( response_bytes <= MAX_API_RESPONSE_BYTES )) || {
+    echo "GitHub API response exceeds ${MAX_API_RESPONSE_BYTES} bytes" >&2
+    return 1
+  }
+  printf '%s' "${response}"
+}
 
 safe_id() {
   local value="${1}"
@@ -55,7 +80,7 @@ if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign 
 elif [[ "${CLA_PASSED}" != "true" ]]; then
   fail "The CLA action did not report cla_passed=true for the recheck"
 fi
-[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{40}$ ]] || fail "Invalid CLA generation marker"
 [[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
 checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
 [[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -81,6 +81,28 @@ readonly MAX_LEDGER_RAW_BYTES=2000000
 readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
 readonly CLA_WRITER_JOB='CLA ledger writer'
 readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
+# A pull_request_target run normally reports the source head in `head_sha`,
+# but GitHub has also returned a base execution SHA for fork runs.  The check
+# run attached to the live source SHA is the authoritative fallback binding.
+# Keep only the numeric run/job IDs parsed from GitHub's fixed Actions URL.
+source_check_bindings_json='[]'
+run_has_pull_request_association=false
+
+source_check_binding_for_run() {
+  local target_run_id="$1"
+  jq -e --arg run_id "${target_run_id}" \
+    'any(.[]?; .run_id == $run_id)' <<<"${source_check_bindings_json}" >/dev/null
+}
+
+source_check_binding_for_job() {
+  local target_run_id="$1"
+  local target_job_id="$2"
+  jq -e \
+    --arg run_id "${target_run_id}" \
+    --arg job_id "${target_job_id}" \
+    'any(.[]?; .run_id == $run_id and .job_id == $job_id)' \
+    <<<"${source_check_bindings_json}" >/dev/null
+}
 
 validate_triggering_signature_record() {
   local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
@@ -235,9 +257,10 @@ fi
 
 # The workflow-run list can omit pull_requests for pull_request_target runs.
 # The exact live PR plus the run head_repository/head_branch binding below is
-# used for populated source-head runs. Empty associations are accepted only
-# when the run execution SHA equals the live PR head SHA; a base or merge SHA
-# is not sufficient evidence for a privileged rerun.
+# used for populated source-head runs. Empty associations are accepted when
+# the run execution SHA equals the live PR head SHA, or when the source-bound
+# CLA check identifies the same run and job. A bare base or merge SHA is not
+# sufficient evidence for a privileged rerun.
 # GitHub may return a not-found or validation response when the source commit
 # exists only in a fork. Treat only that documented missing-commit response as
 # an empty association list; every other API failure remains fatal.
@@ -393,6 +416,84 @@ validate_live_open_head_association() {
 }
 validate_live_open_head_association
 
+# The REST workflow-run API can omit `pull_requests` for a fork. Most runs
+# still expose the source SHA in `head_sha`; when they do not, bind the run and
+# selected job to a failed CLA check that GitHub attached to this exact source
+# SHA. A check run is created by the GitHub Actions app, so an untrusted fork
+# cannot forge this association in the base repository. The later job and PR
+# rechecks still require the same source repository, branch, and current SHA.
+refresh_source_check_bindings() {
+  local source_checks_page source_checks_page2 source_checks_error source_checks_error_file
+  local source_check_count source_check_count2
+  if [[ "${head_repo}" == "${GH_REPO}" ]]; then
+    source_check_bindings_json='[]'
+    return 0
+  fi
+
+  source_checks_error_file="$(mktemp)"
+  if source_checks_page="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/commits/${head_sha}/check-runs" 2>"${source_checks_error_file}")"; then
+    rm -f -- "${source_checks_error_file}"
+  else
+    source_checks_error="$(cat "${source_checks_error_file}")"
+    rm -f -- "${source_checks_error_file}"
+    if grep -Eq 'HTTP 404|HTTP 422' <<<"${source_checks_error}" &&
+       grep -Eq 'Not Found|Resource not found|No commit found for SHA: [0-9a-f]{40}' <<<"${source_checks_error}"; then
+      # A fork-only commit may not be addressable through the base repository.
+      # The strict source-SHA run path remains available in that case.
+      source_checks_page='{"check_runs":[]}'
+    else
+      fail "Could not query check runs for the live pull request head"
+    fi
+  fi
+  jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${source_checks_page}" >/dev/null || fail "Could not validate source check runs"
+  source_check_count="$(jq -r '.check_runs | length' <<<"${source_checks_page}")"
+  [[ "${source_check_count}" =~ ^[0-9]+$ ]] || fail "Could not count source check runs"
+  (( source_check_count <= 100 )) || fail "The source check-run page is oversized"
+  if (( source_check_count == 100 )); then
+    source_checks_page2="$(gh api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/commits/${head_sha}/check-runs" 2>/dev/null)" || fail "Could not query source check runs page 2"
+    jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${source_checks_page2}" >/dev/null || fail "Could not validate source check runs page 2"
+    source_check_count2="$(jq -r '.check_runs | length' <<<"${source_checks_page2}")"
+    [[ "${source_check_count2}" =~ ^[0-9]+$ ]] || fail "Could not count source check runs page 2"
+    (( source_check_count2 <= 100 )) || fail "The source check-run page is oversized"
+    source_checks_page="$(jq -c --argjson page2 "${source_checks_page2}" '.check_runs += $page2.check_runs' <<<"${source_checks_page}")"
+    source_check_count=$((source_check_count + source_check_count2))
+    (( source_check_count2 < 100 )) || fail "Too many source check runs for this head; ask an administrator to resolve the check history before requesting a rerun"
+  fi
+  source_check_bindings_json="$(jq -c \
+    --arg sha "${head_sha}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" '
+      [ .check_runs[]?
+        | select(
+            (.name | type == "string") and
+            .name == $assistant_job and
+            (.head_sha | type == "string") and
+            .head_sha == $sha and
+            .conclusion == "failure" and
+            (.app.slug | type == "string") and
+            .app.slug == "github-actions" and
+            (.details_url | type == "string") and
+            (.details_url | test("^https://github\\.com/manaflow-ai/manaflow/actions/runs/[0-9]+/job/[0-9]+$"))
+          )
+        | .details_url
+        | capture("/actions/runs/(?<run>[1-9][0-9]*)/job/(?<job>[1-9][0-9]*)$")
+        | {run_id: .run, job_id: .job}
+      ]
+      | unique_by([.run_id, .job_id])
+    ' <<<"${source_checks_page}")" || fail "Could not identify the source-bound CLA check"
+  jq -e 'all(.[]; (.run_id | type == "string" and test("^[1-9][0-9]{0,15}$")) and (.job_id | type == "string" and test("^[1-9][0-9]{0,15}$")))' <<<"${source_check_bindings_json}" >/dev/null || fail "The source-bound CLA check identity is malformed"
+}
+refresh_source_check_bindings
+
 workflow_page="$(gh api \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
@@ -430,10 +531,10 @@ safe_id "${workflow_id}" || fail "The expected CLA workflow ID is missing or uns
 # event, and PR association. When GitHub includes pull_requests on a
 # run, bind the candidate to the exact PR object, including its
 # source head SHA.
-# GitHub can return an empty array for fork pull_request_target runs,
-# so those candidates are retained only when the run's execution SHA equals
-# the live PR source SHA. Populated pull_requests records may bind a different
-# execution SHA to the exact source PR object.
+# GitHub can return an empty array for fork pull_request_target runs. Those
+# candidates are retained when the execution SHA is the live source SHA, or
+# when a GitHub Actions check on that source SHA identifies the same run. A
+# selected assistant job must match that check's run and job IDs below.
 runs_page="$(gh api \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
@@ -492,6 +593,10 @@ if ! jq -e '
   fail "The CLA workflow returned malformed pull request associations"
 fi
 
+# Keep the run-binding predicate inline in each snapshot check below. These
+# jq programs consume independently fetched API responses; sharing a mutable
+# transformed result would make a later TOCTOU recheck look authoritative when
+# it is only a copy of the earlier response.
 if ! candidate_list_json="$(jq -c \
     --arg path "${WORKFLOW_PATH}" \
     --arg event "${TARGET_EVENT}" \
@@ -502,6 +607,7 @@ if ! candidate_list_json="$(jq -c \
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
     --argjson repo_id "${repo_id}" \
+    --argjson source_check_bindings "${source_check_bindings_json}" \
     --arg base "${TARGET_BASE_REF}" \
     --arg head_ref "${head_ref}" \
     --arg before "${COMMENT_CREATED_AT}" '
@@ -512,8 +618,8 @@ if ! candidate_list_json="$(jq -c \
            else null end) as $prs
         | if $prs == null then false
           elif ($prs | length) == 0 then
-            .head_sha == $sha and
-            .head_branch == $head_ref and
+            (.id | tostring) as $run_id
+            | .head_branch == $head_ref and
             (
               ((.head_repository | type) == "object" and
                .head_repository.full_name == $head_repo and
@@ -523,9 +629,12 @@ if ! candidate_list_json="$(jq -c \
                $head_repo == $repo and
                $head_repo_id == $repo_id)
             )
-            # Empty associations are eligible only for the exact current
-            # source SHA. A base or merge SHA must never shadow an older
-            # eligible run for this pull request.
+            and
+            (
+              .head_sha == $sha or
+              ($head_repo != $repo and
+               any($source_check_bindings[]?; .run_id == $run_id))
+            )
           else any($prs[]?;
             (.number | type == "number") and
             (.number | tostring) == $pr and
@@ -586,9 +695,11 @@ if [[ "${candidate_count}" == "0" ]]; then
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
     --argjson repo_id "${repo_id}" \
+    --argjson source_check_bindings "${source_check_bindings_json}" \
     --arg head_ref "${head_ref}" \
     --arg before "${COMMENT_CREATED_AT}" \
     '[ .[] | .workflow_runs[]?
+      | (.id | tostring) as $run_id
       | select(
           (.path == $path or
            ((.path | startswith($path + "@")) and
@@ -617,7 +728,9 @@ if [[ "${candidate_count}" == "0" ]]; then
             (.head_repository == null and
              $head_repo == $repo and
              $head_repo_id == $repo_id)
-          )
+          ) and
+          (($head_repo != $repo and
+            any($source_check_bindings[]?; .run_id == $run_id)) | not)
         )
     ] | length' <<<"${runs_json}")"
   [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
@@ -640,6 +753,7 @@ if [[ "${candidate_count}" == "0" ]]; then
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
     --argjson repo_id "${repo_id}" \
+    --argjson source_check_bindings "${source_check_bindings_json}" \
     --arg base "${TARGET_BASE_REF}" \
     --arg before "${COMMENT_CREATED_AT}" \
     'def run_binds_to_pr:
@@ -649,8 +763,8 @@ if [[ "${candidate_count}" == "0" ]]; then
           else null end) as $prs
        | if $prs == null then false
          elif ($prs | length) == 0 then
-           .head_sha == $sha and
-           .head_branch == $head_ref and
+           (.id | tostring) as $run_id
+           | .head_branch == $head_ref and
            (
              ((.head_repository | type) == "object" and
               .head_repository.full_name == $head_repo and
@@ -659,6 +773,12 @@ if [[ "${candidate_count}" == "0" ]]; then
              (.head_repository == null and
               $head_repo == $repo and
               $head_repo_id == $repo_id)
+           )
+           and
+           (
+             .head_sha == $sha or
+             ($head_repo != $repo and
+              any($source_check_bindings[]?; .run_id == $run_id))
            )
          else any($prs[]?;
            (.number | type == "number") and
@@ -716,14 +836,15 @@ run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
 [[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
 
 # A run with a populated pull_requests array already carries an
-# authenticated source-PR association. Some GitHub API responses
-# omit that array, so prove a differing execution SHA through the
-# commit association endpoint before allowing the fallback. A bare
-# branch/repository match is not enough because a branch can be
-# reused after a push.
+# authenticated source-PR association. Some GitHub API responses omit that
+# array. For those responses, a source execution SHA is preferred; a fork run
+# with a different execution SHA is accepted only when its failed CLA check is
+# independently attached to the live source SHA. A bare branch/repository
+# match is never enough because a branch can be reused after a push.
 validate_run_source_binding() {
   local run_payload="$1"
   local execution_sha pull_requests_type pull_request_count
+  run_has_pull_request_association=false
   execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
   [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
   pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
@@ -734,12 +855,15 @@ validate_run_source_binding() {
   esac
   [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
   if (( pull_request_count == 0 )); then
-    # GitHub may omit pull_requests on a pull_request_target run. Without an
-    # authenticated PR object, accept only the source-head form. A base or
-    # merge execution SHA cannot be proved to belong to this PR, so fail
-    # closed instead of querying commit associations that may describe an
-    # ancestor or another pull request.
-    [[ "${execution_sha}" == "${head_sha}" ]] || fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+    if [[ "${execution_sha}" == "${head_sha}" ]]; then
+      return 0
+    fi
+    [[ "${head_repo}" != "${GH_REPO}" ]] ||
+      fail "The base-repository workflow run has no pull request association"
+    source_check_binding_for_run "${run_id}" ||
+      fail "The fork workflow run has no check bound to the current pull request head"
+  else
+    run_has_pull_request_association=true
   fi
 }
 
@@ -757,6 +881,7 @@ jq -e \
   --arg repo "${GH_REPO}" \
   --arg head_repo "${head_repo}" \
   --argjson head_repo_id "${head_repo_id}" \
+  --argjson source_check_bindings "${source_check_bindings_json}" \
   --argjson repo_id "${repo_id}" \
   --arg head_ref "${head_ref}" \
   --arg workflow_id "${workflow_id}" \
@@ -769,7 +894,8 @@ jq -e \
          else null end) as $prs
       | if $prs == null then false
         elif ($prs | length) == 0 then
-          .head_branch == $head_ref and
+          (.id | tostring) as $run_id
+          | .head_branch == $head_ref and
           (
             ((.head_repository | type) == "object" and
              .head_repository.full_name == $head_repo and
@@ -778,6 +904,12 @@ jq -e \
             (.head_repository == null and
              $head_repo == $repo and
              $head_repo_id == $repo_id)
+          )
+          and
+          (
+            .head_sha == $sha or
+            ($head_repo != $repo and
+             any($source_check_bindings[]?; .run_id == $run_id))
           )
         else any($prs[]?;
           (.number | type == "number") and
@@ -811,6 +943,26 @@ jq -e \
   ' <<<"${run_json}" >/dev/null || fail "The selected run no longer matches the exact failed CLA check"
 validate_run_source_binding "${run_json}"
 
+# Jobs expose the source head even on GitHub responses where the parent run's
+# execution SHA is the base revision. Use that exact source SHA for every job
+# identity check in the fallback path; the run itself remains bound to its
+# immutable execution SHA above.
+run_job_sha="${run_execution_sha}"
+source_sha_fallback=false
+if [[ "${run_execution_sha}" != "${head_sha}" ]]; then
+  run_job_sha="${head_sha}"
+  if [[ "${run_has_pull_request_association}" == true ]]; then
+    # A populated pull_requests association is the authenticated source
+    # binding. GitHub can expose either the source or execution SHA on jobs;
+    # use the source form for the PR-facing check without requiring a second
+    # check-run lookup.
+    source_sha_fallback=false
+  else
+    source_check_binding_for_run "${run_id}" || fail "The selected fork workflow run is not bound to the current pull request head"
+    source_sha_fallback=true
+  fi
+fi
+
 # Close the main TOCTOU window. A push, close, or another rerun can
 # happen while the API calls above run. Never rerun a stale head.
 latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
@@ -840,6 +992,7 @@ jq -e \
   --arg repo "${GH_REPO}" \
   --arg head_repo "${head_repo}" \
   --argjson head_repo_id "${head_repo_id}" \
+  --argjson source_check_bindings "${source_check_bindings_json}" \
   --argjson repo_id "${repo_id}" \
   --arg head_ref "${head_ref}" \
   --arg workflow_id "${workflow_id}" \
@@ -853,7 +1006,8 @@ jq -e \
          else null end) as $prs
       | if $prs == null then false
         elif ($prs | length) == 0 then
-          .head_branch == $head_ref and
+          (.id | tostring) as $run_id
+          | .head_branch == $head_ref and
           (
             ((.head_repository | type) == "object" and
              .head_repository.full_name == $head_repo and
@@ -862,6 +1016,12 @@ jq -e \
             (.head_repository == null and
              $head_repo == $repo and
              $head_repo_id == $repo_id)
+          )
+          and
+          (
+            .head_sha == $sha or
+            ($head_repo != $repo and
+             any($source_check_bindings[]?; .run_id == $run_id))
           )
         else any($prs[]?;
           (.number | type == "number") and
@@ -978,7 +1138,7 @@ validate_failed_job_set() {
       '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
      ! assistant_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
-       --arg run_sha "${run_execution_sha}" \
+       --arg run_sha "${run_job_sha}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
        --arg assistant_job "${CLA_ASSISTANT_JOB}" \
@@ -1009,7 +1169,7 @@ validate_failed_job_set() {
       '[.[] | select(.name == $writer_job)] | length' <<<"${failed_jobs_json}")" ||
      ! writer_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
-       --arg run_sha "${run_execution_sha}" \
+       --arg run_sha "${run_job_sha}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
        --arg writer_job "${CLA_WRITER_JOB}" \
@@ -1033,7 +1193,7 @@ validate_failed_job_set() {
   compatibility_count="$(jq -r --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" '[.[] | select(.name == $compatibility_job)] | length' <<<"${failed_jobs_json}")"
   if ! compatibility_valid_count="$(jq -r \
       --arg run_id "${run_id}" \
-      --arg run_sha "${run_execution_sha}" \
+      --arg run_sha "${run_job_sha}" \
       --arg head_repo "${head_repo}" \
       --argjson head_repo_id "${head_repo_id}" \
       --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
@@ -1062,7 +1222,7 @@ validate_failed_job_set() {
 validate_failed_job_set "${jobs_json}"
 if ! cla_job_json="$(jq -c \
     --arg run_id "${run_id}" \
-    --arg run_sha "${run_execution_sha}" \
+    --arg run_sha "${run_job_sha}" \
     --arg assistant_job "${CLA_ASSISTANT_JOB}" \
     --arg generation_step "CLA generation ${CLA_GENERATION}" \
     --arg head_repo "${head_repo}" \
@@ -1098,6 +1258,10 @@ if [[ -z "${cla_job_json}" ]]; then
 fi
 job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
 safe_id "${job_id}" || fail "The selected CLA job ID is invalid or unsafe"
+if [[ "${source_sha_fallback}" == true ]]; then
+  source_check_binding_for_job "${run_id}" "${job_id}" ||
+    fail "The selected CLA job is not the job bound to the current pull request head"
+fi
 
 # Re-read the individual job. The jobs list is discovery only, just
 # like the workflow-run list above.
@@ -1105,7 +1269,7 @@ job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fa
 jq -e \
   --arg job_id "${job_id}" \
   --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
+  --arg run_sha "${run_job_sha}" \
   --arg assistant_job "${CLA_ASSISTANT_JOB}" \
   --arg generation_step "CLA generation ${CLA_GENERATION}" \
   --arg head_repo "${head_repo}" \
@@ -1150,7 +1314,7 @@ final_job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)"
 jq -e \
   --arg job_id "${job_id}" \
   --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
+  --arg run_sha "${run_job_sha}" \
   --arg assistant_job "${CLA_ASSISTANT_JOB}" \
   --arg generation_step "CLA generation ${CLA_GENERATION}" \
   --arg head_repo "${head_repo}" \
@@ -1173,7 +1337,11 @@ jq -e \
       .name == $generation_step and
       .status == "completed"
     )
-  ' <<<"${final_job_json}" >/dev/null || fail "The exact failed CLA Assistant v3 job is no longer eligible"
+' <<<"${final_job_json}" >/dev/null || fail "The exact failed CLA Assistant v3 job is no longer eligible"
+if [[ "${source_sha_fallback}" == true ]]; then
+  source_check_binding_for_job "${run_id}" "${job_id}" ||
+    fail "The selected CLA job is no longer bound to the current pull request head"
+fi
 
 # Re-fetch the whole job set immediately before the state-changing call. This
 # catches a newly cancelled or unrelated failed job that could otherwise be
@@ -1182,7 +1350,7 @@ final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck a
 validate_failed_job_set "${final_jobs_json}"
 final_job_id="$(jq -r \
   --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
+  --arg run_sha "${run_job_sha}" \
   --arg assistant_job "${CLA_ASSISTANT_JOB}" \
   --arg generation_step "CLA generation ${CLA_GENERATION}" \
   --arg head_repo "${head_repo}" \
@@ -1228,6 +1396,13 @@ fi
 # immediately before the Actions mutation. The API cannot provide a
 # transaction, so this is the narrowest practical final race window.
 validate_live_open_head_association
+if [[ "${source_sha_fallback}" == true ]]; then
+  # Re-read the source check immediately before the mutation. This keeps the
+  # run/job binding from becoming stale while the PR and job checks execute.
+  refresh_source_check_bindings
+  source_check_binding_for_job "${run_id}" "${job_id}" ||
+    fail "The selected CLA job is no longer bound to the current pull request head"
+fi
 
 if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
   rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -13,22 +13,43 @@ readonly MAX_API_RESPONSE_BYTES=8000000
 
 # Every GitHub API response is bounded before a caller parses it. The helper
 # still applies endpoint-specific page and object limits below; this shared
-# cap rejects an unexpectedly large response before it reaches jq.
+# cap limits the bytes retained before the response reaches jq.
 gh_api() {
-  local response response_bytes
-  if ! response="$(command gh api "$@")"; then
-    return 1
+  local response_file response_bytes command_status
+  response_file="$(mktemp)" || return 1
+  # Keep reading after the retained prefix so gh can report its real exit
+  # status without a SIGPIPE. Only MAX+1 bytes are written to disk; the extra
+  # byte lets the size check distinguish an exact-limit response from an
+  # oversized one without buffering the complete body in shell memory.
+  if command gh api "$@" |
+    { head -c "$((MAX_API_RESPONSE_BYTES + 1))"; cat >/dev/null; } >"${response_file}"; then
+    command_status=0
+  else
+    command_status=$?
   fi
-  response_bytes="$(printf '%s' "${response}" | wc -c | tr -d '[:space:]')" || return 1
+  if (( command_status != 0 )); then
+    rm -f -- "${response_file}"
+    return "${command_status}"
+  fi
+  response_bytes="$(wc -c <"${response_file}" | tr -d '[:space:]')" || {
+    rm -f -- "${response_file}"
+    return 1
+  }
   [[ "${response_bytes}" =~ ^[0-9]+$ ]] || {
+    rm -f -- "${response_file}"
     echo "GitHub API response size is invalid" >&2
     return 1
   }
   (( response_bytes <= MAX_API_RESPONSE_BYTES )) || {
+    rm -f -- "${response_file}"
     echo "GitHub API response exceeds ${MAX_API_RESPONSE_BYTES} bytes" >&2
     return 1
   }
-  printf '%s' "${response}"
+  if ! cat -- "${response_file}"; then
+    rm -f -- "${response_file}"
+    return 1
+  fi
+  rm -f -- "${response_file}"
 }
 
 safe_id() {

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -529,6 +529,7 @@ if ! candidate_list_json="$(jq -c \
           else any($prs[]?;
             (.number | type == "number") and
             (.number | tostring) == $pr and
+            .base.ref == $base and
             ((.base.repo.full_name // "") == "" or
              .base.repo.full_name == $repo) and
             (.base.repo.id | type == "number") and

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -778,7 +778,9 @@ classify_workflow_runs_snapshot() {
                 ($head_repo != $repo and
                  any($source_check_bindings[]?; .run_id == $run_id))
               )
-            else any($prs[]?;
+            else
+              (.id | tostring) as $run_id
+              | any($prs[]?;
               (.number | type == "number") and
               (.number | tostring) == $pr and
               .base.ref == $base and
@@ -787,7 +789,9 @@ classify_workflow_runs_snapshot() {
               (.base.repo.id | type == "number") and
               .base.repo.id == $repo_id and
               .head.ref == $head_ref and
-              .head.sha == $sha and
+              (.head.sha == $sha or
+               ($head_repo != $repo and
+                any($source_check_bindings[]?; .run_id == $run_id))) and
               (.head.repo.id | type == "number") and
               .head.repo.id == $head_repo_id and
               ((.head.repo.full_name // "") == "" or
@@ -965,7 +969,9 @@ if [[ "${candidate_count}" == "0" ]]; then
              ($head_repo != $repo and
               any($source_check_bindings[]?; .run_id == $run_id))
            )
-         else any($prs[]?;
+         else
+           (.id | tostring) as $run_id
+           | any($prs[]?;
            (.number | type == "number") and
            (.number | tostring) == $pr and
            .base.ref == $base and
@@ -974,7 +980,9 @@ if [[ "${candidate_count}" == "0" ]]; then
            (.base.repo.id | type == "number") and
            .base.repo.id == $repo_id and
            .head.ref == $head_ref and
-           .head.sha == $sha and
+           (.head.sha == $sha or
+            ($head_repo != $repo and
+             any($source_check_bindings[]?; .run_id == $run_id))) and
            (.head.repo.id | type == "number") and
            .head.repo.id == $head_repo_id and
            ((.head.repo.full_name // "") == "" or
@@ -1096,7 +1104,9 @@ jq -e \
             ($head_repo != $repo and
              any($source_check_bindings[]?; .run_id == $run_id))
           )
-        else any($prs[]?;
+        else
+          (.id | tostring) as $run_id
+          | any($prs[]?;
           (.number | type == "number") and
           (.number | tostring) == $pr and
           .base.ref == $base and
@@ -1105,7 +1115,9 @@ jq -e \
           (.base.repo.id | type == "number") and
           .base.repo.id == $repo_id and
           .head.ref == $head_ref and
-          .head.sha == $sha and
+          (.head.sha == $sha or
+           ($head_repo != $repo and
+            any($source_check_bindings[]?; .run_id == $run_id))) and
           (.head.repo.id | type == "number") and
           .head.repo.id == $head_repo_id and
           ((.head.repo.full_name // "") == "" or
@@ -1128,22 +1140,23 @@ jq -e \
   ' <<<"${run_json}" >/dev/null || fail "The selected run no longer matches the exact failed CLA check"
 validate_run_source_binding "${run_json}"
 
-# Jobs expose the source head even on GitHub responses where the parent run's
-# execution SHA is the base revision. Use that exact source SHA for every job
-# identity check in the fallback path; the run itself remains bound to its
-# immutable execution SHA above.
+# Jobs can expose either the source head or the pull_request_target execution
+# SHA. Keep both authenticated values available for job identity checks. The
+# source-check binding remains mandatory when the parent run has no populated
+# pull request association.
 set_run_job_binding() {
   run_job_sha="${1}"
+  run_job_sha_alt="${head_sha}"
   source_sha_fallback=false
   if [[ "${1}" != "${head_sha}" ]]; then
-    run_job_sha="${head_sha}"
     if [[ "${run_has_pull_request_association}" == true ]]; then
       # A populated pull_requests association is the authenticated source
       # binding. GitHub can expose either the source or execution SHA on jobs;
-      # use the source form for the PR-facing check without requiring a second
-      # check-run lookup.
+      # accept both forms without requiring a second check-run lookup.
       return 0
     fi
+    run_job_sha="${head_sha}"
+    run_job_sha_alt="${head_sha}"
     source_check_binding_for_run "${run_id}" || fail "The selected fork workflow run is not bound to the current pull request head"
     source_sha_fallback=true
   fi
@@ -1210,7 +1223,9 @@ jq -e \
             ($head_repo != $repo and
              any($source_check_bindings[]?; .run_id == $run_id))
           )
-        else any($prs[]?;
+        else
+          (.id | tostring) as $run_id
+          | any($prs[]?;
           (.number | type == "number") and
           (.number | tostring) == $pr and
           .base.ref == $base and
@@ -1219,7 +1234,9 @@ jq -e \
           (.base.repo.id | type == "number") and
           .base.repo.id == $repo_id and
           .head.ref == $head_ref and
-          .head.sha == $sha and
+          (.head.sha == $sha or
+           ($head_repo != $repo and
+            any($source_check_bindings[]?; .run_id == $run_id))) and
           (.head.repo.id | type == "number") and
           .head.repo.id == $head_repo_id and
           ((.head.repo.full_name // "") == "" or
@@ -1296,6 +1313,7 @@ validate_failed_job_set() {
      ! assistant_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
        --arg run_sha "${run_job_sha}" \
+       --arg source_sha "${run_job_sha_alt}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
        --arg assistant_job "${CLA_ASSISTANT_JOB}" \
@@ -1304,7 +1322,7 @@ validate_failed_job_set() {
           .name == $assistant_job and
           .run_id == ($run_id | tonumber) and
           (.head_sha | type == "string") and
-          .head_sha == $run_sha and
+          (.head_sha == $run_sha or .head_sha == $source_sha) and
           ((has("head_repository") | not) or
            (.head_repository == null or
             ((.head_repository | type) == "object" and
@@ -1327,6 +1345,7 @@ validate_failed_job_set() {
      ! writer_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
        --arg run_sha "${run_job_sha}" \
+       --arg source_sha "${run_job_sha_alt}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
        --arg writer_job "${CLA_WRITER_JOB}" \
@@ -1334,7 +1353,7 @@ validate_failed_job_set() {
           .name == $writer_job and
           .run_id == ($run_id | tonumber) and
           (.head_sha | type == "string") and
-          .head_sha == $run_sha and
+          (.head_sha == $run_sha or .head_sha == $source_sha) and
           ((has("head_repository") | not) or
            (.head_repository == null or
             ((.head_repository | type) == "object" and
@@ -1351,6 +1370,7 @@ validate_failed_job_set() {
   if ! compatibility_valid_count="$(jq -r \
       --arg run_id "${run_id}" \
       --arg run_sha "${run_job_sha}" \
+      --arg source_sha "${run_job_sha_alt}" \
       --arg head_repo "${head_repo}" \
       --argjson head_repo_id "${head_repo_id}" \
       --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
@@ -1358,7 +1378,7 @@ validate_failed_job_set() {
          .name == $compatibility_job and
          .run_id == ($run_id | tonumber) and
          (.head_sha | type == "string") and
-         .head_sha == $run_sha and
+         (.head_sha == $run_sha or .head_sha == $source_sha) and
          ((has("head_repository") | not) or
           (.head_repository == null or
            ((.head_repository | type) == "object" and
@@ -1380,6 +1400,7 @@ validate_failed_job_set "${jobs_json}"
 if ! cla_job_json="$(jq -c \
     --arg run_id "${run_id}" \
     --arg run_sha "${run_job_sha}" \
+    --arg source_sha "${run_job_sha_alt}" \
     --arg assistant_job "${CLA_ASSISTANT_JOB}" \
     --arg generation_step "CLA generation ${CLA_GENERATION}" \
     --arg head_repo "${head_repo}" \
@@ -1391,7 +1412,7 @@ if ! cla_job_json="$(jq -c \
           .status == "completed" and
           .conclusion == "failure" and
           (.head_sha | type == "string") and
-          .head_sha == $run_sha and
+          (.head_sha == $run_sha or .head_sha == $source_sha) and
           (
             .head_repository == null or
             (.head_repository.full_name == $head_repo and
@@ -1427,6 +1448,7 @@ jq -e \
   --arg job_id "${job_id}" \
   --arg run_id "${run_id}" \
   --arg run_sha "${run_job_sha}" \
+  --arg source_sha "${run_job_sha_alt}" \
   --arg assistant_job "${CLA_ASSISTANT_JOB}" \
   --arg generation_step "CLA generation ${CLA_GENERATION}" \
   --arg head_repo "${head_repo}" \
@@ -1437,7 +1459,7 @@ jq -e \
     .status == "completed" and
     .conclusion == "failure" and
     (.head_sha | type == "string") and
-    .head_sha == $run_sha and
+    (.head_sha == $run_sha or .head_sha == $source_sha) and
     (
       (has("head_repository") | not) or
       .head_repository == null or
@@ -1472,6 +1494,7 @@ jq -e \
   --arg job_id "${job_id}" \
   --arg run_id "${run_id}" \
   --arg run_sha "${run_job_sha}" \
+  --arg source_sha "${run_job_sha_alt}" \
   --arg assistant_job "${CLA_ASSISTANT_JOB}" \
   --arg generation_step "CLA generation ${CLA_GENERATION}" \
   --arg head_repo "${head_repo}" \
@@ -1482,7 +1505,7 @@ jq -e \
     .status == "completed" and
     .conclusion == "failure" and
     (.head_sha | type == "string") and
-    .head_sha == $run_sha and
+    (.head_sha == $run_sha or .head_sha == $source_sha) and
     (
       (has("head_repository") | not) or
       .head_repository == null or
@@ -1508,6 +1531,7 @@ validate_failed_job_set "${final_jobs_json}"
 final_job_id="$(jq -r \
   --arg run_id "${run_id}" \
   --arg run_sha "${run_job_sha}" \
+  --arg source_sha "${run_job_sha_alt}" \
   --arg assistant_job "${CLA_ASSISTANT_JOB}" \
   --arg generation_step "CLA generation ${CLA_GENERATION}" \
   --arg head_repo "${head_repo}" \
@@ -1518,7 +1542,7 @@ final_job_id="$(jq -r \
       .status == "completed" and
       .conclusion == "failure" and
       (.head_sha | type == "string") and
-      .head_sha == $run_sha and
+      (.head_sha == $run_sha or .head_sha == $source_sha) and
       ((has("head_repository") | not) or
        (.head_repository == null or
         ((.head_repository | type) == "object" and

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -13,14 +13,10 @@ readonly MAX_API_RESPONSE_BYTES=8000000
 
 # Every GitHub API response is bounded before a caller parses it. The helper
 # still applies endpoint-specific page and object limits below; this shared
-# cap prevents a malformed response from consuming unbounded shell memory.
-gh() {
+# cap rejects an unexpectedly large response before it reaches jq.
+gh_api() {
   local response response_bytes
-  if [[ "${1:-}" != "api" ]]; then
-    command gh "$@"
-    return
-  fi
-  if ! response="$(command gh "$@")"; then
+  if ! response="$(command gh api "$@")"; then
     return 1
   fi
   response_bytes="$(printf '%s' "${response}" | wc -c | tr -d '[:space:]')" || return 1
@@ -80,8 +76,10 @@ if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign 
 elif [[ "${CLA_PASSED}" != "true" ]]; then
   fail "The CLA action did not report cla_passed=true for the recheck"
 fi
-[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{40}$ ]] || fail "Invalid CLA generation marker"
 [[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
+[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{40}-workflow-[0-9a-f]{40}$ ]] || fail "Invalid CLA generation marker"
+generation_workflow_sha="${CLA_GENERATION##*-workflow-}"
+[[ "${generation_workflow_sha}" == "${WORKFLOW_SHA}" ]] || fail "CLA generation marker is for a different workflow revision"
 checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
 [[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
 [[ "${WORKFLOW_PATH}" == ".github/workflows/cla.yml" ]] || fail "Unexpected CLA workflow path"
@@ -131,7 +129,7 @@ source_check_binding_for_job() {
 
 validate_triggering_signature_record() {
   local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
-  ledger_response="$(gh api \
+  ledger_response="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field ref="${SIGNATURES_BRANCH}" \
@@ -186,7 +184,7 @@ validate_triggering_signature_record() {
      )' <<<"${ledger_json}" >/dev/null || fail "The signing comment was not the signature persisted by the CLA action"
 }
 
-issue_json="$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
+issue_json="$(gh_api "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
 issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
 issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
 [[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
@@ -194,7 +192,7 @@ issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
 
 validate_live_triggering_comment() {
   local comment_json comment_body_bytes
-  comment_json="$(gh api \
+  comment_json="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --header 'X-GitHub-Api-Version: 2022-11-28' \
@@ -241,7 +239,7 @@ validate_live_triggering_comment() {
 # stale event payload must never authorize a rerun of the failed check.
 validate_live_triggering_comment
 
-pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
+pr_json="$(gh_api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
   .number == $number and
   .state == "open" and
@@ -296,7 +294,7 @@ cleanup_commit_association_stderr() {
   rm -f -- "${commit_association_stderr_file}"
 }
 trap cleanup_commit_association_stderr EXIT
-if commit_prs_json="$(gh api \
+if commit_prs_json="$(gh_api \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field per_page=100 \
@@ -327,7 +325,7 @@ association_count="$(jq -r 'length' <<<"${commit_prs_json}")"
 [[ "${association_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations"
 (( association_count <= 100 )) || fail "The pull request association page is oversized"
 if (( association_count == 100 )); then
-  commit_prs_page2="$(gh api \
+  commit_prs_page2="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -375,7 +373,7 @@ validate_live_open_head_association() {
   head_owner="${head_repo%%/*}"
   head_name="${head_repo#*/}"
   [[ -n "${head_owner}" && -n "${head_name}" ]] || fail "The pull request head repository name is invalid"
-  open_prs_page="$(gh api \
+  open_prs_page="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field state=open \
@@ -389,7 +387,7 @@ validate_live_open_head_association() {
   [[ "${open_pr_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests"
   (( open_pr_count <= 100 )) || fail "The live open pull request page is oversized"
   if (( open_pr_count == 100 )); then
-    open_prs_page2="$(gh api \
+    open_prs_page2="$(gh_api \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field state=open \
@@ -456,7 +454,7 @@ refresh_source_check_bindings() {
   fi
 
   source_checks_error_file="$(mktemp)"
-  if source_checks_page="$(gh api \
+  if source_checks_page="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -480,7 +478,7 @@ refresh_source_check_bindings() {
   [[ "${source_check_count}" =~ ^[0-9]+$ ]] || fail "Could not count source check runs"
   (( source_check_count <= 100 )) || fail "The source check-run page is oversized"
   if (( source_check_count == 100 )); then
-    source_checks_page2="$(gh api \
+    source_checks_page2="$(gh_api \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field per_page=100 \
@@ -519,7 +517,7 @@ refresh_source_check_bindings() {
 }
 refresh_source_check_bindings
 
-workflow_page="$(gh api \
+workflow_page="$(gh_api \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field per_page=100 \
@@ -530,7 +528,7 @@ workflow_count="$(jq -r '.workflows | length' <<<"${workflow_page}")"
 [[ "${workflow_count}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows"
 (( workflow_count <= 100 )) || fail "The repository workflow page is oversized"
 if (( workflow_count == 100 )); then
-  workflow_page2="$(gh api \
+  workflow_page2="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -560,7 +558,7 @@ safe_id "${workflow_id}" || fail "The expected CLA workflow ID is missing or uns
 # candidates are retained when the execution SHA is the live source SHA, or
 # when a GitHub Actions check on that source SHA identifies the same run. A
 # selected assistant job must match that check's run and job IDs below.
-runs_page="$(gh api \
+runs_page="$(gh_api \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field event="${TARGET_EVENT}" \
@@ -587,7 +585,7 @@ runs_json="$(jq -c '[.]' <<<"${runs_page}")"
 page_count="${run_count}"
 page_number=2
 while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
-  next_runs_page="$(gh api \
+  next_runs_page="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field event="${TARGET_EVENT}" \
@@ -894,7 +892,7 @@ validate_run_source_binding() {
 
 # Re-read the individual run. The list response is only a discovery
 # result, not authorization to rerun it.
-run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
+run_json="$(gh_api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
 jq -e \
   --arg run_id "${run_id}" \
   --arg path "${WORKFLOW_PATH}" \
@@ -992,7 +990,7 @@ set_run_job_binding "${run_execution_sha}"
 
 # Close the main TOCTOU window. A push, close, or another rerun can
 # happen while the API calls above run. Never rerun a stale head.
-latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
+latest_pr_json="$(gh_api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" --argjson opener_id "${pr_author_id}" '
   .number == $number and
   .state == "open" and
@@ -1008,7 +1006,7 @@ jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_
 ' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA run"
 
 # Ensure another queued invocation did not already rerun this run.
-final_run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
+final_run_json="$(gh_api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
 jq -e \
   --arg path "${WORKFLOW_PATH}" \
   --arg event "${TARGET_EVENT}" \
@@ -1099,23 +1097,23 @@ set_run_job_binding "${run_execution_sha}"
 fetch_jobs_for_run() {
   local target_run_id="$1"
   local page_json page_count page2_json page2_count
-  page_json="$(gh api \
+  page_json="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
     --raw-field page=1 \
-    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs")" || return 1
   jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page_json}" >/dev/null || return 1
   page_count="$(jq -r '.jobs | length' <<<"${page_json}")"
   [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
   (( page_count <= 100 )) || return 1
   if (( page_count == 100 )); then
-    page2_json="$(gh api \
+    page2_json="$(gh_api \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field per_page=100 \
       --raw-field page=2 \
-      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs")" || return 1
     jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page2_json}" >/dev/null || return 1
     page2_count="$(jq -r '.jobs | length' <<<"${page2_json}")"
     [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
@@ -1299,7 +1297,7 @@ fi
 
 # Re-read the individual job. The jobs list is discovery only, just
 # like the workflow-run list above.
-job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA Assistant v3 job"
+job_json="$(gh_api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA Assistant v3 job"
 jq -e \
   --arg job_id "${job_id}" \
   --arg run_id "${run_id}" \
@@ -1331,7 +1329,7 @@ jq -e \
 # Recheck both resources immediately before the state-changing call.
 # This prevents a push or a concurrent rerun from making the job
 # stale while the preceding API requests were in flight.
-latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+latest_pr_json="$(gh_api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
   .number == $number and
   .state == "open" and
@@ -1344,7 +1342,7 @@ jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_
   .head.repo.id == $head_repo_id and
   .user.login == $opener
 ' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA job"
-final_job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
+final_job_json="$(gh_api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
 jq -e \
   --arg job_id "${job_id}" \
   --arg run_id "${run_id}" \
@@ -1445,7 +1443,7 @@ else
   rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
   rerun_description="CLA job ${job_id}"
 fi
-if ! gh api \
+if ! gh_api \
   --method POST \
   --header 'Accept: application/vnd.github+json' \
   --header 'X-GitHub-Api-Version: 2022-11-28' \

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -112,6 +112,7 @@ checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify th
 readonly SIGNATURES_BRANCH='cla-signatures'
 readonly SIGNATURES_PATH='signatures/version2/cla.json'
 readonly MAX_RUN_PAGES=10
+readonly MAX_SUCCESS_RUNS_TO_VALIDATE=50
 readonly MAX_LEDGER_BYTES=1000000
 readonly MAX_LEDGER_SIGNATURES=10000
 # GitHub wraps Contents API Base64 responses with newlines. Allow that
@@ -460,6 +461,118 @@ validate_live_open_head_association() {
 }
 validate_live_open_head_association
 
+# Fetch the complete bounded job set for one exact run. The rerun endpoint
+# requires actions:write, so discovery must fail closed if pagination or shape
+# checks cannot prove that every failed job belongs to this CLA workflow.
+# The workflow-run response is authoritative for workflow name, head branch,
+# and source repository. GitHub's jobs endpoint does not document those fields
+# and omits them in production, so job validation uses only its documented
+# identity fields, plus optional source metadata when GitHub supplies it.
+fetch_jobs_for_run() {
+  local target_run_id="$1"
+  local page_json page_count page2_json page2_count
+  page_json="$(gh_api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs")" || return 1
+  jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page_json}" >/dev/null || return 1
+  page_count="$(jq -r '.jobs | length' <<<"${page_json}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2_json="$(gh_api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs")" || return 1
+    jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page2_json}" >/dev/null || return 1
+    page2_count="$(jq -r '.jobs | length' <<<"${page2_json}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    page_json="$(jq -c --argjson page2 "${page2_json}" '.jobs += $page2.jobs' <<<"${page_json}")"
+    (( page2_count < 100 )) || return 1
+  fi
+  jq -c '[.]' <<<"${page_json}"
+}
+
+# A successful run may only suppress an older failure when its required v3
+# job carries this workflow generation marker. Workflow IDs stay constant
+# across edits, so the job marker is the authenticated revision binding.
+current_generation_success_run_ids='[]'
+refresh_current_generation_successes() {
+  local bound_runs="$1"
+  local success_runs_json success_count success_runs_tsv
+  local success_id success_run_sha success_jobs_json
+
+  success_runs_json="$(jq -c '
+    . as $runs
+    | [
+        $runs[] as $success
+        | select(
+            $success.conclusion == "success" and
+            any($runs[]?;
+              .conclusion == "failure" and
+              (
+                .created_at < $success.created_at or
+                (.created_at == $success.created_at and .id < $success.id)
+              )
+            )
+          )
+        | {id: $success.id, head_sha: $success.head_sha}
+      ]
+    | unique_by(.id)
+  ' <<<"${bound_runs}")" || fail "Could not identify successful CLA workflow runs"
+  success_count="$(jq -r 'length' <<<"${success_runs_json}")"
+  [[ "${success_count}" =~ ^[0-9]+$ ]] || fail "Could not count successful CLA workflow runs"
+  (( success_count <= MAX_SUCCESS_RUNS_TO_VALIDATE )) ||
+    fail "Too many successful CLA workflow runs need generation validation; ask an administrator to resolve the workflow history before requesting a rerun"
+
+  current_generation_success_run_ids='[]'
+  success_runs_tsv="$(jq -r '.[] | [.id, .head_sha] | @tsv' <<<"${success_runs_json}")" ||
+    fail "Could not prepare successful CLA workflow runs"
+  while IFS=$'\t' read -r success_id success_run_sha; do
+    [[ -n "${success_id}" ]] || continue
+    safe_id "${success_id}" || fail "A successful CLA workflow run ID is invalid or unsafe"
+    [[ "${success_run_sha}" =~ ^[0-9a-f]{40}$ ]] ||
+      fail "A successful CLA workflow run execution SHA is invalid"
+    success_jobs_json="$(fetch_jobs_for_run "${success_id}")" ||
+      fail "Could not query jobs for successful CLA workflow run ${success_id}"
+    if jq -e \
+      --arg run_id "${success_id}" \
+      --arg source_sha "${head_sha}" \
+      --arg run_sha "${success_run_sha}" \
+      --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+      --arg generation_step "CLA generation ${CLA_GENERATION}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" '
+        any(.[] | .jobs[]?;
+          (.run_id | type == "number" and floor == . and . == ($run_id | tonumber)) and
+          .name == $assistant_job and
+          .status == "completed" and
+          .conclusion == "success" and
+          (.head_sha | type == "string") and
+          (.head_sha == $source_sha or .head_sha == $run_sha) and
+          (
+            (has("head_repository") | not) or
+            .head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)
+          ) and
+          any(.steps[]?;
+            .name == $generation_step and
+            .status == "completed"
+          )
+        )
+      ' <<<"${success_jobs_json}" >/dev/null; then
+      current_generation_success_run_ids="$(jq -c --arg id "${success_id}" '. + [$id]' <<<"${current_generation_success_run_ids}")"
+    fi
+  done <<<"${success_runs_tsv}"
+}
+
 # The REST workflow-run API can omit `pull_requests` for a fork. Most runs
 # still expose the source SHA in `head_sha`; when they do not, bind the run and
 # selected job to a failed CLA check that GitHub attached to this exact source
@@ -567,181 +680,181 @@ workflow_json="$(jq -c '[.]' <<<"${workflow_page}")"
 workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | select(.path == $path and .state == "active") | .id] | if length == 1 then .[0] else empty end' <<<"${workflow_json}")"
 safe_id "${workflow_id}" || fail "The expected CLA workflow ID is missing or unsafe"
 
-# Search a bounded first page, then choose the newest completed
-# failure created no later than this comment. Edited, reopened, and
-# synchronize events can leave several eligible failures for one
-# exact head, so sort by creation time and run ID and select the
-# newest one. Every candidate is tied to the exact workflow path,
-# event, and PR association. When GitHub includes pull_requests on a
-# run, bind the candidate to the exact PR object, including its
-# source head SHA.
-# GitHub can return an empty array for fork pull_request_target runs. Those
-# candidates are retained when the execution SHA is the live source SHA, or
-# when a GitHub Actions check on that source SHA identifies the same run. A
-# selected assistant job must match that check's run and job IDs below.
-runs_page="$(gh_api \
-  --method GET \
-  --header 'Accept: application/vnd.github+json' \
-  --raw-field event="${TARGET_EVENT}" \
-  --raw-field branch="${head_ref}" \
-  --raw-field per_page=100 \
-  --raw-field page=1 \
-  "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs"
-jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${runs_page}" >/dev/null || fail "Could not validate CLA workflow runs"
-run_count="$(jq -r '.workflow_runs | length' <<<"${runs_page}")"
-[[ "${run_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs"
-(( run_count <= 100 )) || fail "The CLA workflow run page is oversized"
-runs_json="$(jq -c '[.]' <<<"${runs_page}")"
-
-# The API returns newest runs first. Probe additional bounded pages when the
-# first page is full, so normal workflow history growth does not strand a
-# failed check. GitHub documents a 1,000-result cap for filtered workflow-run
-# queries, so ten 100-item pages cover the complete API result window. Search
-# the complete bounded window before deciding whether it is full: a valid
-# candidate on page ten is still actionable. If the window is full and no
-# candidate matches, fail with an actionable message instead of pretending page
-# 11 can reveal an unreported run. `runs_json` stays an array of response
-# objects; the candidate query below flattens each `.workflow_runs` array
-# explicitly.
-page_count="${run_count}"
-page_number=2
-while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
-  next_runs_page="$(gh_api \
+# Fetch a complete, independently bounded workflow-run snapshot. The helper is
+# called once for discovery and again immediately before the mutation. Keeping
+# pagination here avoids a final check accidentally reading only the first page.
+fetch_workflow_runs_snapshot() {
+  local first_page first_count next_page page_count page_number
+  first_page="$(gh_api \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field event="${TARGET_EVENT}" \
     --raw-field branch="${head_ref}" \
     --raw-field per_page=100 \
-    --raw-field page="${page_number}" \
-    "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs page ${page_number}"
-  jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${next_runs_page}" >/dev/null || fail "Could not validate CLA workflow runs page ${page_number}"
-  page_count="$(jq -r '.workflow_runs | length' <<<"${next_runs_page}")"
-  [[ "${page_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs page ${page_number}"
-  (( page_count <= 100 )) || fail "The CLA workflow returned an oversized run page"
-  runs_json="$(jq -c --argjson next_page "${next_runs_page}" '. + [$next_page]' <<<"${runs_json}")"
-  (( page_number++ ))
-done
-run_window_full=false
-(( page_count == 100 )) && run_window_full=true
+    --raw-field page=1 \
+    "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${first_page}" >/dev/null || return 1
+  first_count="$(jq -r '.workflow_runs | length' <<<"${first_page}")"
+  [[ "${first_count}" =~ ^[0-9]+$ ]] || return 1
+  (( first_count <= 100 )) || return 1
+  runs_json="$(jq -c '[.]' <<<"${first_page}")" || return 1
 
-# `pull_requests` is optional for fork runs, but when GitHub sends it, the
-# field must keep its documented array shape. Treat a changed or malformed
-# response as an infrastructure error. Silently treating it as an unmatched
-# run could strand a required failed check with no recovery path.
-if ! jq -e '
-  all(.[] | .workflow_runs[]?;
-    (type == "object") and
-    (.pull_requests == null or (.pull_requests | type == "array"))
-  )
-' <<<"${runs_json}" >/dev/null; then
-  fail "The CLA workflow returned malformed pull request associations"
-fi
+  # GitHub documents a 1,000-result cap for filtered workflow-run queries.
+  # Ten 100-item pages cover the complete API result window. A full final page
+  # remains a deliberate fail-closed signal when no matching run is found.
+  page_count="${first_count}"
+  page_number=2
+  while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
+    next_page="$(gh_api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field event="${TARGET_EVENT}" \
+      --raw-field branch="${head_ref}" \
+      --raw-field per_page=100 \
+      --raw-field page="${page_number}" \
+      "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${next_page}" >/dev/null || return 1
+    page_count="$(jq -r '.workflow_runs | length' <<<"${next_page}")"
+    [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page_count <= 100 )) || return 1
+    runs_json="$(jq -c --argjson next_page "${next_page}" '. + [$next_page]' <<<"${runs_json}")" || return 1
+    (( page_number++ ))
+  done
+  run_window_full=false
+  (( page_count == 100 )) && run_window_full=true
 
-# Keep the run-binding predicate inline in each snapshot check below. These
-# jq programs consume independently fetched API responses; sharing a mutable
-# transformed result would make a later TOCTOU recheck look authoritative when
-# it is only a copy of the earlier response.
-#
-# Keep successful runs in the bounded candidate snapshot long enough to mark
-# an older failure as superseded. A later successful run for this exact PR
-# head means there is no failed CLA context left to refresh.
-if ! run_failure_candidates_json="$(jq -c \
-    --arg path "${WORKFLOW_PATH}" \
-    --arg event "${TARGET_EVENT}" \
-    --arg sha "${head_sha}" \
-    --arg workflow_id "${workflow_id}" \
-    --arg pr "${PR_NUMBER}" \
-    --arg repo "${GH_REPO}" \
-    --arg head_repo "${head_repo}" \
-    --argjson head_repo_id "${head_repo_id}" \
-    --argjson repo_id "${repo_id}" \
-    --argjson source_check_bindings "${source_check_bindings_json}" \
-    --arg base "${TARGET_BASE_REF}" \
-    --arg head_ref "${head_ref}" \
-    --arg before "${COMMENT_CREATED_AT}" '
-      def run_binds_to_pr:
-        (.pull_requests) as $raw_prs
-        | (if $raw_prs == null then []
-           elif ($raw_prs | type) == "array" then $raw_prs
-           else null end) as $prs
-        | if $prs == null then false
-          elif ($prs | length) == 0 then
-            (.id | tostring) as $run_id
-            | .head_branch == $head_ref and
-            (
-              ((.head_repository | type) == "object" and
-               .head_repository.full_name == $head_repo and
-               (.head_repository.id | type == "number") and
-               .head_repository.id == $head_repo_id) or
-              (.head_repository == null and
-               $head_repo == $repo and
-               $head_repo_id == $repo_id)
+  # `pull_requests` is optional for fork runs, but a present field must keep
+  # its documented array shape. Reject malformed objects instead of silently
+  # treating them as an unrelated run.
+  jq -e '
+    all(.[] | .workflow_runs[]?;
+      (type == "object") and
+      (.pull_requests == null or (.pull_requests | type == "array"))
+    )
+  ' <<<"${runs_json}" >/dev/null || return 1
+}
+
+# Classify one snapshot against the live PR. `before` is the comment timestamp
+# for initial discovery and empty for the final race check, which must include
+# a successful or in-progress run created after the comment.
+classify_workflow_runs_snapshot() {
+  local before="$1"
+  local snapshot="$2"
+  if ! all_bound_runs_json="$(jq -c \
+      --arg path "${WORKFLOW_PATH}" \
+      --arg event "${TARGET_EVENT}" \
+      --arg sha "${head_sha}" \
+      --arg workflow_id "${workflow_id}" \
+      --arg pr "${PR_NUMBER}" \
+      --arg repo "${GH_REPO}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      --argjson repo_id "${repo_id}" \
+      --argjson source_check_bindings "${source_check_bindings_json}" \
+      --arg base "${TARGET_BASE_REF}" \
+      --arg head_ref "${head_ref}" \
+      --arg before "${before}" '
+        def run_binds_to_pr:
+          (.pull_requests) as $raw_prs
+          | (if $raw_prs == null then []
+             elif ($raw_prs | type) == "array" then $raw_prs
+             else null end) as $prs
+          | if $prs == null then false
+            elif ($prs | length) == 0 then
+              (.id | tostring) as $run_id
+              | .head_branch == $head_ref and
+              (
+                ((.head_repository | type) == "object" and
+                 .head_repository.full_name == $head_repo and
+                 (.head_repository.id | type == "number") and
+                 .head_repository.id == $head_repo_id) or
+                (.head_repository == null and
+                 $head_repo == $repo and
+                 $head_repo_id == $repo_id)
+              )
+              and
+              (
+                .head_sha == $sha or
+                ($head_repo != $repo and
+                 any($source_check_bindings[]?; .run_id == $run_id))
+              )
+            else any($prs[]?;
+              (.number | type == "number") and
+              (.number | tostring) == $pr and
+              .base.ref == $base and
+              ((.base.repo.full_name // "") == "" or
+               .base.repo.full_name == $repo) and
+              (.base.repo.id | type == "number") and
+              .base.repo.id == $repo_id and
+              .head.ref == $head_ref and
+              .head.sha == $sha and
+              (.head.repo.id | type == "number") and
+              .head.repo.id == $head_repo_id and
+              ((.head.repo.full_name // "") == "" or
+               .head.repo.full_name == $head_repo)
             )
-            and
-            (
-              .head_sha == $sha or
-              ($head_repo != $repo and
-               any($source_check_bindings[]?; .run_id == $run_id))
+            end;
+        [ .[] | .workflow_runs[]?
+          | select(
+              (.path == $path or
+              ((.path | startswith($path + "@")) and
+               ((.path | length) > (($path | length) + 1)))) and
+              .event == $event and
+              (.workflow_id | type == "number") and
+              .workflow_id == ($workflow_id | tonumber) and
+              (.head_sha | type == "string") and
+              (.head_sha | test("^[0-9a-f]{40}$")) and
+              (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
+              (.status | type == "string") and
+              (.conclusion == null or (.conclusion | type == "string")) and
+              (.created_at | type == "string") and
+              ($before == "" or .created_at <= $before) and
+              run_binds_to_pr
             )
-          else any($prs[]?;
-            (.number | type == "number") and
-            (.number | tostring) == $pr and
-            .base.ref == $base and
-            ((.base.repo.full_name // "") == "" or
-             .base.repo.full_name == $repo) and
-            (.base.repo.id | type == "number") and
-            .base.repo.id == $repo_id and
-            .head.ref == $head_ref and
-            .head.sha == $sha and
-            (.head.repo.id | type == "number") and
-            .head.repo.id == $head_repo_id and
-            ((.head.repo.full_name // "") == "" or
-             .head.repo.full_name == $head_repo)
-          )
-          end;
-      [ .[] | .workflow_runs[]?
-        | select(
-            (.path == $path or
-            ((.path | startswith($path + "@")) and
-             ((.path | length) > (($path | length) + 1)))) and
-            .event == $event and
-            (.workflow_id | type == "number") and
-            .workflow_id == ($workflow_id | tonumber) and
-            (.head_sha | type == "string") and
-            (.head_sha | test("^[0-9a-f]{40}$")) and
-            (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
-            .status == "completed" and
-            (.conclusion | type == "string") and
-            (.created_at | type == "string") and
-            .created_at <= $before and
-            run_binds_to_pr
-          )
-      ] as $bound_runs
+        ]
+        | sort_by([.created_at, .id])
+      ' <<<"${snapshot}")"; then
+    return 1
+  fi
+  if ! jq -e 'all(.[]; .status != "completed" or (.conclusion | type == "string"))' <<<"${all_bound_runs_json}" >/dev/null; then
+    return 1
+  fi
+  bound_runs_json="$(jq -c '[.[] | select(.status == "completed" and (.conclusion | type == "string"))]' <<<"${all_bound_runs_json}")" || return 1
+  active_bound_runs_json="$(jq -c '[.[] | select(.status != "completed")]' <<<"${all_bound_runs_json}")" || return 1
+  refresh_current_generation_successes "${bound_runs_json}"
+  run_failure_candidates_json="$(jq -c \
+    --argjson current_successes "${current_generation_success_run_ids}" '
+      . as $bound_runs
       | [
           $bound_runs[]
           | select(.conclusion == "failure")
           | . as $failed
           | . + {
               superseded: any($bound_runs[]?;
-                .conclusion == "success" and
-                (
-                  .created_at > $failed.created_at or
-                  (.created_at == $failed.created_at and .id > $failed.id)
-                )
+                . as $success
+                | $success.conclusion == "success" and
+                  any($current_successes[]?; . == ($success.id | tostring)) and
+                  (
+                    $success.created_at > $failed.created_at or
+                    ($success.created_at == $failed.created_at and $success.id > $failed.id)
+                  )
               )
             }
         ]
       | sort_by([.created_at, .id])
-    ' <<<"${runs_json}")"; then
-  fail "Could not validate CLA workflow run data"
-fi
-if ! candidate_list_json="$(jq -c '[.[] | select(.superseded != true)]' <<<"${run_failure_candidates_json}")"; then
-  fail "Could not filter superseded CLA workflow runs"
-fi
-superseded_failure_count="$(jq -r '[.[] | select(.superseded == true)] | length' <<<"${run_failure_candidates_json}")"
-[[ "${superseded_failure_count}" =~ ^[0-9]+$ ]] || fail "Could not count superseded CLA workflow runs"
-candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
-[[ "${candidate_count}" =~ ^[0-9]+$ ]] || fail "Could not count matching CLA workflow runs"
+    ' <<<"${bound_runs_json}")" || return 1
+  candidate_list_json="$(jq -c '[.[] | select(.superseded != true)]' <<<"${run_failure_candidates_json}")" || return 1
+  superseded_failure_count="$(jq -r '[.[] | select(.superseded == true)] | length' <<<"${run_failure_candidates_json}")"
+  [[ "${superseded_failure_count}" =~ ^[0-9]+$ ]] || return 1
+  candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
+  [[ "${candidate_count}" =~ ^[0-9]+$ ]] || return 1
+}
+
+# Search a bounded first page, then choose the newest completed failure created
+# no later than this comment. The final snapshot below intentionally omits the
+# timestamp so a newer successful or in-progress run cannot race the POST.
+fetch_workflow_runs_snapshot || fail "Could not query or validate CLA workflow runs"
+classify_workflow_runs_snapshot "${COMMENT_CREATED_AT}" "${runs_json}" || fail "Could not classify CLA workflow runs"
 if [[ "${candidate_count}" == "0" ]]; then
   # Do not silently treat a failed run with an empty association and a
   # different execution SHA as a successful no-op. It is not eligible for a
@@ -1136,43 +1249,6 @@ if [[ "${run_has_pull_request_association}" != true &&
 fi
 set_run_job_binding "${run_execution_sha}"
 
-# Fetch the complete bounded job set for one exact run. The rerun endpoint
-# requires actions:write, so discovery must fail closed if pagination or shape
-# checks cannot prove that every failed job belongs to this CLA workflow.
-# The workflow-run response is authoritative for workflow name, head branch,
-# and source repository. GitHub's jobs endpoint does not document those fields
-# and omits them in production, so job validation uses only its documented
-# identity fields, plus optional source metadata when GitHub supplies it.
-fetch_jobs_for_run() {
-  local target_run_id="$1"
-  local page_json page_count page2_json page2_count
-  page_json="$(gh_api \
-    --method GET \
-    --header 'Accept: application/vnd.github+json' \
-    --raw-field per_page=100 \
-    --raw-field page=1 \
-    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs")" || return 1
-  jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page_json}" >/dev/null || return 1
-  page_count="$(jq -r '.jobs | length' <<<"${page_json}")"
-  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
-  (( page_count <= 100 )) || return 1
-  if (( page_count == 100 )); then
-    page2_json="$(gh_api \
-      --method GET \
-      --header 'Accept: application/vnd.github+json' \
-      --raw-field per_page=100 \
-      --raw-field page=2 \
-      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs")" || return 1
-    jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page2_json}" >/dev/null || return 1
-    page2_count="$(jq -r '.jobs | length' <<<"${page2_json}")"
-    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
-    (( page2_count <= 100 )) || return 1
-    page_json="$(jq -c --argjson page2 "${page2_json}" '.jobs += $page2.jobs' <<<"${page_json}")"
-    (( page2_count < 100 )) || return 1
-  fi
-  jq -c '[.]' <<<"${page_json}"
-}
-
 jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
 
 # Validate every failed job before granting the state-changing API call. The
@@ -1481,6 +1557,60 @@ if [[ "${source_sha_fallback}" == true ]]; then
   # Re-read the source check immediately before the mutation. This keeps the
   # run/job binding from becoming stale while the PR and job checks execute.
   refresh_source_check_bindings
+  source_check_binding_for_job "${run_id}" "${job_id}" ||
+    fail "The selected CLA job is no longer bound to the current pull request head"
+fi
+
+# Re-fetch the bounded workflow-run history after every job, PR, comment, and
+# source-check validation. A successful lifecycle run can finish after the
+# discovery snapshot; rerunning the old failed job in that window would create
+# a duplicate check and can overwrite a newer result. The final snapshot also
+# blocks while another exact-head lifecycle run is active. A shared GitHub
+# concurrency group is not sufficient because GitHub replaces older pending
+# events, which can strand a required CLA check. The final read is the safer
+# serialization boundary.
+fetch_workflow_runs_snapshot || fail "Could not recheck CLA workflow runs before rerun"
+classify_workflow_runs_snapshot "" "${runs_json}" || fail "Could not classify final CLA workflow runs"
+
+# The selected run must still be the only exact failed run eligible for replay.
+# The shared classifier validates the current generation marker on every
+# successful run before marking an older failure as superseded.
+final_selected_count="$(jq -r --arg run_id "${run_id}" \
+  '[.[] | select((.id | tostring) == $run_id and .conclusion == "failure")] | length' \
+  <<<"${bound_runs_json}")"
+[[ "${final_selected_count}" =~ ^[0-9]+$ && ${final_selected_count} -eq 1 ]] ||
+  fail "The selected CLA workflow run changed before the rerun"
+
+final_selected_id="$(jq -r '.[-1].id // empty' <<<"${candidate_list_json}")"
+if [[ -z "${final_selected_id}" ]]; then
+  # A current-generation success now supersedes the failed attempt. The
+  # classifier has already checked the successful job and generation marker.
+  selected_superseded_count="$(jq -r --arg run_id "${run_id}" \
+    '[.[] | select((.id | tostring) == $run_id and .superseded == true)] | length' \
+    <<<"${run_failure_candidates_json}")"
+  [[ "${selected_superseded_count}" =~ ^[0-9]+$ ]] || fail "Could not classify final superseded CLA workflow runs"
+  (( selected_superseded_count == 1 )) ||
+    fail "The selected CLA workflow run disappeared before the rerun"
+  echo "No failed CLA run exists for this pull request head; a newer successful run superseded the failed attempt"
+  exit 0
+fi
+safe_id "${final_selected_id}" || fail "The final CLA workflow run selection is invalid"
+[[ "${final_selected_id}" == "${run_id}" ]] ||
+  fail "A newer failed CLA workflow run appeared before the rerun; retry the exact CLA comment"
+
+# Do not race an exact-head lifecycle run that is still queued or in progress.
+# It may publish a newer result after this read, so fail closed and let the
+# next explicit comment retry after it finishes.
+final_active_count="$(jq -r --arg run_id "${run_id}" \
+  '[.[] | select((.id | tostring) != $run_id)] | length' <<<"${active_bound_runs_json}")"
+[[ "${final_active_count}" =~ ^[0-9]+$ ]] || fail "Could not count active CLA workflow runs"
+(( final_active_count == 0 )) ||
+  fail "Another CLA workflow run for this pull request head is still active; retry after it finishes"
+
+# Reconfirm the source association after the final workflow snapshot. This
+# keeps the selected run tied to the same open PR if its fork ref was reused.
+validate_live_open_head_association
+if [[ "${source_sha_fallback}" == true ]]; then
   source_check_binding_for_job "${run_id}" "${job_id}" ||
     fail "The selected CLA job is no longer bound to the current pull request head"
 fi

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -1582,10 +1582,14 @@ fi
 # immediately before the Actions mutation. The API cannot provide a
 # transaction, so this is the narrowest practical final race window.
 validate_live_open_head_association
-if [[ "${source_sha_fallback}" == true ]]; then
-  # Re-read the source check immediately before the mutation. This keeps the
-  # run/job binding from becoming stale while the PR and job checks execute.
+if [[ "${head_repo}" != "${GH_REPO}" ]]; then
+  # Re-read source checks for every fork immediately before the final workflow
+  # snapshot. A populated pull_requests association can use the source SHA,
+  # while a newly started run may expose only its base execution SHA; both
+  # shapes need a fresh binding for active-run and supersession checks.
   refresh_source_check_bindings
+fi
+if [[ "${source_sha_fallback}" == true ]]; then
   source_check_binding_for_job "${run_id}" "${job_id}" ||
     fail "The selected CLA job is no longer bound to the current pull request head"
 fi

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -1,0 +1,1245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "::error title=CLA rerun policy::$1" >&2
+  exit 1
+}
+
+readonly MAX_SAFE_INTEGER=9007199254740991
+readonly MAX_COMMENT_BYTES=65536
+readonly EXPECTED_REPOSITORY='manaflow-ai/manaflow'
+
+safe_id() {
+  local value="${1}"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( ${#value} <= 16 )) || return 1
+  (( value <= MAX_SAFE_INTEGER ))
+}
+
+# The job-level expression is the first gate. Repeat it here so a
+# future edit to that expression cannot turn this token into a
+# general-purpose workflow rerunner.
+[[ "${GH_REPO}" == "${EXPECTED_REPOSITORY}" ]] || fail "Unexpected target repository"
+[[ "${EVENT_NAME}" == "issue_comment" ]] || fail "Unexpected event for CLA rerun"
+[[ "${TARGET_EVENT}" == "pull_request_target" ]] || fail "Unexpected target event"
+[[ "${TARGET_BASE_REF}" == "main" ]] || fail "Unexpected target base branch"
+safe_id "${ISSUE_NUMBER}" || fail "Invalid or unsafe issue number"
+[[ "${PR_NUMBER}" == "${ISSUE_NUMBER}" ]] || fail "Issue and pull request numbers differ"
+[[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]] || fail "Comment is not an accepted CLA trigger"
+[[ "${COMMENT_CREATED_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail "Invalid comment timestamp"
+safe_id "${COMMENT_ID}" || fail "Comment ID is invalid"
+safe_id "${COMMENT_AUTHOR_ID}" || fail "Comment author ID is invalid"
+[[ -n "${COMMENT_AUTHOR_LOGIN}" && "${COMMENT_AUTHOR_LOGIN}" != *$'\n'* && "${COMMENT_AUTHOR_LOGIN}" != *$'\r'* ]] || fail "Comment author is missing or malformed"
+[[ "${COMMENT_AUTHOR_TYPE}" == "User" ]] || fail "Comment author is not a human user"
+case "$(printf '%s' "${COMMENT_AUTHOR_LOGIN}" | tr '[:upper:]' '[:lower:]')" in
+  *"[bot]") fail "Bot comments cannot trigger a CLA rerun" ;;
+esac
+[[ -n "${COMMENT_AUTHOR_ASSOCIATION}" &&
+   "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* &&
+   "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] ||
+  fail "Comment author association is malformed"
+case "${SIGNATURE_RECORDED}" in
+  true|false|'') ;;
+  *) fail "The CLA action did not provide a valid signature result" ;;
+esac
+case "${CLA_PASSED}" in
+  true|false|'') ;;
+  *) fail "The CLA action did not provide a valid final result" ;;
+esac
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+  [[ "${SIGNATURE_RECORDED}" == "true" ]] ||
+    fail "The signing comment did not result in a persisted signature"
+  [[ "${CLA_PASSED}" == "true" ]] ||
+    fail "The CLA action did not report cla_passed=true after the signature"
+elif [[ "${CLA_PASSED}" != "true" ]]; then
+  fail "The CLA action did not report cla_passed=true for the recheck"
+fi
+[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+[[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
+checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
+[[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
+[[ "${WORKFLOW_PATH}" == ".github/workflows/cla.yml" ]] || fail "Unexpected CLA workflow path"
+[[ -f .github/scripts/rerun-failed-cla.sh ]] || fail "The trusted CLA rerun helper is missing"
+
+# These values are part of the trusted workflow contract. They are deliberately
+# constants, not event or comment input, so a contributor cannot redirect this
+# check to a different ledger.
+readonly SIGNATURES_BRANCH='cla-signatures'
+readonly SIGNATURES_PATH='signatures/version2/cla.json'
+readonly MAX_RUN_PAGES=10
+readonly MAX_LEDGER_BYTES=1000000
+readonly MAX_LEDGER_SIGNATURES=10000
+# GitHub wraps Contents API Base64 responses with newlines. Allow that
+# transport overhead while bounding the raw field before normalization.
+readonly MAX_LEDGER_RAW_BYTES=2000000
+# These rendered job names are part of the v3 workflow contract. Keep them
+# fixed here so a workflow edit cannot make this actions:write helper rerun an
+# arbitrary failed job. The writer and compatibility jobs are optional failed
+# members because a recheck can target a result-only failure; when either is
+# failed, rerun-failed-jobs refreshes every failed v3 context together.
+readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
+readonly CLA_WRITER_JOB='CLA ledger writer'
+readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
+
+validate_triggering_signature_record() {
+  local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
+  ledger_response="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field ref="${SIGNATURES_BRANCH}" \
+    "repos/${GH_REPO}/contents/${SIGNATURES_PATH}" 2>/dev/null)" || fail "Could not query the trusted CLA signature ledger"
+  jq -e '.type == "file" and .encoding == "base64" and (.content | type == "string") and (.content | length > 0)' <<<"${ledger_response}" >/dev/null || fail "The trusted CLA signature ledger response is malformed"
+  ledger_content="$(jq -r '.content' <<<"${ledger_response}")"
+  ledger_raw_bytes="$(printf '%s' "${ledger_content}" | wc -c | tr -d '[:space:]')"
+  [[ "${ledger_raw_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the trusted CLA signature ledger"
+  (( ledger_raw_bytes <= MAX_LEDGER_RAW_BYTES )) || fail "The trusted CLA signature ledger response is too large"
+  # The Contents API inserts line breaks into Base64 content. Remove only
+  # transport whitespace before applying the encoded-size limit; otherwise a
+  # valid near-limit ledger is rejected solely because it is wrapped.
+  ledger_content_compact="$(printf '%s' "${ledger_content}" | LC_ALL=C tr -d '[:space:]')"
+  [[ "${ledger_content_compact}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]] || fail "The trusted CLA signature ledger is not valid base64"
+  ledger_encoded_bytes="$(printf '%s' "${ledger_content_compact}" | wc -c | tr -d '[:space:]')"
+  [[ "${ledger_encoded_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the trusted CLA signature ledger"
+  (( ledger_encoded_bytes % 4 == 0 )) || fail "The trusted CLA signature ledger is not valid base64"
+  # The maintained action rejects ledgers larger than 1 MB. Enforce the same
+  # bound before decoding, so a malformed Contents response cannot make this
+  # privileged job retain an unbounded payload.
+  (( ledger_encoded_bytes <= ((MAX_LEDGER_BYTES + 2) * 4 / 3 + 4) )) || fail "The trusted CLA signature ledger exceeds the 1 MB limit; ask an administrator to compact or migrate it before signing"
+  if ! ledger_json="$(
+    if base64 --decode >/dev/null 2>&1 <<<''; then
+      printf '%s' "${ledger_content_compact}" | base64 --decode
+    else
+      printf '%s' "${ledger_content_compact}" | base64 -D
+    fi
+  )"; then
+    fail "The trusted CLA signature ledger is not valid base64"
+  fi
+  ledger_decoded_bytes="$(printf '%s' "${ledger_json}" | wc -c | tr -d ' ')"
+  [[ "${ledger_decoded_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the decoded CLA signature ledger"
+  (( ledger_decoded_bytes <= MAX_LEDGER_BYTES )) || fail "The trusted CLA signature ledger exceeds the 1 MB limit; ask an administrator to compact or migrate it before signing"
+  jq -e \
+    --arg login "${LIVE_COMMENT_LOGIN}" \
+    --argjson id "${COMMENT_AUTHOR_ID}" \
+    --argjson comment_id "${COMMENT_ID}" \
+    --arg created_at "${COMMENT_CREATED_AT}" \
+    --argjson repo_id "${repo_id}" \
+    --argjson pr_number "${PR_NUMBER}" \
+    --argjson max_signatures "${MAX_LEDGER_SIGNATURES}" \
+    'type == "object" and
+     (.signedContributors | type == "array") and
+     (.signedContributors | length <= $max_signatures) and
+     any(.signedContributors[]?;
+       (.name | type == "string") and .name == $login and
+       (.id | type == "number") and .id == $id and
+       (.comment_id | type == "number") and .comment_id == $comment_id and
+       (.created_at | type == "string") and .created_at == $created_at and
+       (.repoId | type == "number") and .repoId == $repo_id and
+       (.pullRequestNo | type == "number") and .pullRequestNo == $pr_number
+     )' <<<"${ledger_json}" >/dev/null || fail "The signing comment was not the signature persisted by the CLA action"
+}
+
+issue_json="$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
+issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
+issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
+[[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
+[[ "${issue_pr_url}" == "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" ]] || fail "The issue is not the exact repository pull request"
+
+validate_live_triggering_comment() {
+  local comment_json comment_body_bytes
+  comment_json="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" 2>/dev/null)" ||
+    fail "Could not query the triggering comment"
+  comment_body_bytes="$(jq -r '.body // empty' <<<"${comment_json}" | wc -c | tr -d '[:space:]')"
+  [[ "${comment_body_bytes}" =~ ^[0-9]+$ && ${comment_body_bytes} -le ${MAX_COMMENT_BYTES} ]] ||
+    fail "The triggering CLA comment exceeds the raw body bound"
+  jq -e \
+    --arg comment_id "${COMMENT_ID}" \
+    --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+    --arg body "${COMMENT_BODY}" \
+    --arg author_id "${COMMENT_AUTHOR_ID}" \
+    --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+    --arg created_at "${COMMENT_CREATED_AT}" \
+    '(.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
+     ((.id | tostring) == $comment_id)' <<<"${comment_json}" >/dev/null ||
+    fail "The triggering CLA comment ID is malformed"
+  jq -e \
+    --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+    --arg body "${COMMENT_BODY}" \
+    --arg author_id "${COMMENT_AUTHOR_ID}" \
+    --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+    --arg created_at "${COMMENT_CREATED_AT}" \
+    '.issue_url == $issue_url and
+     .body == $body and
+     (.user | type == "object") and
+     (.user.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
+     (.user.id | tostring) == $author_id and
+     .user.type == $author_type and
+     (.user.login | type == "string") and
+     (.user.login | length > 0) and
+     .created_at == $created_at and
+     .updated_at == $created_at and
+     (.author_association | type == "string")' <<<"${comment_json}" >/dev/null ||
+    fail "The triggering CLA comment was edited, deleted, or moved"
+  LIVE_COMMENT_LOGIN="$(jq -er '.user.login | strings' <<<"${comment_json}")" ||
+    fail "The triggering CLA comment author is malformed"
+  LIVE_COMMENT_ASSOCIATION="$(jq -er '.author_association | strings' <<<"${comment_json}")" ||
+    fail "The triggering CLA comment association is malformed"
+}
+
+# A comment can be edited or deleted after the writer records a signature; a
+# stale event payload must never authorize a rerun of the failed check.
+validate_live_triggering_comment
+
+pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  (.base.repo.id | type == "number") and
+  .base.repo.full_name == $repo and
+  (.head.sha | type == "string") and
+  (.head.sha | test("^[0-9a-f]{40}$")) and
+  (.head.repo.id | type == "number") and
+  (.head.repo.full_name | type == "string") and
+  (.user.login | type == "string") and
+  (.user.id | type == "number")
+' <<<"${pr_json}" >/dev/null || fail "The live pull request is not valid"
+head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
+head_ref="$(jq -r '.head.ref // empty' <<<"${pr_json}")"
+head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
+head_repo_id="$(jq -r '.head.repo.id // empty' <<<"${pr_json}")"
+repo_id="$(jq -r '.base.repo.id // empty' <<<"${pr_json}")"
+pr_author_login="$(jq -r '.user.login // empty' <<<"${pr_json}")"
+pr_author_id="$(jq -r '.user.id // empty' <<<"${pr_json}")"
+[[ "${head_ref}" != "" && "${head_repo}" != "" ]] || fail "The pull request head repository is missing"
+safe_id "${head_repo_id}" || fail "The pull request head repository ID is missing or unsafe"
+safe_id "${repo_id}" || fail "The pull request base repository ID is missing or unsafe"
+[[ "${pr_author_login}" != "" ]] || fail "The pull request author is missing"
+safe_id "${pr_author_id}" || fail "The pull request author ID is missing or unsafe"
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+  validate_triggering_signature_record
+fi
+# A contributor may recheck their own pull request. A different
+# commenter must be a trusted repository participant, which limits
+# unauthenticated users to the harmless no-op path.
+if [[ "${COMMENT_BODY}" == "recheck" && "${COMMENT_AUTHOR_ID}" != "${pr_author_id}" ]]; then
+  case "${LIVE_COMMENT_ASSOCIATION}" in
+    OWNER|MEMBER|COLLABORATOR) ;;
+    *) fail "Only the pull request author or a trusted repository participant may request a CLA rerun" ;;
+  esac
+fi
+
+# The workflow-run list can omit pull_requests for pull_request_target runs.
+# The exact live PR plus the run head_repository/head_branch binding below is
+# used for populated source-head runs. Empty associations are accepted only
+# when the run execution SHA equals the live PR head SHA; a base or merge SHA
+# is not sufficient evidence for a privileged rerun.
+# GitHub may return a not-found or validation response when the source commit
+# exists only in a fork. Treat only that documented missing-commit response as
+# an empty association list; every other API failure remains fatal.
+commit_prs_json=""
+commit_association_error=""
+commit_association_stderr_file="$(mktemp)"
+cleanup_commit_association_stderr() {
+  rm -f -- "${commit_association_stderr_file}"
+}
+trap cleanup_commit_association_stderr EXIT
+if commit_prs_json="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>"${commit_association_stderr_file}")"; then
+  :
+else
+  commit_association_error="${commit_prs_json}"$'\n'"$(cat "${commit_association_stderr_file}")"
+  if jq -e '
+    ((.status == 404 or .status == "404") and
+      (.message == "Not Found" or .message == "Resource not found")) or
+    ((.status == 422 or .status == "422") and
+      (.message | type == "string" and startswith("No commit found for SHA: ")))
+  ' <<<"${commit_prs_json}" >/dev/null 2>&1 ||
+     { grep -Eq 'HTTP 404' <<<"${commit_association_error}" &&
+       grep -Eq 'Not Found|Resource not found' <<<"${commit_association_error}"; } ||
+     { grep -Eq 'HTTP 422' <<<"${commit_association_error}" &&
+       grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${commit_association_error}"; }; then
+    commit_prs_json='[]'
+  else
+    fail "Could not query pull request associations"
+  fi
+fi
+cleanup_commit_association_stderr
+trap - EXIT
+jq -e 'type == "array"' <<<"${commit_prs_json}" >/dev/null || fail "Could not validate pull request associations"
+association_count="$(jq -r 'length' <<<"${commit_prs_json}")"
+[[ "${association_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations"
+(( association_count <= 100 )) || fail "The pull request association page is oversized"
+if (( association_count == 100 )); then
+  commit_prs_page2="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=2 \
+    "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>/dev/null)" || fail "Could not query pull request associations page 2"
+  jq -e 'type == "array"' <<<"${commit_prs_page2}" >/dev/null || fail "Could not validate pull request associations page 2"
+  commit_prs_page2_count="$(jq -r 'length' <<<"${commit_prs_page2}")"
+  [[ "${commit_prs_page2_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations page 2"
+  (( commit_prs_page2_count <= 100 )) || fail "The pull request association page is oversized"
+  commit_prs_json="$(jq -c --argjson page2 "${commit_prs_page2}" '. + $page2' <<<"${commit_prs_json}")"
+  association_count=$((association_count + commit_prs_page2_count))
+  (( commit_prs_page2_count < 100 )) || fail "Too many pull request associations for this head after two pages; ask an administrator to resolve the association before requesting a rerun"
+fi
+if (( association_count > 0 )); then
+  jq -e \
+    --arg repo "${GH_REPO}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg sha "${head_sha}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --argjson head_repo_id "${head_repo_id}" '
+      any(.[]?;
+        (.number | tostring) == $pr and
+        .base.ref == $base and
+        .base.repo.full_name == $repo and
+        .head.ref == $head_ref and
+        .head.sha == $sha and
+        (.head.repo.id | type == "number") and
+        .head.repo.id == $head_repo_id
+      )
+    ' <<<"${commit_prs_json}" >/dev/null || fail "The current head is not associated with this pull request"
+elif [[ "${head_repo}" == "${GH_REPO}" ]]; then
+  fail "The base-repository head has no pull request association"
+fi
+
+# A fork-only commit can be absent from the commit association API.
+# Resolve it through the live open-PR list instead. The head filter
+# is owner:ref, so the result must contain exactly one PR with the
+# exact number, SHA, head repository, and base repository. This
+# rejects duplicate or cross-PR matches before a run is selected,
+# and the helper is called again immediately before the POST.
+validate_live_open_head_association() {
+  local head_owner head_name open_prs_page open_pr_count open_prs_json matching_open_prs_json open_association_count
+  [[ "${head_repo}" == */* && "${head_repo}" != */*/* ]] || fail "The pull request head repository name is invalid"
+  head_owner="${head_repo%%/*}"
+  head_name="${head_repo#*/}"
+  [[ -n "${head_owner}" && -n "${head_name}" ]] || fail "The pull request head repository name is invalid"
+  open_prs_page="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field state=open \
+    --raw-field base="${TARGET_BASE_REF}" \
+    --raw-field head="${head_owner}:${head_ref}" \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/pulls" 2>/dev/null)" || fail "Could not query live open pull requests for this head"
+  jq -e 'type == "array"' <<<"${open_prs_page}" >/dev/null || fail "Could not validate live open pull requests"
+  open_pr_count="$(jq -r 'length' <<<"${open_prs_page}")"
+  [[ "${open_pr_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests"
+  (( open_pr_count <= 100 )) || fail "The live open pull request page is oversized"
+  if (( open_pr_count == 100 )); then
+    open_prs_page2="$(gh api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field state=open \
+      --raw-field base="${TARGET_BASE_REF}" \
+      --raw-field head="${head_owner}:${head_ref}" \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/pulls" 2>/dev/null)" || fail "Could not query live open pull requests page 2"
+    jq -e 'type == "array"' <<<"${open_prs_page2}" >/dev/null || fail "Could not validate live open pull requests page 2"
+    open_pr_count2="$(jq -r 'length' <<<"${open_prs_page2}")"
+    [[ "${open_pr_count2}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests page 2"
+    (( open_pr_count2 <= 100 )) || fail "The live open pull request page is oversized"
+    open_prs_page="$(jq -c --argjson page2 "${open_prs_page2}" '. + $page2' <<<"${open_prs_page}")"
+    open_pr_count=$((open_pr_count + open_pr_count2))
+    (( open_pr_count2 < 100 )) || fail "Too many open pull requests share this head after two pages; push a new head or ask an administrator to resolve the association before requesting a rerun"
+  fi
+  open_prs_json="$(jq -c '[.]' <<<"${open_prs_page}")"
+  if ! matching_open_prs_json="$(jq -c \
+      --arg repo "${GH_REPO}" \
+      --arg sha "${head_sha}" \
+      --arg base "${TARGET_BASE_REF}" \
+      --arg head_ref "${head_ref}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      --argjson repo_id "${repo_id}" '
+        [ .[] | .[]?
+          | select(
+              (.number | type == "number") and
+              .state == "open" and
+              .base.ref == $base and
+              .base.repo.full_name == $repo and
+              (.base.repo.id | type == "number") and
+              .base.repo.id == $repo_id and
+              .head.ref == $head_ref and
+              .head.sha == $sha and
+              .head.repo.full_name == $head_repo and
+              (.head.repo.id | type == "number") and
+              .head.repo.id == $head_repo_id
+            )
+        ]
+        | sort_by(.number)
+      ' <<<"${open_prs_json}")"; then
+    fail "Could not validate live open pull request data"
+  fi
+  open_association_count="$(jq -r 'length' <<<"${matching_open_prs_json}")"
+  [[ "${open_association_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull request associations"
+  [[ "${open_association_count}" == "1" ]] || fail "Expected exactly one open pull request for this head"
+  jq -e --argjson number "${PR_NUMBER}" '.[0].number == $number' <<<"${matching_open_prs_json}" >/dev/null || fail "The live head is associated with a different pull request"
+}
+validate_live_open_head_association
+
+workflow_page="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/actions/workflows" 2>/dev/null)" || fail "Could not query repository workflows"
+jq -e 'type == "object" and (.workflows | type == "array")' <<<"${workflow_page}" >/dev/null || fail "Could not validate repository workflows"
+workflow_count="$(jq -r '.workflows | length' <<<"${workflow_page}")"
+[[ "${workflow_count}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows"
+(( workflow_count <= 100 )) || fail "The repository workflow page is oversized"
+if (( workflow_count == 100 )); then
+  workflow_page2="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=2 \
+    "repos/${GH_REPO}/actions/workflows" 2>/dev/null)" || fail "Could not query repository workflows page 2"
+  jq -e 'type == "object" and (.workflows | type == "array")' <<<"${workflow_page2}" >/dev/null || fail "Could not validate repository workflows page 2"
+  workflow_count2="$(jq -r '.workflows | length' <<<"${workflow_page2}")"
+  [[ "${workflow_count2}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows page 2"
+  (( workflow_count2 <= 100 )) || fail "The repository workflow page is oversized"
+  workflow_page="$(jq -c --argjson page2 "${workflow_page2}" '.workflows += $page2.workflows' <<<"${workflow_page}")"
+  workflow_count=$((workflow_count + workflow_count2))
+  (( workflow_count2 < 100 )) || fail "Too many active repository workflows after two pages; ask an administrator to reduce the workflow list before requesting a rerun"
+fi
+workflow_json="$(jq -c '[.]' <<<"${workflow_page}")"
+workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | select(.path == $path and .state == "active") | .id] | if length == 1 then .[0] else empty end' <<<"${workflow_json}")"
+safe_id "${workflow_id}" || fail "The expected CLA workflow ID is missing or unsafe"
+
+# Search a bounded first page, then choose the newest completed
+# failure created no later than this comment. Edited, reopened, and
+# synchronize events can leave several eligible failures for one
+# exact head, so sort by creation time and run ID and select the
+# newest one. Every candidate is tied to the exact workflow path,
+# event, and PR association. When GitHub includes pull_requests on a
+# run, bind the candidate to the exact PR object, including its
+# source head SHA.
+# GitHub can return an empty array for fork pull_request_target runs,
+# so those candidates are retained only when the run's execution SHA equals
+# the live PR source SHA. Populated pull_requests records may bind a different
+# execution SHA to the exact source PR object.
+runs_page="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field event="${TARGET_EVENT}" \
+  --raw-field branch="${head_ref}" \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs"
+jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${runs_page}" >/dev/null || fail "Could not validate CLA workflow runs"
+run_count="$(jq -r '.workflow_runs | length' <<<"${runs_page}")"
+[[ "${run_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs"
+(( run_count <= 100 )) || fail "The CLA workflow run page is oversized"
+runs_json="$(jq -c '[.]' <<<"${runs_page}")"
+
+# The API returns newest runs first. Probe additional bounded pages when the
+# first page is full, so normal workflow history growth does not strand a
+# failed check. GitHub documents a 1,000-result cap for filtered workflow-run
+# queries, so ten 100-item pages cover the complete API result window. Search
+# the complete bounded window before deciding whether it is full: a valid
+# candidate on page ten is still actionable. If the window is full and no
+# candidate matches, fail with an actionable message instead of pretending page
+# 11 can reveal an unreported run. `runs_json` stays an array of response
+# objects; the candidate query below flattens each `.workflow_runs` array
+# explicitly.
+page_count="${run_count}"
+page_number=2
+while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
+  next_runs_page="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field event="${TARGET_EVENT}" \
+    --raw-field branch="${head_ref}" \
+    --raw-field per_page=100 \
+    --raw-field page="${page_number}" \
+    "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs page ${page_number}"
+  jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${next_runs_page}" >/dev/null || fail "Could not validate CLA workflow runs page ${page_number}"
+  page_count="$(jq -r '.workflow_runs | length' <<<"${next_runs_page}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs page ${page_number}"
+  (( page_count <= 100 )) || fail "The CLA workflow returned an oversized run page"
+  runs_json="$(jq -c --argjson next_page "${next_runs_page}" '. + [$next_page]' <<<"${runs_json}")"
+  (( page_number++ ))
+done
+run_window_full=false
+(( page_count == 100 )) && run_window_full=true
+
+# `pull_requests` is optional for fork runs, but when GitHub sends it, the
+# field must keep its documented array shape. Treat a changed or malformed
+# response as an infrastructure error. Silently treating it as an unmatched
+# run could strand a required failed check with no recovery path.
+if ! jq -e '
+  all(.[] | .workflow_runs[]?;
+    (type == "object") and
+    (.pull_requests == null or (.pull_requests | type == "array"))
+  )
+' <<<"${runs_json}" >/dev/null; then
+  fail "The CLA workflow returned malformed pull request associations"
+fi
+
+if ! candidate_list_json="$(jq -c \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --arg before "${COMMENT_CREATED_AT}" '
+      def run_binds_to_pr:
+        (.pull_requests) as $raw_prs
+        | (if $raw_prs == null then []
+           elif ($raw_prs | type) == "array" then $raw_prs
+           else null end) as $prs
+        | if $prs == null then false
+          elif ($prs | length) == 0 then
+            .head_sha == $sha and
+            .head_branch == $head_ref and
+            (
+              ((.head_repository | type) == "object" and
+               .head_repository.full_name == $head_repo and
+               (.head_repository.id | type == "number") and
+               .head_repository.id == $head_repo_id) or
+              (.head_repository == null and
+               $head_repo == $repo and
+               $head_repo_id == $repo_id)
+            )
+            # Empty associations are eligible only for the exact current
+            # source SHA. A base or merge SHA must never shadow an older
+            # eligible run for this pull request.
+          else any($prs[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            ((.base.repo.full_name // "") == "" or
+             .base.repo.full_name == $repo) and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            ((.head.repo.full_name // "") == "" or
+             .head.repo.full_name == $head_repo)
+          )
+          end;
+      [ .[] | .workflow_runs[]?
+        | select(
+            (.path == $path or
+            ((.path | startswith($path + "@")) and
+             ((.path | length) > (($path | length) + 1)))) and
+            .event == $event and
+            (.workflow_id | type == "number") and
+            .workflow_id == ($workflow_id | tonumber) and
+            (.head_sha | type == "string") and
+            (.head_sha | test("^[0-9a-f]{40}$")) and
+            (.id | type == "number") and
+            .id > 0 and
+            .status == "completed" and
+            .conclusion == "failure" and
+            (.created_at | type == "string") and
+            .created_at <= $before and
+            run_binds_to_pr
+          )
+      ]
+      | sort_by([.created_at, .id])
+    ' <<<"${runs_json}")"; then
+  fail "Could not validate CLA workflow run data"
+fi
+candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
+[[ "${candidate_count}" =~ ^[0-9]+$ ]] || fail "Could not count matching CLA workflow runs"
+if [[ "${candidate_count}" == "0" ]]; then
+  if [[ "${run_window_full}" == true ]]; then
+    fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
+  fi
+  # Do not silently treat a failed run with an empty association and a
+  # different execution SHA as a successful no-op. It is not eligible for a
+  # rerun, but it still needs an explicit fail-closed migration/error path.
+  # Runs with the exact source SHA are handled by the candidate query above;
+  # this count therefore only catches mismatched runs that would otherwise be
+  # indistinguishable from an absent check.
+  empty_execution_mismatch_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    '[ .[] | .workflow_runs[]?
+      | select(
+          (.path == $path or
+           ((.path | startswith($path + "@")) and
+            ((.path | length) > (($path | length) + 1)))) and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          .head_sha != $sha and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          .created_at <= $before and
+          .head_branch == $head_ref and
+          (.pull_requests == null or
+           ((.pull_requests | type) == "array" and
+            (.pull_requests | length) == 0)) and
+          (
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             (.head_repository.id | type == "number") and
+             .head_repository.id == $head_repo_id) or
+            (.head_repository == null and
+             $head_repo == $repo and
+             $head_repo_id == $repo_id)
+          )
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
+  if (( empty_execution_mismatch_count > 0 )); then
+    fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+  fi
+  # A run from before this workflow generation cannot be safely
+  # rerun: GitHub reruns the old workflow revision, which could
+  # execute the archived action or an obsolete policy. Distinguish
+  # that migration case from a normal no-op after a successful CLA
+  # check so contributors receive an actionable recovery path.
+  stale_run_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    'def run_binds_to_pr:
+       (.pull_requests) as $raw_prs
+       | (if $raw_prs == null then []
+          elif ($raw_prs | type) == "array" then $raw_prs
+          else null end) as $prs
+       | if $prs == null then false
+         elif ($prs | length) == 0 then
+           .head_sha == $sha and
+           .head_branch == $head_ref and
+           (
+             ((.head_repository | type) == "object" and
+              .head_repository.full_name == $head_repo and
+              (.head_repository.id | type == "number") and
+              .head_repository.id == $head_repo_id) or
+             (.head_repository == null and
+              $head_repo == $repo and
+              $head_repo_id == $repo_id)
+           )
+         else any($prs[]?;
+           (.number | type == "number") and
+           (.number | tostring) == $pr and
+           .base.ref == $base and
+           ((.base.repo.full_name // "") == "" or
+            .base.repo.full_name == $repo) and
+           (.base.repo.id | type == "number") and
+           .base.repo.id == $repo_id and
+           .head.ref == $head_ref and
+           .head.sha == $sha and
+           (.head.repo.id | type == "number") and
+           .head.repo.id == $head_repo_id and
+           ((.head.repo.full_name // "") == "" or
+            .head.repo.full_name == $head_repo)
+         )
+         end;
+     [ .[] | .workflow_runs[]?
+      | select(
+          (.path == $path or
+          ((.path | startswith($path + "@")) and
+            ((.path | length) > (($path | length) + 1)))) and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          .created_at <= $before and
+          run_binds_to_pr
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${stale_run_count}" =~ ^[0-9]+$ ]] || fail "Could not count stale CLA workflow runs"
+  if (( stale_run_count > 0 )); then
+    fail "The failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  fi
+  # A valid signature can arrive after the check already passed.
+  # Preserve the action's historical no-op behavior in that case.
+  echo "No failed CLA run exists for this pull request head"
+  exit 0
+fi
+# candidate_list_json is sorted oldest-first above. The selected run
+# is fully fetched and validated below before any state-changing API
+# call, so multiple historical failures do not create ambiguity.
+candidate_json="$(jq -c '.[-1]' <<<"${candidate_list_json}")"
+run_id="$(jq -r '.id // empty' <<<"${candidate_json}")"
+safe_id "${run_id}" || fail "The selected CLA run ID is invalid or unsafe"
+run_execution_sha="$(jq -r '.head_sha // empty' <<<"${candidate_json}")"
+[[ "${run_execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The selected CLA run execution SHA is invalid"
+run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
+[[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
+
+# A run with a populated pull_requests array already carries an
+# authenticated source-PR association. Some GitHub API responses
+# omit that array, so prove a differing execution SHA through the
+# commit association endpoint before allowing the fallback. A bare
+# branch/repository match is not enough because a branch can be
+# reused after a push.
+validate_run_source_binding() {
+  local run_payload="$1"
+  local execution_sha pull_requests_type pull_request_count
+  execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
+  [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
+  pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
+  case "${pull_requests_type}" in
+    null) pull_request_count=0 ;;
+    array) pull_request_count="$(jq -r '.pull_requests | length' <<<"${run_payload}")" ;;
+    *) fail "The workflow run pull request association is malformed" ;;
+  esac
+  [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
+  if (( pull_request_count == 0 )); then
+    # GitHub may omit pull_requests on a pull_request_target run. Without an
+    # authenticated PR object, accept only the source-head form. A base or
+    # merge execution SHA cannot be proved to belong to this PR, so fail
+    # closed instead of querying commit associations that may describe an
+    # ancestor or another pull request.
+    [[ "${execution_sha}" == "${head_sha}" ]] || fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+  fi
+}
+
+# Re-read the individual run. The list response is only a discovery
+# result, not authorization to rerun it.
+run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
+jq -e \
+  --arg run_id "${run_id}" \
+  --arg path "${WORKFLOW_PATH}" \
+  --arg event "${TARGET_EVENT}" \
+  --arg sha "${head_sha}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg run_head_branch "${run_head_branch}" \
+  --arg pr "${PR_NUMBER}" \
+  --arg repo "${GH_REPO}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" \
+  --argjson repo_id "${repo_id}" \
+  --arg head_ref "${head_ref}" \
+  --arg workflow_id "${workflow_id}" \
+  --arg base "${TARGET_BASE_REF}" \
+  --arg before "${COMMENT_CREATED_AT}" '
+    def run_binds_to_pr:
+      (.pull_requests) as $raw_prs
+      | (if $raw_prs == null then []
+         elif ($raw_prs | type) == "array" then $raw_prs
+         else null end) as $prs
+      | if $prs == null then false
+        elif ($prs | length) == 0 then
+          .head_branch == $head_ref and
+          (
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             (.head_repository.id | type == "number") and
+             .head_repository.id == $head_repo_id) or
+            (.head_repository == null and
+             $head_repo == $repo and
+             $head_repo_id == $repo_id)
+          )
+        else any($prs[]?;
+          (.number | type == "number") and
+          (.number | tostring) == $pr and
+          .base.ref == $base and
+          ((.base.repo.full_name // "") == "" or
+           .base.repo.full_name == $repo) and
+          (.base.repo.id | type == "number") and
+          .base.repo.id == $repo_id and
+          .head.ref == $head_ref and
+          .head.sha == $sha and
+          (.head.repo.id | type == "number") and
+          .head.repo.id == $head_repo_id and
+          ((.head.repo.full_name // "") == "" or
+           .head.repo.full_name == $head_repo)
+        )
+        end;
+    .id == ($run_id | tonumber) and
+    .workflow_id == ($workflow_id | tonumber) and
+    (.path == $path or
+     ((.path | startswith($path + "@")) and
+      ((.path | length) > (($path | length) + 1)))) and
+    .event == $event and
+    .status == "completed" and
+    .conclusion == "failure" and
+    .head_sha == $run_sha and
+    .head_branch == $run_head_branch and
+    (.created_at | type == "string") and
+    .created_at <= $before and
+    run_binds_to_pr
+  ' <<<"${run_json}" >/dev/null || fail "The selected run no longer matches the exact failed CLA check"
+validate_run_source_binding "${run_json}"
+
+# Close the main TOCTOU window. A push, close, or another rerun can
+# happen while the API calls above run. Never rerun a stale head.
+latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" --argjson opener_id "${pr_author_id}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  .base.repo.full_name == $repo and
+  .base.repo.id == $base_repo_id and
+  .head.sha == $sha and
+  .head.ref == $head_ref and
+  .head.repo.full_name == $head_repo and
+  .head.repo.id == $head_repo_id and
+  .user.id == $opener_id and
+  .user.login == $opener
+' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA run"
+
+# Ensure another queued invocation did not already rerun this run.
+final_run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
+jq -e \
+  --arg path "${WORKFLOW_PATH}" \
+  --arg event "${TARGET_EVENT}" \
+  --arg sha "${head_sha}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg run_head_branch "${run_head_branch}" \
+  --arg pr "${PR_NUMBER}" \
+  --arg repo "${GH_REPO}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" \
+  --argjson repo_id "${repo_id}" \
+  --arg head_ref "${head_ref}" \
+  --arg workflow_id "${workflow_id}" \
+  --arg run_id "${run_id}" \
+  --arg base "${TARGET_BASE_REF}" \
+  --arg before "${COMMENT_CREATED_AT}" '
+    def run_binds_to_pr:
+      (.pull_requests) as $raw_prs
+      | (if $raw_prs == null then []
+         elif ($raw_prs | type) == "array" then $raw_prs
+         else null end) as $prs
+      | if $prs == null then false
+        elif ($prs | length) == 0 then
+          .head_branch == $head_ref and
+          (
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             (.head_repository.id | type == "number") and
+             .head_repository.id == $head_repo_id) or
+            (.head_repository == null and
+             $head_repo == $repo and
+             $head_repo_id == $repo_id)
+          )
+        else any($prs[]?;
+          (.number | type == "number") and
+          (.number | tostring) == $pr and
+          .base.ref == $base and
+          ((.base.repo.full_name // "") == "" or
+           .base.repo.full_name == $repo) and
+          (.base.repo.id | type == "number") and
+          .base.repo.id == $repo_id and
+          .head.ref == $head_ref and
+          .head.sha == $sha and
+          (.head.repo.id | type == "number") and
+          .head.repo.id == $head_repo_id and
+          ((.head.repo.full_name // "") == "" or
+           .head.repo.full_name == $head_repo)
+        )
+        end;
+    .id == ($run_id | tonumber) and
+    .workflow_id == ($workflow_id | tonumber) and
+    (.path == $path or
+     ((.path | startswith($path + "@")) and
+      ((.path | length) > (($path | length) + 1)))) and
+    .event == $event and
+    .status == "completed" and
+    .conclusion == "failure" and
+    .head_sha == $run_sha and
+    .head_branch == $run_head_branch and
+    (.created_at | type == "string") and
+    .created_at <= $before and
+    run_binds_to_pr
+' <<<"${final_run_json}" >/dev/null || fail "The exact failed CLA run is no longer eligible"
+validate_run_source_binding "${final_run_json}"
+
+# Fetch the complete bounded job set for one exact run. The rerun endpoint
+# requires actions:write, so discovery must fail closed if pagination or shape
+# checks cannot prove that every failed job belongs to this CLA workflow.
+# The workflow-run response is authoritative for workflow name, head branch,
+# and source repository. GitHub's jobs endpoint does not document those fields
+# and omits them in production, so job validation uses only its documented
+# identity fields, plus optional source metadata when GitHub supplies it.
+fetch_jobs_for_run() {
+  local target_run_id="$1"
+  local page_json page_count page2_json page2_count
+  page_json="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page_json}" >/dev/null || return 1
+  page_count="$(jq -r '.jobs | length' <<<"${page_json}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2_json="$(gh api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page2_json}" >/dev/null || return 1
+    page2_count="$(jq -r '.jobs | length' <<<"${page2_json}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    page_json="$(jq -c --argjson page2 "${page2_json}" '.jobs += $page2.jobs' <<<"${page_json}")"
+    (( page2_count < 100 )) || return 1
+  fi
+  jq -c '[.]' <<<"${page_json}"
+}
+
+jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
+
+# Validate every failed job before granting the state-changing API call. The
+# v3 writer, required result, and migration compatibility jobs are the only
+# failures this helper may replay. If the writer or compatibility job failed,
+# use the failed-jobs endpoint so GitHub refreshes every head-bound context;
+# otherwise replay only the required result job. Any extra failure,
+# cancellation, malformed job, or stale source identity aborts the request.
+validate_failed_job_set() {
+  local payload="$1"
+  local all_jobs_json failed_jobs_json failed_count nonfailure_count
+  local unexpected_count assistant_count assistant_valid_count writer_count writer_valid_count
+  local compatibility_count compatibility_valid_count
+  if ! all_jobs_json="$(jq -c '[.[] | .jobs[]?]' <<<"${payload}")"; then
+    fail "Could not flatten jobs for the selected CLA run"
+  fi
+  jq -e \
+    --arg run_id "${run_id}" \
+    'type == "array" and all(.[];
+      (.id | type == "number") and
+      .id > 0 and
+      (.run_id | type == "number") and
+      .run_id == ($run_id | tonumber) and
+      (.name | type == "string") and
+      (.status == "completed") and
+      (.conclusion | type == "string")
+    )' <<<"${all_jobs_json}" >/dev/null || fail "The selected CLA run contains a malformed or incomplete job"
+
+  failed_jobs_json="$(jq -c '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' <<<"${all_jobs_json}")"
+  failed_count="$(jq -r 'length' <<<"${failed_jobs_json}")"
+  [[ "${failed_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed jobs for the selected CLA run"
+  nonfailure_count="$(jq -r '[.[] | select(.conclusion != "failure")] | length' <<<"${failed_jobs_json}")"
+  (( nonfailure_count == 0 )) || fail "The selected CLA run contains a cancelled or non-failure job; refusing to rerun it"
+  unexpected_count="$(jq -r \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg writer_job "${CLA_WRITER_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    '[.[] | select(.name != $assistant_job and .name != $writer_job and .name != $compatibility_job)] | length' \
+    <<<"${failed_jobs_json}")"
+  (( unexpected_count == 0 )) || fail "The selected CLA run contains an unexpected failed job; refusing to rerun it"
+
+  if ! assistant_count="$(jq -r \
+      --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+      '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! assistant_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       --arg generation_step "CLA generation ${CLA_GENERATION}" \
+       '[.[] | select(
+          .name == $assistant_job and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id))) and
+          any(.steps[]?;
+            .name == $generation_step and
+            .status == "completed"
+          )
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA Assistant v3 jobs"
+  fi
+  [[ "${assistant_count}" =~ ^[0-9]+$ && "${assistant_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v3 jobs"
+  (( assistant_count == 1 )) || fail "Expected exactly one failed CLA Assistant v3 job"
+  (( assistant_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+
+  if ! writer_count="$(jq -r \
+      --arg writer_job "${CLA_WRITER_JOB}" \
+      '[.[] | select(.name == $writer_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! writer_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg writer_job "${CLA_WRITER_JOB}" \
+       '[.[] | select(
+          .name == $writer_job and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)))
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA ledger writer jobs"
+  fi
+  [[ "${writer_count}" =~ ^[0-9]+$ && "${writer_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA ledger writer jobs"
+  (( writer_count <= 1 )) || fail "The selected CLA run contains multiple failed CLA ledger writer jobs"
+  (( writer_valid_count == writer_count )) || fail "The failed CLA ledger writer job is malformed or bound to a different source"
+
+  compatibility_count="$(jq -r --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" '[.[] | select(.name == $compatibility_job)] | length' <<<"${failed_jobs_json}")"
+  if ! compatibility_valid_count="$(jq -r \
+      --arg run_id "${run_id}" \
+      --arg run_sha "${run_execution_sha}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+      '[.[] | select(
+         .name == $compatibility_job and
+         .run_id == ($run_id | tonumber) and
+         (.head_sha | type == "string") and
+         .head_sha == $run_sha and
+         ((has("head_repository") | not) or
+          (.head_repository == null or
+           ((.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            .head_repository.id == $head_repo_id)))
+      )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA compatibility jobs"
+  fi
+  [[ "${compatibility_count}" =~ ^[0-9]+$ && "${compatibility_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA compatibility jobs"
+  (( compatibility_count <= 1 )) || fail "The selected CLA run contains multiple failed compatibility jobs"
+  (( compatibility_valid_count == compatibility_count )) || fail "The failed CLA compatibility job is malformed or bound to a different source"
+  if (( writer_count == 1 || compatibility_count == 1 )); then
+    RERUN_FAILED_JOBS=true
+  else
+    RERUN_FAILED_JOBS=false
+  fi
+}
+validate_failed_job_set "${jobs_json}"
+if ! cla_job_json="$(jq -c \
+    --arg run_id "${run_id}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    '[.[] | .jobs[]?
+      | select(
+          (.run_id | tostring) == $run_id and
+          .name == $assistant_job and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          (
+            .head_repository == null or
+            (.head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)
+          ) and
+          any(.steps[]?;
+            .name == $generation_step and
+            .status == "completed"
+          )
+        )
+    ]
+    | if length == 1 then .[0] else empty end
+  ' <<<"${jobs_json}")"; then
+  fail "Could not validate CLA Assistant v3 job data"
+fi
+if [[ -z "${cla_job_json}" ]]; then
+  # The run matched the current PR and failed, but no job carried
+  # this workflow generation marker. It is an old or malformed
+  # generation and must not be replayed with the privileged token.
+  fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+fi
+job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
+safe_id "${job_id}" || fail "The selected CLA job ID is invalid or unsafe"
+
+# Re-read the individual job. The jobs list is discovery only, just
+# like the workflow-run list above.
+job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA Assistant v3 job"
+jq -e \
+  --arg job_id "${job_id}" \
+  --arg run_id "${run_id}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+  --arg generation_step "CLA generation ${CLA_GENERATION}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" '
+    .id == ($job_id | tonumber) and
+    .run_id == ($run_id | tonumber) and
+    .name == $assistant_job and
+    .status == "completed" and
+    .conclusion == "failure" and
+    (.head_sha | type == "string") and
+    .head_sha == $run_sha and
+    (
+      (has("head_repository") | not) or
+      .head_repository == null or
+      ((.head_repository | type) == "object" and
+       .head_repository.full_name == $head_repo and
+       .head_repository.id == $head_repo_id)
+    ) and
+    any(.steps[]?;
+      .name == $generation_step and
+      .status == "completed"
+    )
+  ' <<<"${job_json}" >/dev/null || fail "The selected CLA Assistant v3 job no longer matches the failed job in this run"
+
+# Recheck both resources immediately before the state-changing call.
+# This prevents a push or a concurrent rerun from making the job
+# stale while the preceding API requests were in flight.
+latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  .base.repo.full_name == $repo and
+  .base.repo.id == $base_repo_id and
+  .head.sha == $sha and
+  .head.ref == $head_ref and
+  .head.repo.full_name == $head_repo and
+  .head.repo.id == $head_repo_id and
+  .user.login == $opener
+' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA job"
+final_job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
+jq -e \
+  --arg job_id "${job_id}" \
+  --arg run_id "${run_id}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+  --arg generation_step "CLA generation ${CLA_GENERATION}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" '
+    .id == ($job_id | tonumber) and
+    .run_id == ($run_id | tonumber) and
+    .name == $assistant_job and
+    .status == "completed" and
+    .conclusion == "failure" and
+    (.head_sha | type == "string") and
+    .head_sha == $run_sha and
+    (
+      (has("head_repository") | not) or
+      .head_repository == null or
+      ((.head_repository | type) == "object" and
+       .head_repository.full_name == $head_repo and
+       .head_repository.id == $head_repo_id)
+    ) and
+    any(.steps[]?;
+      .name == $generation_step and
+      .status == "completed"
+    )
+  ' <<<"${final_job_json}" >/dev/null || fail "The exact failed CLA Assistant v3 job is no longer eligible"
+
+# Re-fetch the whole job set immediately before the state-changing call. This
+# catches a newly cancelled or unrelated failed job that could otherwise be
+# pulled into a failed-jobs rerun after the first validation.
+final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck and validate jobs for the selected CLA run"
+validate_failed_job_set "${final_jobs_json}"
+final_job_id="$(jq -r \
+  --arg run_id "${run_id}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+  --arg generation_step "CLA generation ${CLA_GENERATION}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" \
+  '[.[] | .jobs[]? | select(
+      .run_id == ($run_id | tonumber) and
+      .name == $assistant_job and
+      .status == "completed" and
+      .conclusion == "failure" and
+      (.head_sha | type == "string") and
+      .head_sha == $run_sha and
+      ((has("head_repository") | not) or
+       (.head_repository == null or
+        ((.head_repository | type) == "object" and
+         .head_repository.full_name == $head_repo and
+         .head_repository.id == $head_repo_id))) and
+      any(.steps[]?;
+        .name == $generation_step and
+        .status == "completed"
+      )
+    )]
+    | if length == 1 then .[0].id else empty end' <<<"${final_jobs_json}")"
+[[ "${final_job_id}" == "${job_id}" ]] || fail "The selected CLA job changed while preparing the rerun"
+
+# Repeat the positive live-PR association check after all discovery
+# calls. A second open PR for the same fork ref and SHA must stop the
+# rerun even if it appeared while the earlier checks were running.
+validate_live_open_head_association
+
+# Revalidate the exact comment and persisted signature after every discovery
+# request. This closes the final comment and ledger TOCTOU window before the
+# Actions API mutation.
+validate_live_triggering_comment
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+  validate_triggering_signature_record
+elif [[ "${COMMENT_AUTHOR_ID}" != "${pr_author_id}" ]]; then
+  case "${LIVE_COMMENT_ASSOCIATION}" in
+    OWNER|MEMBER|COLLABORATOR) ;;
+    *) fail "Only the pull request author or a trusted repository participant may request a CLA rerun" ;;
+  esac
+fi
+# Reconfirm that this exact source head is still the one open pull request
+# immediately before the Actions mutation. The API cannot provide a
+# transaction, so this is the narrowest practical final race window.
+validate_live_open_head_association
+
+if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
+  rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
+  rerun_description="failed CLA v3 jobs (writer, assistant, and compatibility)"
+else
+  rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
+  rerun_description="CLA job ${job_id}"
+fi
+if ! gh api \
+  --method POST \
+  --header 'Accept: application/vnd.github+json' \
+  --header 'X-GitHub-Api-Version: 2022-11-28' \
+  "${rerun_endpoint}" >/dev/null 2>&1; then
+  fail "Could not rerun the exact failed CLA job set"
+fi
+echo "Requested rerun for ${rerun_description} in workflow run ${run_id} at execution ${run_execution_sha} for PR head ${head_sha}"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -635,7 +635,12 @@ refresh_source_check_bindings() {
             .name == $assistant_job and
             (.head_sha | type == "string") and
             .head_sha == $sha and
-            (.conclusion == "success" or .conclusion == "failure") and
+            (
+              .conclusion == "success" or
+              .conclusion == "failure" or
+              (.conclusion == null and
+               (.status == "queued" or .status == "in_progress"))
+            ) and
             (.app.slug | type == "string") and
             .app.slug == "github-actions" and
             (.details_url | type == "string") and

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -522,7 +522,7 @@ refresh_source_check_bindings() {
             .name == $assistant_job and
             (.head_sha | type == "string") and
             .head_sha == $sha and
-            .conclusion == "failure" and
+            (.conclusion == "success" or .conclusion == "failure") and
             (.app.slug | type == "string") and
             .app.slug == "github-actions" and
             (.details_url | type == "string") and
@@ -641,7 +641,11 @@ fi
 # jq programs consume independently fetched API responses; sharing a mutable
 # transformed result would make a later TOCTOU recheck look authoritative when
 # it is only a copy of the earlier response.
-if ! candidate_list_json="$(jq -c \
+#
+# Keep successful runs in the bounded candidate snapshot long enough to mark
+# an older failure as superseded. A later successful run for this exact PR
+# head means there is no failed CLA context left to refresh.
+if ! run_failure_candidates_json="$(jq -c \
     --arg path "${WORKFLOW_PATH}" \
     --arg event "${TARGET_EVENT}" \
     --arg sha "${head_sha}" \
@@ -705,25 +709,40 @@ if ! candidate_list_json="$(jq -c \
             .workflow_id == ($workflow_id | tonumber) and
             (.head_sha | type == "string") and
             (.head_sha | test("^[0-9a-f]{40}$")) and
-            (.id | type == "number") and
-            .id > 0 and
+            (.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
             .status == "completed" and
-            .conclusion == "failure" and
+            (.conclusion | type == "string") and
             (.created_at | type == "string") and
             .created_at <= $before and
             run_binds_to_pr
           )
-      ]
+      ] as $bound_runs
+      | [
+          $bound_runs[]
+          | select(.conclusion == "failure")
+          | . as $failed
+          | . + {
+              superseded: any($bound_runs[]?;
+                .conclusion == "success" and
+                (
+                  .created_at > $failed.created_at or
+                  (.created_at == $failed.created_at and .id > $failed.id)
+                )
+              )
+            }
+        ]
       | sort_by([.created_at, .id])
     ' <<<"${runs_json}")"; then
   fail "Could not validate CLA workflow run data"
 fi
+if ! candidate_list_json="$(jq -c '[.[] | select(.superseded != true)]' <<<"${run_failure_candidates_json}")"; then
+  fail "Could not filter superseded CLA workflow runs"
+fi
+superseded_failure_count="$(jq -r '[.[] | select(.superseded == true)] | length' <<<"${run_failure_candidates_json}")"
+[[ "${superseded_failure_count}" =~ ^[0-9]+$ ]] || fail "Could not count superseded CLA workflow runs"
 candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
 [[ "${candidate_count}" =~ ^[0-9]+$ ]] || fail "Could not count matching CLA workflow runs"
 if [[ "${candidate_count}" == "0" ]]; then
-  if [[ "${run_window_full}" == true ]]; then
-    fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
-  fi
   # Do not silently treat a failed run with an empty association and a
   # different execution SHA as a successful no-op. It is not eligible for a
   # rerun, but it still needs an explicit fail-closed migration/error path.
@@ -780,6 +799,15 @@ if [[ "${candidate_count}" == "0" ]]; then
   [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
   if (( empty_execution_mismatch_count > 0 )); then
     fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+  fi
+  if (( superseded_failure_count > 0 )); then
+    # A newer successful run already published the current CLA result. Do not
+    # replay an older failed attempt, even when the history window is full.
+    echo "No failed CLA run exists for this pull request head; a newer successful run superseded the failed attempt"
+    exit 0
+  fi
+  if [[ "${run_window_full}" == true ]]; then
+    fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
   fi
   # A run from before this workflow generation cannot be safely
   # rerun: GitHub reruns the old workflow revision, which could

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -972,21 +972,23 @@ validate_run_source_binding "${run_json}"
 # execution SHA is the base revision. Use that exact source SHA for every job
 # identity check in the fallback path; the run itself remains bound to its
 # immutable execution SHA above.
-run_job_sha="${run_execution_sha}"
-source_sha_fallback=false
-if [[ "${run_execution_sha}" != "${head_sha}" ]]; then
-  run_job_sha="${head_sha}"
-  if [[ "${run_has_pull_request_association}" == true ]]; then
-    # A populated pull_requests association is the authenticated source
-    # binding. GitHub can expose either the source or execution SHA on jobs;
-    # use the source form for the PR-facing check without requiring a second
-    # check-run lookup.
-    source_sha_fallback=false
-  else
+set_run_job_binding() {
+  run_job_sha="${1}"
+  source_sha_fallback=false
+  if [[ "${1}" != "${head_sha}" ]]; then
+    run_job_sha="${head_sha}"
+    if [[ "${run_has_pull_request_association}" == true ]]; then
+      # A populated pull_requests association is the authenticated source
+      # binding. GitHub can expose either the source or execution SHA on jobs;
+      # use the source form for the PR-facing check without requiring a second
+      # check-run lookup.
+      return 0
+    fi
     source_check_binding_for_run "${run_id}" || fail "The selected fork workflow run is not bound to the current pull request head"
     source_sha_fallback=true
   fi
-fi
+}
+set_run_job_binding "${run_execution_sha}"
 
 # Close the main TOCTOU window. A push, close, or another rerun can
 # happen while the API calls above run. Never rerun a stale head.
@@ -1079,6 +1081,13 @@ jq -e \
     run_binds_to_pr
 ' <<<"${final_run_json}" >/dev/null || fail "The exact failed CLA run is no longer eligible"
 validate_run_source_binding "${final_run_json}"
+if [[ "${run_has_pull_request_association}" != true &&
+      "${run_execution_sha}" != "${head_sha}" ]]; then
+  # The association shape can change between API reads. Refresh the source
+  # check before deriving the job binding when the fallback is still needed.
+  refresh_source_check_bindings
+fi
+set_run_job_binding "${run_execution_sha}"
 
 # Fetch the complete bounded job set for one exact run. The rerun endpoint
 # requires actions:write, so discovery must fail closed if pagination or shape

--- a/.github/scripts/validate-cla-trigger.sh
+++ b/.github/scripts/validate-cla-trigger.sh
@@ -195,16 +195,28 @@ if [[ "${EVENT_NAME}" == 'pull_request_target' ]]; then
   nonempty "${EVENT_HEAD_REPOSITORY:-}" || fail 'Event head repository is missing'
   nonempty "${EVENT_HEAD_REPOSITORY_ID:-}" || fail 'Event head repository ID is missing'
   nonempty "${EVENT_HEAD_SHA:-}" || fail 'Event head SHA is missing'
+  safe_sha "${EVENT_BASE_SHA}" || fail 'Event base SHA is invalid'
+  safe_sha "${EVENT_HEAD_SHA}" || fail 'Event head SHA is invalid'
   [[ "${EVENT_PR_NUMBER:-}" == "${PR_NUMBER}" ]] || fail 'Event pull request number does not match'
   [[ "${EVENT_BASE_REF}" == "${live_base_ref}" &&
      "$(printf '%s' "${EVENT_BASE_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "${live_base_repo}" | tr '[:upper:]' '[:lower:]')" &&
      "${EVENT_BASE_REPOSITORY_ID}" == "${live_base_repo_id}" &&
-     "${EVENT_BASE_SHA}" == "${live_base_sha}" &&
      "${EVENT_HEAD_REF}" == "${live_head_ref}" &&
      "$(printf '%s' "${EVENT_HEAD_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "${live_head_repo}" | tr '[:upper:]' '[:lower:]')" &&
      "${EVENT_HEAD_REPOSITORY_ID}" == "${live_head_repo_id}" &&
      "${EVENT_HEAD_SHA}" == "${live_head_sha}" ]] ||
     fail 'Pull-request event does not match the live pull request'
+  if [[ "${EVENT_BASE_SHA}" != "${live_base_sha}" ]]; then
+    # The base branch can advance after GitHub creates a lifecycle event but
+    # before the queued runner starts. Do not fail a valid PR or pass a stale
+    # payload to the action. A later synchronize event or exact recheck can
+    # evaluate the current base through the live API.
+    emit base_stale true
+    emit ignored true
+    emit admitted false
+    echo 'CLA lifecycle event ignored: the base branch advanced before execution'
+    exit 0
+  fi
 fi
 
 emit head_sha "${live_head_sha}"

--- a/.github/scripts/validate-cla-trigger.sh
+++ b/.github/scripts/validate-cla-trigger.sh
@@ -212,9 +212,12 @@ if [[ "${EVENT_NAME}" == 'pull_request_target' ]]; then
     # payload to the action. A later synchronize event or exact recheck can
     # evaluate the current base through the live API.
     emit base_stale true
-    emit ignored true
+    # This is an invalid lifecycle snapshot, not an ordinary comment to
+    # ignore. Keep the required result job active so branch protection sees a
+    # failure instead of treating a skipped job as successful.
+    emit ignored false
     emit admitted false
-    echo 'CLA lifecycle event ignored: the base branch advanced before execution'
+    echo 'CLA lifecycle event is stale: the required check will fail until a current event is processed'
     exit 0
   fi
 fi

--- a/.github/scripts/validate-cla-trigger.sh
+++ b/.github/scripts/validate-cla-trigger.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_REPOSITORY='manaflow-ai/manaflow'
+readonly SIGN_PHRASE='I have read the CLA Document v2.2 and I hereby sign the CLA'
+readonly MAX_SAFE_INTEGER=9007199254740991
+readonly MAX_COMMENT_BYTES=65536
+
+fail() {
+  echo "::error title=CLA admission::${1}" >&2
+  exit 1
+}
+
+emit() {
+  [[ -n "${GITHUB_OUTPUT:-}" ]] || fail 'GITHUB_OUTPUT is unavailable'
+  printf '%s=%s\n' "${1}" "${2}" >>"${GITHUB_OUTPUT}"
+}
+
+safe_id() {
+  local value="${1}"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( ${#value} <= 16 )) || return 1
+  (( value <= MAX_SAFE_INTEGER ))
+}
+
+safe_sha() {
+  [[ "${1}" =~ ^[0-9a-f]{40}$ ]]
+}
+
+nonempty() {
+  [[ -n "${1}" && "${1}" != *$'\n'* && "${1}" != *$'\r'* ]]
+}
+
+same_repository() {
+  [[ "$(printf '%s' "${1}" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "${EXPECTED_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" ]]
+}
+
+require_event_repository() {
+  nonempty "${EVENT_REPOSITORY:-}" || fail 'Event repository is missing'
+  same_repository "${EVENT_REPOSITORY}" || fail 'Event repository is not manaflow-ai/manaflow'
+  safe_id "${EVENT_REPOSITORY_ID:-}" || fail 'Event repository ID is invalid'
+}
+
+require_pr_number() {
+  safe_id "${PR_NUMBER:-}" || fail 'Pull request number is invalid'
+}
+
+require_event_repository
+require_pr_number
+
+if [[ "${EVENT_NAME:-}" == 'issue_comment' ]]; then
+  [[ "${EVENT_ACTION:-}" == 'created' ]] || fail 'Issue-comment action is not created'
+
+  # Ordinary comments are not CLA commands. Ignore them before making any
+  # privileged admission decision, while exact commands receive full live
+  # identity validation below.
+  if [[ "${COMMENT_BODY:-}" != 'recheck' &&
+        "${COMMENT_BODY:-}" != "${SIGN_PHRASE}" ]]; then
+    emit admitted false
+    echo 'CLA comment ignored: body is not an exact command'
+    exit 0
+  fi
+
+  [[ "${EVENT_ISSUE_STATE:-}" == 'open' ]] || fail 'Comment is not on an open issue'
+  [[ "${EVENT_ISSUE_PR_URL:-}" == "https://api.github.com/repos/${EXPECTED_REPOSITORY}/pulls/${PR_NUMBER}" ]] ||
+    fail 'Comment issue is not the exact repository pull request'
+  [[ "${COMMENT_AUTHOR_TYPE:-}" == 'User' ]] || fail 'Comment author is not a human user'
+  nonempty "${COMMENT_AUTHOR_LOGIN:-}" || fail 'Comment author login is missing'
+  [[ "$(printf '%s' "${COMMENT_AUTHOR_LOGIN}" | tr '[:upper:]' '[:lower:]')" != *'[bot]' ]] || fail 'Bot comments cannot trigger CLA'
+  safe_id "${COMMENT_AUTHOR_ID:-}" || fail 'Comment author ID is invalid'
+  safe_id "${COMMENT_ID:-}" || fail 'Comment ID is invalid'
+  [[ "${COMMENT_CREATED_AT:-}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+    fail 'Comment creation timestamp is invalid'
+  [[ "${COMMENT_UPDATED_AT:-}" == "${COMMENT_CREATED_AT}" ]] ||
+    fail 'The newly created comment is already edited'
+elif [[ "${EVENT_NAME:-}" == 'pull_request_target' ]]; then
+  case "${EVENT_ACTION:-}" in
+    opened|edited|reopened|synchronize) ;;
+    *) fail 'Pull-request action is not an accepted CLA transition' ;;
+  esac
+  [[ "${EVENT_PR_STATE:-}" == 'open' ]] || fail 'Pull request is not open'
+else
+  fail 'Event is not an accepted CLA trigger'
+fi
+
+pr_json="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --header 'X-GitHub-Api-Version: 2022-11-28' \
+  "repos/${EXPECTED_REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null)" ||
+  fail 'Could not read the live pull request'
+
+jq -e \
+  --arg repository "${EXPECTED_REPOSITORY}" \
+  --arg number "${PR_NUMBER}" \
+  --argjson repository_id "${EVENT_REPOSITORY_ID}" '
+    (.number | type == "number") and
+    ((.number | tostring) == $number) and
+    .state == "open" and
+    (.merged_at == null) and
+    .base.ref == "main" and
+    (.base.repo | type == "object") and
+    .base.repo.full_name == $repository and
+    (.base.repo.id | type == "number") and
+    .base.repo.id == $repository_id and
+    (.base.sha | type == "string") and
+    (.base.sha | test("^[0-9a-f]{40}$")) and
+    (.head.ref | type == "string") and
+    (.head.ref | length > 0) and
+    (.head.sha | type == "string") and
+    (.head.sha | test("^[0-9a-f]{40}$")) and
+    (.head.repo | type == "object") and
+    (.head.repo.full_name | type == "string") and
+    (.head.repo.full_name | length > 0) and
+    (.head.repo.id | type == "number") and
+    (.head.repo.id > 0 and .head.repo.id <= 9007199254740991) and
+    (.user | type == "object") and
+    (.user.id | type == "number") and
+    (.user.id > 0 and .user.id <= 9007199254740991) and
+    (.user.login | type == "string") and
+    (.user.login | length > 0)
+  ' <<<"${pr_json}" >/dev/null ||
+  fail 'Live pull request identity is incomplete or targets a branch other than main'
+
+live_number="$(jq -er '.number | tostring' <<<"${pr_json}")" || fail 'Live pull request number is malformed'
+live_base_sha="$(jq -er '.base.sha | strings' <<<"${pr_json}")" || fail 'Live base SHA is malformed'
+live_head_sha="$(jq -er '.head.sha | strings' <<<"${pr_json}")" || fail 'Live head SHA is malformed'
+live_base_ref="$(jq -er '.base.ref | strings' <<<"${pr_json}")" || fail 'Live base ref is malformed'
+live_base_repo="$(jq -er '.base.repo.full_name | strings' <<<"${pr_json}")" || fail 'Live base repository is malformed'
+live_base_repo_id="$(jq -er '.base.repo.id | numbers | tostring' <<<"${pr_json}")" || fail 'Live base repository ID is malformed'
+live_head_ref="$(jq -er '.head.ref | strings' <<<"${pr_json}")" || fail 'Live head ref is malformed'
+live_head_repo="$(jq -er '.head.repo.full_name | strings' <<<"${pr_json}")" || fail 'Live head repository is malformed'
+live_head_repo_id="$(jq -er '.head.repo.id | numbers | tostring' <<<"${pr_json}")" || fail 'Live head repository ID is malformed'
+live_opener_id="$(jq -er '.user.id | numbers | tostring' <<<"${pr_json}")" || fail 'Live opener ID is malformed'
+
+[[ "${live_number}" == "${PR_NUMBER}" ]] || fail 'Live pull request number changed'
+safe_sha "${live_base_sha}" || fail 'Live base SHA is invalid'
+safe_sha "${live_head_sha}" || fail 'Live head SHA is invalid'
+safe_id "${live_base_repo_id}" || fail 'Live base repository ID is invalid'
+safe_id "${live_head_repo_id}" || fail 'Live head repository ID is invalid'
+safe_id "${live_opener_id}" || fail 'Live opener ID is invalid'
+
+if [[ "${EVENT_NAME}" == 'issue_comment' ]]; then
+  comment_json="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    "repos/${EXPECTED_REPOSITORY}/issues/comments/${COMMENT_ID}" 2>/dev/null)" ||
+    fail 'Could not read the live triggering comment'
+  comment_body_bytes="$(jq -r '.body // empty' <<<"${comment_json}" | wc -c | tr -d '[:space:]')" ||
+    fail 'Could not measure the live comment'
+  [[ "${comment_body_bytes}" =~ ^[0-9]+$ && ${comment_body_bytes} -le ${MAX_COMMENT_BYTES} ]] ||
+    fail 'The triggering comment is larger than the supported bound'
+  jq -e \
+    --arg issue_url "https://api.github.com/repos/${EXPECTED_REPOSITORY}/issues/${PR_NUMBER}" \
+    --arg body "${COMMENT_BODY}" \
+    --arg author_id "${COMMENT_AUTHOR_ID}" \
+    --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+    --arg created_at "${COMMENT_CREATED_AT}" \
+    '.issue_url == $issue_url and
+     .body == $body and
+     (.user | type == "object") and
+     (.user.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991) and
+     (.user.id | tostring) == $author_id and
+     .user.type == $author_type and
+     (.user.login | type == "string") and
+     (.user.login | length > 0 and (test("[\\r\\n]") | not)) and
+     .created_at == $created_at and
+     .updated_at == $created_at and
+     (.author_association | type == "string" and length > 0 and (test("[\\r\\n]") | not))' <<<"${comment_json}" >/dev/null ||
+    fail 'The triggering comment changed, moved, or has an invalid identity'
+  jq -e \
+    '.id | type == "number" and floor == . and . > 0 and . <= 9007199254740991' \
+    <<<"${comment_json}" >/dev/null ||
+    fail 'The triggering comment ID is outside the safe numeric range'
+  live_comment_association="$(jq -er '.author_association | strings' <<<"${comment_json}")" ||
+    fail 'Live comment association is malformed'
+  live_comment_login="$(jq -er '.user.login | strings' <<<"${comment_json}")" ||
+    fail 'Live comment author login is malformed'
+  nonempty "${live_comment_login}" || fail 'Live comment author login is malformed'
+  nonempty "${live_comment_association}" || fail 'Live comment association is malformed'
+fi
+
+if [[ "${EVENT_NAME}" == 'pull_request_target' ]]; then
+  nonempty "${EVENT_BASE_REF:-}" || fail 'Event base ref is missing'
+  nonempty "${EVENT_BASE_REPOSITORY:-}" || fail 'Event base repository is missing'
+  nonempty "${EVENT_BASE_REPOSITORY_ID:-}" || fail 'Event base repository ID is missing'
+  nonempty "${EVENT_BASE_SHA:-}" || fail 'Event base SHA is missing'
+  nonempty "${EVENT_HEAD_REF:-}" || fail 'Event head ref is missing'
+  nonempty "${EVENT_HEAD_REPOSITORY:-}" || fail 'Event head repository is missing'
+  nonempty "${EVENT_HEAD_REPOSITORY_ID:-}" || fail 'Event head repository ID is missing'
+  nonempty "${EVENT_HEAD_SHA:-}" || fail 'Event head SHA is missing'
+  [[ "${EVENT_PR_NUMBER:-}" == "${PR_NUMBER}" ]] || fail 'Event pull request number does not match'
+  [[ "${EVENT_BASE_REF}" == "${live_base_ref}" &&
+     "$(printf '%s' "${EVENT_BASE_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "${live_base_repo}" | tr '[:upper:]' '[:lower:]')" &&
+     "${EVENT_BASE_REPOSITORY_ID}" == "${live_base_repo_id}" &&
+     "${EVENT_BASE_SHA}" == "${live_base_sha}" &&
+     "${EVENT_HEAD_REF}" == "${live_head_ref}" &&
+     "$(printf '%s' "${EVENT_HEAD_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "${live_head_repo}" | tr '[:upper:]' '[:lower:]')" &&
+     "${EVENT_HEAD_REPOSITORY_ID}" == "${live_head_repo_id}" &&
+     "${EVENT_HEAD_SHA}" == "${live_head_sha}" ]] ||
+    fail 'Pull-request event does not match the live pull request'
+fi
+
+emit head_sha "${live_head_sha}"
+emit base_sha "${live_base_sha}"
+
+if [[ "${EVENT_NAME}" == 'issue_comment' ]]; then
+  if [[ "${COMMENT_BODY}" == "${SIGN_PHRASE}" ]]; then
+    emit signing true
+  else
+    case "${live_comment_association:-}" in
+      OWNER|MEMBER|COLLABORATOR)
+        emit trusted_recheck true
+        ;;
+      *)
+        if [[ "${COMMENT_AUTHOR_ID}" == "${live_opener_id}" ]]; then
+          emit trusted_recheck true
+        else
+          fail 'Only the pull request author or a trusted repository participant may request a CLA recheck'
+        fi
+        ;;
+    esac
+  fi
+fi
+
+emit admitted true

--- a/.github/scripts/validate-cla-trigger.sh
+++ b/.github/scripts/validate-cla-trigger.sh
@@ -80,7 +80,7 @@ if [[ "${EVENT_NAME:-}" == 'issue_comment' ]]; then
     fail 'The newly created comment is already edited'
 elif [[ "${EVENT_NAME:-}" == 'pull_request_target' ]]; then
   case "${EVENT_ACTION:-}" in
-    opened|edited|reopened|synchronize) ;;
+    opened|edited|ready_for_review|reopened|synchronize) ;;
     *) fail 'Pull-request action is not an accepted CLA transition' ;;
   esac
   [[ "${EVENT_PR_STATE:-}" == 'open' ]] || fail 'Pull request is not open'

--- a/.github/scripts/validate-cla-trigger.sh
+++ b/.github/scripts/validate-cla-trigger.sh
@@ -56,6 +56,11 @@ if [[ "${EVENT_NAME:-}" == 'issue_comment' ]]; then
   # identity validation below.
   if [[ "${COMMENT_BODY:-}" != 'recheck' &&
         "${COMMENT_BODY:-}" != "${SIGN_PHRASE}" ]]; then
+    # GitHub Actions expression equality is case-insensitive. The workflow
+    # may therefore invoke this gate for a case-variant command that is not an
+    # exact declaration. Mark it explicitly so the required result job can be
+    # skipped instead of manufacturing a failed check for ordinary traffic.
+    emit ignored true
     emit admitted false
     echo 'CLA comment ignored: body is not an exact command'
     exit 0

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,6 +19,7 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
+        github.event.issue.state == 'open' &&
         (
           github.event.comment.body == 'recheck' ||
           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
     types: [created]
   pull_request_target:
     branches: [main]
-    types: [opened,closed,reopened,synchronize]
+    types: [opened,closed,reopened,synchronize,edited]
 
 # Keep the default token empty. Each job grants only the permissions it uses.
 permissions: {}
@@ -33,6 +33,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Signature updates share one file. Queue every pending validation instead
     # of dropping all but the newest event.
     concurrency:
@@ -190,6 +191,7 @@ jobs:
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Locking a merged PR does not need signature or repository-write access.
     # Share the signature queue so lock and signature updates cannot race.
     concurrency:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -136,7 +136,7 @@ jobs:
           echo "CLA preflight passed: ${commits} commits (maximum 100)."
           echo "validated=true" >> "${GITHUB_OUTPUT}"
 
-      - name: "Validate historical CLA comments"
+      - name: "Validate historical CLA declarations"
         id: cla_history
         # The archived action rescans issue comments on both event types and
         # accepts trimmed, lower-case, and wrapped declarations. Inspect the
@@ -146,11 +146,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body || '' }}
           CLA_SIGN_PHRASE: 'I have read the CLA Document and I hereby sign the CLA'
         run: |
           set -euo pipefail
           if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error title=CLA history preflight failed::Invalid pull request number."
+            exit 1
+          fi
+          if [[ "${EVENT_NAME}" == "issue_comment" &&
+                "${EVENT_COMMENT_BODY}" != "recheck" &&
+                "${EVENT_COMMENT_BODY}" != "${CLA_SIGN_PHRASE}" ]]; then
+            echo "::error title=CLA comment policy::The issue comment must be exactly recheck or the approved CLA signature phrase."
             exit 1
           fi
 
@@ -162,11 +170,20 @@ jobs:
 
           scan_comments_page() {
             local page_number="$1"
-            local unsafe_stats unsafe_count non_exact_count non_human_count
+            local unsafe_stats unsafe_count marker_count non_exact_count non_human_count
 
-            if ! jq -e 'type == "array"' <<<"${page_json}" >/dev/null 2>&1 ||
-               ! jq -e 'all(.[]; type == "object")' <<<"${page_json}" >/dev/null 2>&1 ||
-               ! jq -e 'all(.[]; (type == "object") and ((.body | type) == "string") and ((.user == null) or ((.user | type) == "object")))' <<<"${page_json}" >/dev/null 2>&1; then
+            if ! jq -e 'type == "array" and all(.[];
+              type == "object" and
+              (.body | type) == "string" and
+              (.user | type) == "object" and
+              (.user.login | type) == "string" and
+              (.user.login | length) > 0 and
+              (.user.type | type) == "string" and
+              (.user.type == "User" or .user.type == "Bot") and
+              (.user.id | type) == "number" and
+              (.user.id | tostring | test("^[1-9][0-9]*$")) and
+              (.user.id <= 9007199254740991)
+            )' <<<"${page_json}" >/dev/null 2>&1; then
               echo "::error title=CLA history preflight failed::GitHub returned invalid comment data on page ${page_number}."
               return 1
             fi
@@ -190,35 +207,38 @@ jobs:
                 | (.body // "") as $body
                 | ($body | ascii_downcase | gsub("^\\s+|\\s+$"; "")) as $normalized
                 | ($phrase | ascii_downcase) as $expected
+                | ($normalized == $expected or
+                   ($normalized | test("^.*i\\s+have\\s+read\\s+the\\s+cla\\s+document\\s+and\\s+i\\s+hereby\\s+sign\\s+the\\s+cla.*$"))) as $candidate
+                | (($body | ascii_downcase | contains("cla assistant lite bot")) or
+                   ($body | ascii_downcase | contains("dco assistant lite bot"))) as $marker
+                | (((.user.login | ascii_downcase) == "github-actions[bot]") and
+                   .user.type == "Bot" and .user.id == 41898282) as $canonical_bot
                 | select(
-                    $normalized == $expected or
-                    ($normalized | test("^.*i\\s+have\\s+read\\s+the\\s+cla\\s+document\\s+and\\s+i\\s+hereby\\s+sign\\s+the\\s+cla.*$"))
-                  )
-                | select(
-                    ((.user.login // "" | tostring | ascii_downcase) != "github-actions[bot]" or
-                     (.user.type // "") != "Bot")
-                  )
-                | select(
-                    ($body != $phrase) or
-                    ((.user.type // "") != "User")
+                    ($marker and ($canonical_bot | not)) or
+                    ($candidate and ($canonical_bot | not) and
+                     (($body != $phrase) or .user.type != "User"))
                   )
                 | {
-                    non_exact: ($body != $phrase),
-                    non_human: ((.user.type // "") != "User")
+                    marker: $marker,
+                    non_exact: ($candidate and ($body != $phrase)),
+                    non_human: ($candidate and (.user.type != "User"))
                   }
               ]
-              | [length, (map(select(.non_exact)) | length), (map(select(.non_human)) | length)]
+              | [length, (map(select(.marker)) | length), (map(select(.non_exact)) | length), (map(select(.non_human)) | length)]
               | @tsv
             ' <<<"${page_json}" 2>/dev/null)"; then
               echo "::error title=CLA history preflight failed::Could not validate historical comment bodies on page ${page_number}."
               return 1
             fi
-            if ! IFS=$'\t' read -r unsafe_count non_exact_count non_human_count <<<"${unsafe_stats}" ||
-               ! [[ "${unsafe_count}" =~ ^[0-9]+$ && "${non_exact_count}" =~ ^[0-9]+$ && "${non_human_count}" =~ ^[0-9]+$ ]]; then
+            if ! IFS=$'\t' read -r unsafe_count marker_count non_exact_count non_human_count <<<"${unsafe_stats}" ||
+               ! [[ "${unsafe_count}" =~ ^[0-9]+$ && "${marker_count}" =~ ^[0-9]+$ && "${non_exact_count}" =~ ^[0-9]+$ && "${non_human_count}" =~ ^[0-9]+$ ]]; then
               echo "::error title=CLA history preflight failed::Could not count historical CLA comment candidates on page ${page_number}."
               return 1
             fi
             if (( unsafe_count > 0 )); then
+              if (( marker_count > 0 )); then
+                echo "::error title=CLA historical comment policy::A historical comment contains the archived CLA or DCO Assistant bot marker from a non-canonical actor."
+              fi
               if (( non_exact_count > 0 )); then
                 echo "::error title=CLA historical comment policy::A historical comment matches the archived trimmed/lower-case/broad CLA matcher but is not the exact signing phrase."
               fi
@@ -250,7 +270,18 @@ jobs:
             echo "::error title=CLA history preflight failed::Could not query the pull request comment overflow probe."
             exit 1
           fi
-          if ! jq -e 'type == "array" and all(.[]; type == "object")' <<<"${overflow_json}" >/dev/null 2>&1 ||
+          if ! jq -e 'type == "array" and all(.[];
+               type == "object" and
+               (.body | type) == "string" and
+               (.user | type) == "object" and
+               (.user.login | type) == "string" and
+               (.user.login | length) > 0 and
+               (.user.type | type) == "string" and
+               (.user.type == "User" or .user.type == "Bot") and
+               (.user.id | type) == "number" and
+               (.user.id | tostring | test("^[1-9][0-9]*$")) and
+               (.user.id <= 9007199254740991)
+             )' <<<"${overflow_json}" >/dev/null 2>&1 ||
              ! overflow_count="$(jq -er 'length | numbers' <<<"${overflow_json}" 2>/dev/null)" ||
              ! [[ "${overflow_count}" =~ ^[0-9]+$ ]]; then
             echo "::error title=CLA history preflight failed::GitHub returned invalid comment data for the overflow probe."

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,11 +28,11 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Signature updates share one file. Queue every pending validation instead
-    # of dropping all but the newest event.
+    # Signature updates share one file. GitHub keeps one running and one
+    # pending run for this group; cancel-in-progress=false preserves the
+    # running update while a newer event may replace the pending update.
     concurrency:
       group: cla-signatures
-      queue: max
       cancel-in-progress: false
     permissions:
       # The archived action attempts a branch-based rerun after a contributor
@@ -373,10 +373,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Locking a merged PR does not need signature or repository-write access.
-    # Share the signature queue so lock and signature updates cannot race.
+    # Share the signature group so lock and signature updates cannot race.
     concurrency:
       group: cla-signatures
-      queue: max
       cancel-in-progress: false
     permissions:
       issues: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,10 +41,10 @@ jobs:
       cancel-in-progress: false
     permissions: {}
     outputs:
-      admitted: ${{ steps.admit.outputs.admitted }}
+      admitted: ${{ steps.validate-trigger.outputs.admitted }}
     steps:
       - name: "Validate exact CLA trigger"
-        id: admit
+        id: validate-trigger
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action || '' }}
@@ -153,6 +153,7 @@ jobs:
 
       - name: "Validate live pull request before CLA validation"
         id: cla_preflight
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -254,6 +255,7 @@ jobs:
 
       - name: "Validate historical CLA declarations"
         id: cla_history
+        if: success()
         # Bound and shape-check comment history before the maintained action.
         # The action owns exact raw signing matches and canonical bot-marker
         # identity. Do not inspect marker or broad-match text here, because an
@@ -382,6 +384,7 @@ jobs:
 
       - name: "Validate exact CLA comment"
         id: cla_comment
+        if: success()
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
@@ -415,6 +418,7 @@ jobs:
         # worker can target the exact live PR head, so this job has no Actions
         # API permission by design.
         if: >-
+          success() &&
           steps.cla_preflight.outputs.validated == 'true' &&
           steps.cla_history.outputs.validated == 'true' &&
           steps.cla_comment.outputs.validated == 'true' &&

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
     types: [created]
   pull_request_target:
     branches: [main]
-    types: [opened,closed,reopened,synchronize,edited]
+    types: [opened,closed,reopened,synchronize]
 
 # Keep the default token empty. Each job grants only the permissions it uses.
 permissions: {}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,7 +30,11 @@ jobs:
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
         github.event.comment.user.type == 'User' &&
-        github.event.comment.user.id > 0
+        github.event.comment.user.id > 0 &&
+        (
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -113,7 +117,11 @@ jobs:
           github.event.issue.pull_request &&
           github.event.issue.state == 'open' &&
           github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id > 0
+          github.event.comment.user.id > 0 &&
+          (
+            github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          )
         )
       ) &&
       (

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -136,6 +136,133 @@ jobs:
           echo "CLA preflight passed: ${commits} commits (maximum 100)."
           echo "validated=true" >> "${GITHUB_OUTPUT}"
 
+      - name: "Validate historical CLA comments"
+        id: cla_history
+        # The archived action rescans issue comments on both event types and
+        # accepts trimmed, lower-case, and wrapped declarations. Inspect the
+        # bounded history first so a stale or malformed comment cannot become
+        # a signature before the exact-comment step and action run.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          CLA_SIGN_PHRASE: 'I have read the CLA Document and I hereby sign the CLA'
+        run: |
+          set -euo pipefail
+          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error title=CLA history preflight failed::Invalid pull request number."
+            exit 1
+          fi
+
+          comments_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}/comments"
+          page_size=100
+          page_limit=10
+          max_comments=1000
+          total_comments=0
+
+          scan_comments_page() {
+            local page_number="$1"
+            local unsafe_stats unsafe_count non_exact_count non_human_count
+
+            if ! jq -e 'type == "array"' <<<"${page_json}" >/dev/null 2>&1 ||
+               ! jq -e 'all(.[]; type == "object")' <<<"${page_json}" >/dev/null 2>&1 ||
+               ! jq -e 'all(.[]; (type == "object") and ((.body | type) == "string") and ((.user == null) or ((.user | type) == "object")))' <<<"${page_json}" >/dev/null 2>&1; then
+              echo "::error title=CLA history preflight failed::GitHub returned invalid comment data on page ${page_number}."
+              return 1
+            fi
+            if ! page_count="$(jq -er 'length | numbers' <<<"${page_json}" 2>/dev/null)" ||
+               ! [[ "${page_count}" =~ ^[0-9]+$ ]]; then
+              echo "::error title=CLA history preflight failed::Could not count comments on page ${page_number}."
+              return 1
+            fi
+            if (( page_count > page_size )); then
+              echo "::error title=CLA history preflight failed::GitHub returned more than ${page_size} comments on page ${page_number}."
+              return 1
+            fi
+            total_comments=$((total_comments + page_count))
+            if (( total_comments > max_comments )); then
+              echo "::error title=CLA history limit::This pull request has more than ${max_comments} comments. Remove old comments before requesting a CLA check."
+              return 1
+            fi
+
+            if ! unsafe_stats="$(jq -r --arg phrase "${CLA_SIGN_PHRASE}" '
+              [ .[]
+                | (.body // "") as $body
+                | ($body | ascii_downcase | gsub("^\\s+|\\s+$"; "")) as $normalized
+                | ($phrase | ascii_downcase) as $expected
+                | select(
+                    $normalized == $expected or
+                    ($normalized | test("^.*i\\s+have\\s+read\\s+the\\s+cla\\s+document\\s+and\\s+i\\s+hereby\\s+sign\\s+the\\s+cla.*$"))
+                  )
+                | select(
+                    ((.user.login // "" | tostring | ascii_downcase) != "github-actions[bot]" or
+                     (.user.type // "") != "Bot")
+                  )
+                | select(
+                    ($body != $phrase) or
+                    ((.user.type // "") != "User")
+                  )
+                | {
+                    non_exact: ($body != $phrase),
+                    non_human: ((.user.type // "") != "User")
+                  }
+              ]
+              | [length, (map(select(.non_exact)) | length), (map(select(.non_human)) | length)]
+              | @tsv
+            ' <<<"${page_json}" 2>/dev/null)"; then
+              echo "::error title=CLA history preflight failed::Could not validate historical comment bodies on page ${page_number}."
+              return 1
+            fi
+            if ! IFS=$'\t' read -r unsafe_count non_exact_count non_human_count <<<"${unsafe_stats}" ||
+               ! [[ "${unsafe_count}" =~ ^[0-9]+$ && "${non_exact_count}" =~ ^[0-9]+$ && "${non_human_count}" =~ ^[0-9]+$ ]]; then
+              echo "::error title=CLA history preflight failed::Could not count historical CLA comment candidates on page ${page_number}."
+              return 1
+            fi
+            if (( unsafe_count > 0 )); then
+              if (( non_exact_count > 0 )); then
+                echo "::error title=CLA historical comment policy::A historical comment matches the archived trimmed/lower-case/broad CLA matcher but is not the exact signing phrase."
+              fi
+              if (( non_human_count > 0 )); then
+                echo "::error title=CLA historical comment policy::A historical CLA candidate was authored by a non-human account."
+              fi
+              return 1
+            fi
+          }
+
+          # Read every bounded page even after a short page. This avoids
+          # missing a comment if the API view changes while comments are
+          # edited during the run.
+          for ((page_number = 1; page_number <= page_limit; page_number++)); do
+            if ! page_json="$(gh api "${comments_endpoint}?per_page=${page_size}&page=${page_number}" --jq '.' 2>/dev/null)"; then
+              echo "::error title=CLA history preflight failed::Could not query pull request comments on page ${page_number}."
+              exit 1
+            fi
+            if ! scan_comments_page "${page_number}"; then
+              exit 1
+            fi
+          done
+
+          # Probe one page beyond the bounded scan. A non-empty page means the
+          # history exceeded the cap, even if an earlier page was short due to
+          # concurrent comment edits or an inconsistent API response.
+          overflow_page=11
+          if ! overflow_json="$(gh api "${comments_endpoint}?per_page=${page_size}&page=${overflow_page}" --jq '.' 2>/dev/null)"; then
+            echo "::error title=CLA history preflight failed::Could not query the pull request comment overflow probe."
+            exit 1
+          fi
+          if ! jq -e 'type == "array" and all(.[]; type == "object")' <<<"${overflow_json}" >/dev/null 2>&1 ||
+             ! overflow_count="$(jq -er 'length | numbers' <<<"${overflow_json}" 2>/dev/null)" ||
+             ! [[ "${overflow_count}" =~ ^[0-9]+$ ]]; then
+            echo "::error title=CLA history preflight failed::GitHub returned invalid comment data for the overflow probe."
+            exit 1
+          fi
+          if (( overflow_count > 0 )); then
+            echo "::error title=CLA history limit::This pull request has more than ${max_comments} comments. Remove old comments before requesting a CLA check."
+            exit 1
+          fi
+          echo "CLA historical comment validation passed: ${total_comments} comments checked."
+          echo "validated=true" >> "${GITHUB_OUTPUT}"
+
       - name: "Validate exact CLA comment"
         id: cla_comment
         env:
@@ -165,6 +292,7 @@ jobs:
         # invalid lock request.
         if: >-
           steps.cla_preflight.outputs.validated == 'true' &&
+          steps.cla_history.outputs.validated == 'true' &&
           steps.cla_comment.outputs.validated == 'true' &&
           (
             (

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,28 +17,20 @@ jobs:
   CLACommentGate:
     name: "Validate CLA trigger"
     # This job is unprivileged. Its expression is coarse admission; the shell
-    # step is the exact, case-sensitive authority for comment text.
+    # step is the exact, case-sensitive authority for comment text. Human
+    # comments that are not an exact command are ignored with admitted=false,
+    # while malformed event data fails closed.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
-        github.event.pull_request.state == 'open' &&
-        (
-          github.event.action == 'opened' ||
-          github.event.action == 'reopened' ||
-          github.event.action == 'synchronize' ||
-          github.event.action == 'edited'
-        )
+        github.event.action != 'closed'
       ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
         github.event.comment.user.type == 'User' &&
-        github.event.comment.user.id > 0 &&
-        (
-          github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
-        )
+        github.event.comment.user.id > 0
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -48,8 +40,11 @@ jobs:
       group: "cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}"
       cancel-in-progress: false
     permissions: {}
+    outputs:
+      admitted: ${{ steps.admit.outputs.admitted }}
     steps:
       - name: "Validate exact CLA trigger"
+        id: admit
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action || '' }}
@@ -62,6 +57,7 @@ jobs:
         run: |
           set -euo pipefail
           shopt -u nocasematch
+          admitted=false
           fail() {
             echo "::error title=CLA trigger policy::${1}"
             exit 1
@@ -70,22 +66,37 @@ jobs:
           sign_phrase='I have read the CLA Document and I hereby sign the CLA'
           if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
             [[ "${EVENT_ISSUE_STATE}" == "open" && -n "${EVENT_ISSUE_PR_URL}" ]] || fail "The comment is not on an open pull request."
-            [[ "${COMMENT_USER_TYPE}" == "User" ]] || fail "Only a human GitHub user can trigger CLA comment processing."
-            [[ "${COMMENT_USER_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The comment author has no valid GitHub user ID."
-            if (( ${#COMMENT_USER_ID} > 16 )) ||
+            # Non-human and malformed commenter identities are ignored. They
+            # must never reach the maintained action, but they are ordinary
+            # public comment traffic rather than a workflow error.
+            if [[ "${COMMENT_USER_TYPE}" != "User" ]] ||
+               ! [[ "${COMMENT_USER_ID}" =~ ^[1-9][0-9]*$ ]] ||
+               (( ${#COMMENT_USER_ID} > 16 )) ||
                (( ${#COMMENT_USER_ID} == 16 && COMMENT_USER_ID > 9007199254740991 )); then
-              fail "The comment author has an unsafe GitHub user ID."
+              printf 'admitted=%s\n' "${admitted}" >> "${GITHUB_OUTPUT}"
+              echo "CLA event ignored: commenter is not a safe human identity"
+              exit 0
             fi
-            [[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "${sign_phrase}" ]] || fail "Use the exact signing comment or the exact recheck command."
+            if [[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "${sign_phrase}" ]]; then
+              admitted=true
+            fi
           elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
             case "${EVENT_ACTION}" in
               opened|reopened|synchronize|edited) ;;
               *) fail "The pull request event is not an accepted CLA trigger." ;;
             esac
             [[ "${EVENT_PR_STATE}" == "open" ]] || fail "The pull request is not open for CLA signing."
+            admitted=true
           else
             fail "The event is not an accepted CLA trigger."
           fi
+
+          printf 'admitted=%s\n' "${admitted}" >> "${GITHUB_OUTPUT}"
+          if [[ "${admitted}" != "true" ]]; then
+            echo "CLA event ignored: comment body is not an exact command"
+            exit 0
+          fi
+          echo "CLA event admitted"
 
   CLAAssistant:
     needs: CLACommentGate
@@ -95,25 +106,19 @@ jobs:
       (
         (
           github.event_name == 'pull_request_target' &&
-          github.event.pull_request.state == 'open' &&
-          (
-            github.event.action == 'opened' ||
-            github.event.action == 'reopened' ||
-            github.event.action == 'synchronize' ||
-            github.event.action == 'edited'
-          )
+          github.event.action != 'closed'
         ) ||
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           github.event.issue.state == 'open' &&
           github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id > 0 &&
-          (
-            github.event.comment.body == 'recheck' ||
-            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
-          )
+          github.event.comment.user.id > 0
         )
+      ) &&
+      (
+        needs.CLACommentGate.result != 'success' ||
+        needs.CLACommentGate.outputs.admitted == 'true'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -138,10 +143,11 @@ jobs:
       - name: "Require CLA admission gate"
         env:
           CLA_GATE_RESULT: ${{ needs.CLACommentGate.result || '' }}
+          CLA_GATE_ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
         run: |
           set -euo pipefail
-          if [[ "${CLA_GATE_RESULT}" != "success" ]]; then
-            echo "::error title=CLA trigger policy::The unprivileged CLACommentGate did not succeed; refusing CLA writes."
+          if [[ "${CLA_GATE_RESULT}" != "success" || "${CLA_GATE_ADMITTED}" != "true" ]]; then
+            echo "::error title=CLA trigger policy::The unprivileged CLACommentGate did not admit this event; refusing CLA writes."
             exit 1
           fi
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -441,12 +441,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Locking a merged PR does not need signature or repository-write access.
-    # Use the same repository-and-PR group so lock and signature updates cannot
-    # race for this Pull Request.
+    # Keep a distinct repository-and-PR group. A later edited event must not
+    # replace a pending merge-lock run in the signer queue.
     # The lock preflight keeps base and opener identity immutable while it
     # permits a merged source head to advance or disappear.
     concurrency:
-      group: "cla-signatures-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      group: "cla-lock-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
       cancel-in-progress: false
     permissions:
       issues: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -155,6 +155,10 @@ jobs:
         # types and accepted trimmed, lower-case, and wrapped declarations.
         # Inspect bounded history first so a stale or malformed comment cannot
         # become a signature before the exact-comment step and action run.
+        # Fail closed on untrusted marker or broad-match text. The archived
+        # matcher treats those strings as authorization, so ignoring them
+        # would permit a spoofed historical signature. Remove unsafe comments
+        # before requesting a new check.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -483,6 +483,11 @@ jobs:
           # allowlist-ids entry only for an approved automation opener; raw
           # names and emails are never trusted.
           require-opener-as-author: 'true'
+          # Verified in-organization maintainers Austin Wang (@austinywang,
+          # GitHub ID 38676809) and Abdulaziz Albahar (@azooz2003-bit, GitHub
+          # ID 67667005) may use the maintainer exemption. The action matches
+          # these numeric IDs only on authenticated Pull Request openers.
+          allowlist-ids: '38676809,67667005'
 
   LockMergedPullRequest:
     name: "Lock merged pull request"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -348,6 +348,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       issues: write
+      pull-requests: read
     steps:
       - name: "Lock merged pull request"
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -140,12 +140,36 @@ jobs:
           echo "CLA preflight passed: ${commits} commits (maximum 100)."
           echo "validated=true" >> "${GITHUB_OUTPUT}"
 
+      - name: "Validate exact CLA comment"
+        id: cla_comment
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
+            # GitHub expression equality is case-insensitive. Use a shell
+            # comparison here so the archived action receives only the exact
+            # supported command or signature phrase.
+            shopt -u nocasematch
+            case "${COMMENT_BODY}" in
+              'recheck'|'I have read the CLA Document and I hereby sign the CLA')
+                ;;
+              *)
+                echo "::error title=CLA comment policy::The issue comment must be exactly recheck or the approved CLA signature phrase."
+                exit 1
+                ;;
+            esac
+          fi
+          echo "validated=true" >> "${GITHUB_OUTPUT}"
+
       - name: "CLA Assistant"
         # The action handles signing and status updates. Merged pull requests
         # use the separate lock job below because the archived action sends an
         # invalid lock request.
         if: >-
           steps.cla_preflight.outputs.validated == 'true' &&
+          steps.cla_comment.outputs.validated == 'true' &&
           (
             (
               github.event_name == 'pull_request_target' &&
@@ -183,6 +207,7 @@ jobs:
           # signatures live on the unprotected cla-signatures branch so
           # required checks on main don't block the bot's signature commits.
           branch: 'cla-signatures'
+          required-base-ref: 'main'
 
   LockMergedPullRequest:
     name: "Lock merged pull request"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,13 +15,7 @@ jobs:
     if: >-
       (
         github.event_name == 'pull_request_target' &&
-        github.event.action != 'closed' &&
-        github.event.pull_request.state == 'open' &&
-        github.event.pull_request.base.ref == 'main' &&
-        github.event.pull_request.base.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.full_name != '' &&
-        github.event.pull_request.head.repo.id > 0 &&
-        github.event.pull_request.head.sha != ''
+        github.event.action != 'closed'
       ) ||
       (
         github.event_name == 'issue_comment' &&
@@ -41,8 +35,10 @@ jobs:
       queue: max
       cancel-in-progress: false
     permissions:
-      # The action reruns the prior failed CLA check after a contributor signs.
-      actions: write
+      # The archived action attempts a branch-based rerun after a contributor
+      # signs. That selection is unsafe. The exact-PR rerun worker is not
+      # deployed yet, so required-check recovery remains advisory.
+      actions: read
       contents: write
       issues: write
       # GitHub's pull_request_target token denied issue comments for fork PRs

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,7 +49,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           set -euo pipefail
-          if ! commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')"; then
+          if ! commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits' 2>/dev/null)"; then
             echo "::error title=CLA preflight failed::Could not read pull request ${PR_NUMBER} from GitHub." >&2
             exit 1
           fi
@@ -109,7 +109,7 @@ jobs:
           set -euo pipefail
           issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
           lock_endpoint="${issue_endpoint}/lock"
-          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked')"; then
+          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
             echo "::error title=CLA lock failed::Could not read lock state for pull request ${PR_NUMBER}." >&2
             exit 1
           fi
@@ -129,11 +129,11 @@ jobs:
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "${lock_endpoint}" \
-            --field lock_reason=resolved; then
+            --field lock_reason=resolved 2>/dev/null; then
             echo "::error title=CLA lock failed::Could not lock pull request ${PR_NUMBER}." >&2
             exit 1
           fi
-          if ! locked_after="$(gh api "${issue_endpoint}" --jq '.locked')"; then
+          if ! locked_after="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
             echo "::error title=CLA lock failed::Could not verify lock state for pull request ${PR_NUMBER}." >&2
             exit 1
           fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,9 +38,8 @@ jobs:
       cancel-in-progress: false
     permissions:
       # The maintained in-organization action validates the live Pull Request
-      # before it writes. Keep workflow rerun access out of this job; required
-      # check recovery is handled only by an exact, separately reviewed worker.
-      actions: read
+      # before it writes. This job has no Actions API access; required-check
+      # recovery is handled only by an exact, separately reviewed worker.
       contents: write
       issues: write
       # GitHub's pull_request_target token denied issue comments for fork PRs
@@ -184,18 +183,27 @@ jobs:
           scan_comments_page() {
             local page_number="$1"
 
-            if ! jq -e 'type == "array" and all(.[];
-              type == "object" and
-              (.body | type) == "string" and
-              (.user | type) == "object" and
-              (.user.login | type) == "string" and
-              (.user.login | length) > 0 and
-              (.user.type | type) == "string" and
-              (.user.type == "User" or .user.type == "Bot") and
-              (.user.id | type) == "number" and
-              (.user.id | tostring | test("^[1-9][0-9]*$")) and
-              (.user.id <= 9007199254740991)
-            )' <<<"${page_json}" >/dev/null 2>&1; then
+            if ! jq -e '
+              def safe_id:
+                type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+              # GitHub can return a null user for deleted accounts and actor
+              # types beyond User/Bot (for example, Mannequin). The action
+              # skips null users and only calls string methods on named users.
+              def valid_comment:
+                type == "object" and
+                (.body == null or (.body | type) == "string") and
+                (
+                  .user == null or
+                  (
+                    (.user | type) == "object" and
+                    (.user.login | type) == "string" and
+                    (.user.login | length) > 0 and
+                    (.user.type == null or (.user.type | type) == "string") and
+                    (.user.id == null or (.user.id | safe_id))
+                  )
+                );
+              type == "array" and all(.[]; valid_comment)
+            ' <<<"${page_json}" >/dev/null 2>&1; then
               echo "::error title=CLA history preflight failed::GitHub returned invalid comment data on page ${page_number}."
               return 1
             fi
@@ -236,18 +244,26 @@ jobs:
             echo "::error title=CLA history preflight failed::Could not query the pull request comment overflow probe."
             exit 1
           fi
-          if ! jq -e 'type == "array" and all(.[];
-               type == "object" and
-               (.body | type) == "string" and
-               (.user | type) == "object" and
-               (.user.login | type) == "string" and
-               (.user.login | length) > 0 and
-               (.user.type | type) == "string" and
-               (.user.type == "User" or .user.type == "Bot") and
-               (.user.id | type) == "number" and
-               (.user.id | tostring | test("^[1-9][0-9]*$")) and
-               (.user.id <= 9007199254740991)
-             )' <<<"${overflow_json}" >/dev/null 2>&1 ||
+          if ! jq -e '
+               def safe_id:
+                 type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+               # Keep the overflow probe schema check identical to the page
+               # check, including deleted and non-human commenter records.
+               def valid_comment:
+                 type == "object" and
+                 (.body == null or (.body | type) == "string") and
+                 (
+                   .user == null or
+                   (
+                     (.user | type) == "object" and
+                     (.user.login | type) == "string" and
+                     (.user.login | length) > 0 and
+                     (.user.type == null or (.user.type | type) == "string") and
+                     (.user.id == null or (.user.id | safe_id))
+                   )
+                 );
+               type == "array" and all(.[]; valid_comment)
+             ' <<<"${overflow_json}" >/dev/null 2>&1 ||
              ! overflow_count="$(jq -er 'length | numbers' <<<"${overflow_json}" 2>/dev/null)" ||
              ! [[ "${overflow_count}" =~ ^[0-9]+$ ]]; then
             echo "::error title=CLA history preflight failed::GitHub returned invalid comment data for the overflow probe."
@@ -290,6 +306,10 @@ jobs:
         # and opener predicates run in the preflight step above. Keep this
         # gate to event shape so malformed payloads fail in a running step,
         # rather than becoming a skipped-success required check.
+        # Issue-comment signatures are persisted by the maintained action. The
+        # required-check refresh remains advisory until a separately reviewed
+        # worker can target the exact live PR head, so this job has no Actions
+        # API permission by design.
         if: >-
           steps.cla_preflight.outputs.validated == 'true' &&
           steps.cla_history.outputs.validated == 'true' &&

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,7 +33,7 @@ jobs:
       queue: max
       cancel-in-progress: false
     permissions:
-      # The action inspects prior runs; its optional rerun request is best-effort.
+      # The action reruns the prior failed CLA check after a contributor signs.
       actions: write
       contents: write
       issues: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -34,7 +34,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       # The action inspects prior runs; its optional rerun request is best-effort.
-      actions: read
+      actions: write
       contents: write
       issues: write
       # GitHub's pull_request_target token denied issue comments for fork PRs

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -138,10 +138,10 @@ jobs:
 
       - name: "Validate historical CLA declarations"
         id: cla_history
-        # The archived action rescans issue comments on both event types and
-        # accepts trimmed, lower-case, and wrapped declarations. Inspect the
-        # bounded history first so a stale or malformed comment cannot become
-        # a signature before the exact-comment step and action run.
+        # Legacy CLA Assistant behavior rescanned issue comments on both event
+        # types and accepted trimmed, lower-case, and wrapped declarations.
+        # Inspect bounded history first so a stale or malformed comment cannot
+        # become a signature before the exact-comment step and action run.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -237,10 +237,10 @@ jobs:
             fi
             if (( unsafe_count > 0 )); then
               if (( marker_count > 0 )); then
-                echo "::error title=CLA historical comment policy::A historical comment contains the archived CLA or DCO Assistant bot marker from a non-canonical actor."
+                echo "::error title=CLA historical comment policy::A historical comment contains a legacy CLA or DCO Assistant bot marker from a non-canonical actor."
               fi
               if (( non_exact_count > 0 )); then
-                echo "::error title=CLA historical comment policy::A historical comment matches the archived trimmed/lower-case/broad CLA matcher but is not the exact signing phrase."
+                echo "::error title=CLA historical comment policy::A historical comment matches a legacy trimmed/lower-case/broad CLA matcher but is not the exact signing phrase."
               fi
               if (( non_human_count > 0 )); then
                 echo "::error title=CLA historical comment policy::A historical CLA candidate was authored by a non-human account."
@@ -303,7 +303,7 @@ jobs:
           set -euo pipefail
           if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
             # GitHub expression equality is case-insensitive. Use a shell
-            # comparison here so the archived action receives only the exact
+            # comparison here so the CLA action receives only the exact
             # supported command or signature phrase.
             shopt -u nocasematch
             case "${COMMENT_BODY}" in
@@ -319,8 +319,8 @@ jobs:
 
       - name: "CLA Assistant v2"
         # The action handles signing and status updates. Merged pull requests
-        # use the separate lock job below because the archived action sends an
-        # invalid lock request.
+        # use the separate lock job below so lock writes share serialization
+        # and the workflow's live identity checks.
         if: >-
           steps.cla_preflight.outputs.validated == 'true' &&
           steps.cla_history.outputs.validated == 'true' &&
@@ -362,6 +362,10 @@ jobs:
           # required checks on main don't block the bot's signature commits.
           branch: 'cla-signatures'
           required-base-ref: 'main'
+          # Keep the impersonation guard explicit. The action requires the
+          # authenticated Pull Request opener to appear as an author or
+          # co-author unless a maintainer deliberately opts out.
+          require-opener-as-author: 'true'
 
   LockMergedPullRequest:
     name: "Lock merged pull request"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,6 +3,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
+    branches: [main]
     types: [opened,closed,reopened,synchronize]
 
 # Keep the default token empty. Each job grants only the permissions it uses.
@@ -14,7 +15,13 @@ jobs:
     if: >-
       (
         github.event_name == 'pull_request_target' &&
-        github.event.action != 'closed'
+        github.event.action != 'closed' &&
+        github.event.pull_request.state == 'open' &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.base.repo.full_name == github.repository &&
+        github.event.pull_request.head.repo.full_name != '' &&
+        github.event.pull_request.head.repo.id > 0 &&
+        github.event.pull_request.head.sha != ''
       ) ||
       (
         github.event_name == 'issue_comment' &&
@@ -42,13 +49,81 @@ jobs:
       # issues:write. Keep write until that live behavior changes.
       pull-requests: write
     steps:
-      - name: "Check commit count before CLA validation"
+      - name: "Validate live pull request before CLA validation"
+        id: cla_preflight
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
+          EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          EVENT_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || '' }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           set -euo pipefail
+          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error title=CLA preflight failed::Invalid pull request number."
+            exit 1
+          fi
+
+          pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
+          if ! pr_json="$(gh api "${pr_endpoint}" --jq '{number: (.number | tostring), state: .state, merged: (.merged_at != null), base_ref: (.base.ref // ""), base_repo: (.base.repo.full_name // ""), head_sha: (.head.sha // ""), head_repo: (.head.repo.full_name // ""), head_repo_id: (.head.repo.id // 0), commits: .commits}' 2>/dev/null)"; then
+            echo "::error title=CLA preflight failed::Could not read live pull request ${PR_NUMBER} from GitHub."
+            exit 1
+          fi
+
+          if ! returned_number="$(jq -er '.number | strings' <<<"${pr_json}" 2>/dev/null)" || [[ "${returned_number}" != "${PR_NUMBER}" ]]; then
+            echo "::error title=CLA preflight failed::GitHub returned an invalid pull request identity."
+            exit 1
+          fi
+          if ! state="$(jq -er '.state | strings' <<<"${pr_json}" 2>/dev/null)" || [[ "${state}" != "open" ]]; then
+            echo "::error title=CLA state policy::Pull request ${PR_NUMBER} is not open."
+            exit 1
+          fi
+          if ! merged="$(jq -er '.merged | tostring' <<<"${pr_json}" 2>/dev/null)" || [[ "${merged}" != "false" ]]; then
+            echo "::error title=CLA state policy::Pull request ${PR_NUMBER} is already merged or has an invalid merge state."
+            exit 1
+          fi
+          if ! base_ref="$(jq -er '.base_ref | strings' <<<"${pr_json}" 2>/dev/null)" || [[ "${base_ref}" != "main" ]]; then
+            echo "::error title=CLA base branch policy::CLA checks only support pull requests targeting main."
+            exit 1
+          fi
+          if ! base_repo="$(jq -er '.base_repo | strings' <<<"${pr_json}" 2>/dev/null)" || [[ -z "${base_repo}" || "${base_repo,,}" != "${GH_REPO,,}" ]]; then
+            echo "::error title=CLA repository policy::The live pull request base repository does not match this workflow repository."
+            exit 1
+          fi
+          if ! head_repo="$(jq -er '.head_repo | strings' <<<"${pr_json}" 2>/dev/null)" || [[ -z "${head_repo}" ]]; then
+            echo "::error title=CLA repository policy::The live pull request has no head repository."
+            exit 1
+          fi
+          if ! head_repo_id="$(jq -er '.head_repo_id | numbers' <<<"${pr_json}" 2>/dev/null)" || ! [[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error title=CLA repository policy::The live pull request has no valid head repository ID."
+            exit 1
+          fi
+          if ! head_sha="$(jq -er '.head_sha | strings' <<<"${pr_json}" 2>/dev/null)" || [[ -z "${head_sha}" ]]; then
+            echo "::error title=CLA preflight failed::The live pull request has no head commit."
+            exit 1
+          fi
+
+          if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            if [[ -z "${EVENT_BASE_REF}" || -z "${EVENT_BASE_REPOSITORY}" ||
+                  -z "${EVENT_HEAD_REPOSITORY}" || -z "${EVENT_HEAD_REPOSITORY_ID}" ||
+                  -z "${EVENT_HEAD_SHA}" ]]; then
+              echo "::error title=CLA preflight failed::The pull_request_target payload is missing repository or commit identity."
+              exit 1
+            fi
+            if [[ "${EVENT_BASE_REF}" != "${base_ref}" ||
+                  "${EVENT_BASE_REPOSITORY,,}" != "${base_repo,,}" ||
+                  "${EVENT_HEAD_REPOSITORY,,}" != "${head_repo,,}" ||
+                  "${EVENT_HEAD_REPOSITORY_ID}" != "${head_repo_id}" ||
+                  "${EVENT_HEAD_SHA}" != "${head_sha}" ]]; then
+              echo "::error title=CLA preflight failed::The pull_request_target payload does not match the live pull request identity."
+              exit 1
+            fi
+          fi
+
           if ! commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits' 2>/dev/null)"; then
             echo "::error title=CLA preflight failed::Could not read pull request ${PR_NUMBER} from GitHub." >&2
             exit 1
@@ -62,11 +137,35 @@ jobs:
             exit 1
           fi
           echo "CLA preflight passed: ${commits} commits (maximum 100)."
+          echo "validated=true" >> "${GITHUB_OUTPUT}"
 
       - name: "CLA Assistant"
         # The action handles signing and status updates. Merged pull requests
         # use the separate lock job below because the archived action sends an
         # invalid lock request.
+        if: >-
+          steps.cla_preflight.outputs.validated == 'true' &&
+          (
+            (
+              github.event_name == 'pull_request_target' &&
+              github.event.action != 'closed' &&
+              github.event.pull_request.state == 'open' &&
+              github.event.pull_request.base.ref == 'main' &&
+              github.event.pull_request.base.repo.full_name == github.repository &&
+              github.event.pull_request.head.repo.full_name != '' &&
+              github.event.pull_request.head.repo.id > 0 &&
+              github.event.pull_request.head.sha != ''
+            ) ||
+            (
+              github.event_name == 'issue_comment' &&
+              github.event.issue.pull_request &&
+              github.event.issue.state == 'open' &&
+              (
+                github.event.comment.body == 'recheck' ||
+                github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+              )
+            )
+          )
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -151,14 +151,10 @@ jobs:
 
       - name: "Validate historical CLA declarations"
         id: cla_history
-        # Legacy CLA Assistant behavior rescanned issue comments on both event
-        # types and accepted trimmed, lower-case, and wrapped declarations.
-        # Inspect bounded history first so a stale or malformed comment cannot
-        # become a signature before the exact-comment step and action run.
-        # Fail closed on untrusted marker or broad-match text. The archived
-        # matcher treats those strings as authorization, so ignoring them
-        # would permit a spoofed historical signature. Remove unsafe comments
-        # before requesting a new check.
+        # Bound and shape-check comment history before the maintained action.
+        # The action owns exact raw signing matches and canonical bot-marker
+        # identity. Do not inspect marker or broad-match text here, because an
+        # ordinary public comment must not block later CLA checks.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -187,7 +183,6 @@ jobs:
 
           scan_comments_page() {
             local page_number="$1"
-            local unsafe_stats unsafe_count marker_count non_exact_count non_human_count
 
             if ! jq -e 'type == "array" and all(.[];
               type == "object" and
@@ -216,52 +211,6 @@ jobs:
             total_comments=$((total_comments + page_count))
             if (( total_comments > max_comments )); then
               echo "::error title=CLA history limit::This pull request has more than ${max_comments} comments. Remove old comments before requesting a CLA check."
-              return 1
-            fi
-
-            if ! unsafe_stats="$(jq -r --arg phrase "${CLA_SIGN_PHRASE}" '
-              [ .[]
-                | (.body // "") as $body
-                | ($body | ascii_downcase | gsub("^\\s+|\\s+$"; "")) as $normalized
-                | ($phrase | ascii_downcase) as $expected
-                | ($normalized == $expected or
-                   ($normalized | test("^.*i\\s+have\\s+read\\s+the\\s+cla\\s+document\\s+and\\s+i\\s+hereby\\s+sign\\s+the\\s+cla.*$"))) as $candidate
-                | (($body | ascii_downcase | contains("cla assistant lite bot")) or
-                   ($body | ascii_downcase | contains("dco assistant lite bot"))) as $marker
-                | (((.user.login | ascii_downcase) == "github-actions[bot]") and
-                   .user.type == "Bot" and .user.id == 41898282) as $canonical_bot
-                | select(
-                    ($marker and ($canonical_bot | not)) or
-                    ($candidate and ($canonical_bot | not) and
-                     (($body != $phrase) or .user.type != "User"))
-                  )
-                | {
-                    marker: $marker,
-                    non_exact: ($candidate and ($body != $phrase)),
-                    non_human: ($candidate and (.user.type != "User"))
-                  }
-              ]
-              | [length, (map(select(.marker)) | length), (map(select(.non_exact)) | length), (map(select(.non_human)) | length)]
-              | @tsv
-            ' <<<"${page_json}" 2>/dev/null)"; then
-              echo "::error title=CLA history preflight failed::Could not validate historical comment bodies on page ${page_number}."
-              return 1
-            fi
-            if ! IFS=$'\t' read -r unsafe_count marker_count non_exact_count non_human_count <<<"${unsafe_stats}" ||
-               ! [[ "${unsafe_count}" =~ ^[0-9]+$ && "${marker_count}" =~ ^[0-9]+$ && "${non_exact_count}" =~ ^[0-9]+$ && "${non_human_count}" =~ ^[0-9]+$ ]]; then
-              echo "::error title=CLA history preflight failed::Could not count historical CLA comment candidates on page ${page_number}."
-              return 1
-            fi
-            if (( unsafe_count > 0 )); then
-              if (( marker_count > 0 )); then
-                echo "::error title=CLA historical comment policy::A historical comment contains a legacy CLA or DCO Assistant bot marker from a non-canonical actor."
-              fi
-              if (( non_exact_count > 0 )); then
-                echo "::error title=CLA historical comment policy::A historical comment matches a legacy trimmed/lower-case/broad CLA matcher but is not the exact signing phrase."
-              fi
-              if (( non_human_count > 0 )); then
-                echo "::error title=CLA historical comment policy::A historical CLA candidate was authored by a non-human account."
-              fi
               return 1
             fi
           }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -91,7 +91,7 @@ jobs:
     needs: CLACommentGate
     name: "CLA Assistant v2"
     if: >-
-      needs.CLACommentGate.result == 'success' &&
+      always() &&
       (
         (
           github.event_name == 'pull_request_target' &&
@@ -135,6 +135,16 @@ jobs:
       # issues:write. Keep write until that live behavior changes.
       pull-requests: write
     steps:
+      - name: "Require CLA admission gate"
+        env:
+          CLA_GATE_RESULT: ${{ needs.CLACommentGate.result || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "${CLA_GATE_RESULT}" != "success" ]]; then
+            echo "::error title=CLA trigger policy::The unprivileged CLACommentGate did not succeed; refusing CLA writes."
+            exit 1
+          fi
+
       - name: "Validate live pull request before CLA validation"
         id: cla_preflight
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,10 @@ jobs:
     # This job is unprivileged. Its expression is coarse admission; the shell
     # step is the exact, case-sensitive authority for comment text. Human
     # comments that are not an exact command are ignored with admitted=false,
-    # while malformed event data fails closed.
+    # while malformed event data fails closed. Keep the body predicate here so
+    # ordinary public comments do not enter the admission concurrency queue;
+    # the shell repeats the byte-exact check because expression equality is
+    # case-insensitive.
     if: >-
       (
         github.event_name == 'pull_request_target' &&

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,6 +33,8 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
+        github.event.comment.user.type == 'User' &&
+        github.event.comment.user.id > 0 &&
         (
           github.event.comment.body == 'recheck' ||
           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
@@ -54,6 +56,8 @@ jobs:
           EVENT_PR_STATE: ${{ github.event.pull_request.state || '' }}
           EVENT_ISSUE_STATE: ${{ github.event.issue.state || '' }}
           EVENT_ISSUE_PR_URL: ${{ github.event.issue.pull_request.url || '' }}
+          COMMENT_USER_TYPE: ${{ github.event.comment.user.type || '' }}
+          COMMENT_USER_ID: ${{ github.event.comment.user.id || '' }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
         run: |
           set -euo pipefail
@@ -66,6 +70,12 @@ jobs:
           sign_phrase='I have read the CLA Document and I hereby sign the CLA'
           if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
             [[ "${EVENT_ISSUE_STATE}" == "open" && -n "${EVENT_ISSUE_PR_URL}" ]] || fail "The comment is not on an open pull request."
+            [[ "${COMMENT_USER_TYPE}" == "User" ]] || fail "Only a human GitHub user can trigger CLA comment processing."
+            [[ "${COMMENT_USER_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The comment author has no valid GitHub user ID."
+            if (( ${#COMMENT_USER_ID} > 16 )) ||
+               (( ${#COMMENT_USER_ID} == 16 && COMMENT_USER_ID > 9007199254740991 )); then
+              fail "The comment author has an unsafe GitHub user ID."
+            fi
             [[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "${sign_phrase}" ]] || fail "Use the exact signing comment or the exact recheck command."
           elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
             case "${EVENT_ACTION}" in
@@ -97,6 +107,8 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           github.event.issue.state == 'open' &&
+          github.event.comment.user.type == 'User' &&
+          github.event.comment.user.id > 0 &&
           (
             github.event.comment.body == 'recheck' ||
             github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
@@ -405,6 +417,8 @@ jobs:
               github.event_name == 'issue_comment' &&
               github.event.issue.pull_request &&
               github.event.issue.state == 'open' &&
+              github.event.comment.user.type == 'User' &&
+              github.event.comment.user.id > 0 &&
               (
                 github.event.comment.body == 'recheck' ||
                 github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
@@ -432,6 +446,9 @@ jobs:
           # Keep the impersonation guard explicit. The action requires the
           # authenticated Pull Request opener to appear as an author or
           # co-author unless a maintainer deliberately opts out.
+          # Bot-opened Pull Requests remain fail-closed. Add a reviewed numeric
+          # allowlist-ids entry only for an approved automation opener; raw
+          # names and emails are never trusted.
           require-opener-as-author: 'true'
 
   LockMergedPullRequest:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,11 +28,12 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Signature updates share one file. GitHub keeps one running and one
-    # pending run for this group; cancel-in-progress=false preserves the
-    # running update while a newer event may replace the pending update.
+    # Scope concurrency to this repository and Pull Request. GitHub keeps one
+    # running and one pending run for this group; cancel-in-progress=false
+    # preserves the running update while a newer event may replace the pending
+    # update. The maintained action retries bounded ledger conflicts.
     concurrency:
-      group: cla-signatures
+      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     permissions:
       # The maintained in-organization action validates the live Pull Request
@@ -129,11 +130,11 @@ jobs:
             echo "::error title=CLA preflight failed::GitHub returned an invalid commit count for pull request ${PR_NUMBER}." >&2
             exit 1
           fi
-          if (( commits > 100 )); then
-            echo "::error title=CLA preflight failed::Pull request ${PR_NUMBER} has ${commits} commits. The pinned CLA Assistant inspects only the first 100 commits; squash or split the pull request before requesting CLA validation." >&2
+          if (( commits > 1000 )); then
+            echo "::error title=CLA preflight failed::Pull request ${PR_NUMBER} has ${commits} commits. The maintained CLA Assistant supports at most 1,000 commits; squash or split the pull request before requesting CLA validation." >&2
             exit 1
           fi
-          echo "CLA preflight passed: ${commits} commits (maximum 100)."
+          echo "CLA preflight passed: ${commits} commits (maximum 1,000)."
           echo "validated=true" >> "${GITHUB_OUTPUT}"
 
       - name: "Validate historical CLA declarations"
@@ -376,9 +377,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Locking a merged PR does not need signature or repository-write access.
-    # Share the signature group so lock and signature updates cannot race.
+    # Use the same repository-and-PR group so its lock and signature updates
+    # cannot race for this Pull Request.
     concurrency:
-      group: cla-signatures
+      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     permissions:
       issues: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,18 +5,29 @@ on:
   pull_request_target:
     branches: [main]
     # Retargeting and other edits must run the same fail-closed validation.
-    types: [opened,closed,edited,reopened,synchronize]
+    types: [opened,closed,reopened,synchronize,edited]
 
 # Keep the default token empty. Each job grants only the permissions it uses.
 permissions: {}
 
+# Maintained action generation: v2.2, runtime and dist pinned at
+# bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e.
+
 jobs:
-  CLAAssistant:
-    name: "CLA Assistant v2"
+  CLACommentGate:
+    name: "Validate CLA trigger"
+    # This job is unprivileged. Its expression is coarse admission; the shell
+    # step is the exact, case-sensitive authority for comment text.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
-        github.event.action != 'closed'
+        github.event.pull_request.state == 'open' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize' ||
+          github.event.action == 'edited'
+        )
       ) ||
       (
         github.event_name == 'issue_comment' &&
@@ -28,13 +39,78 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Bound admission by repository, event class, and Pull Request. This keeps
+    # public comment traffic from sharing a queue with pull request events.
+    concurrency:
+      group: "cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      cancel-in-progress: false
+    permissions: {}
+    steps:
+      - name: "Validate exact CLA trigger"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
+          EVENT_PR_STATE: ${{ github.event.pull_request.state || '' }}
+          EVENT_ISSUE_STATE: ${{ github.event.issue.state || '' }}
+          EVENT_ISSUE_PR_URL: ${{ github.event.issue.pull_request.url || '' }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+        run: |
+          set -euo pipefail
+          shopt -u nocasematch
+          fail() {
+            echo "::error title=CLA trigger policy::${1}"
+            exit 1
+          }
+
+          sign_phrase='I have read the CLA Document and I hereby sign the CLA'
+          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
+            [[ "${EVENT_ISSUE_STATE}" == "open" && -n "${EVENT_ISSUE_PR_URL}" ]] || fail "The comment is not on an open pull request."
+            [[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "${sign_phrase}" ]] || fail "Use the exact signing comment or the exact recheck command."
+          elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            case "${EVENT_ACTION}" in
+              opened|reopened|synchronize|edited) ;;
+              *) fail "The pull request event is not an accepted CLA trigger." ;;
+            esac
+            [[ "${EVENT_PR_STATE}" == "open" ]] || fail "The pull request is not open for CLA signing."
+          else
+            fail "The event is not an accepted CLA trigger."
+          fi
+
+  CLAAssistant:
+    needs: CLACommentGate
+    name: "CLA Assistant v2"
+    if: >-
+      needs.CLACommentGate.result == 'success' &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.state == 'open' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'edited'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          github.event.issue.state == 'open' &&
+          (
+            github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          )
+        )
+      )
+    runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Scope concurrency to this repository and Pull Request. GitHub keeps one
-    # running and one pending run for this group; cancel-in-progress=false
+    # Serialize signature writes per repository and Pull Request. GitHub keeps
+    # one running and one pending run for this group; cancel-in-progress=false
     # preserves the running update while a newer event may replace the pending
     # update. The maintained action handles bounded ledger writes.
     concurrency:
-      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: "cla-signatures-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
       cancel-in-progress: false
     permissions:
       # The maintained in-organization action validates the live Pull Request
@@ -317,7 +393,13 @@ jobs:
           (
             (
               github.event_name == 'pull_request_target' &&
-              github.event.action != 'closed'
+              github.event.pull_request.state == 'open' &&
+              (
+                github.event.action == 'opened' ||
+                github.event.action == 'reopened' ||
+                github.event.action == 'synchronize' ||
+                github.event.action == 'edited'
+              )
             ) ||
             (
               github.event_name == 'issue_comment' &&
@@ -329,7 +411,7 @@ jobs:
               )
             )
           )
-        uses: manaflow-ai/cla-github-action@c327a6f4071730000bf03f9f85c87d30e1fe8084 # reviewed maintained runtime action, source and dist pinned together
+        uses: manaflow-ai/cla-github-action@bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e # reviewed maintained runtime action, source and dist pinned together
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -359,12 +441,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Locking a merged PR does not need signature or repository-write access.
-    # Use the same repository-and-PR group so its lock and signature updates
-    # cannot race for this Pull Request.
+    # Use the same repository-and-PR group so lock and signature updates cannot
+    # race for this Pull Request.
     # The lock preflight keeps base and opener identity immutable while it
     # permits a merged source head to advance or disappear.
     concurrency:
-      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: "cla-signatures-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
       cancel-in-progress: false
     permissions:
       issues: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,6 +27,37 @@ jobs:
     name: "CLA Assistant"
     runs-on: ubuntu-latest
     steps:
+      - name: "Check commit count before CLA validation"
+        if: >-
+          (
+            github.event_name == 'pull_request_target' &&
+            github.event.action != 'closed'
+          ) ||
+          (
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            (
+              github.event.comment.body == 'recheck' ||
+              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            )
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')"
+          if ! [[ "${commits}" =~ ^[0-9]+$ ]]; then
+            echo "::error title=CLA preflight failed::GitHub returned an invalid commit count for pull request ${PR_NUMBER}." >&2
+            exit 1
+          fi
+          if (( commits > 100 )); then
+            echo "::error title=CLA preflight failed::Pull request ${PR_NUMBER} has ${commits} commits. The pinned CLA Assistant inspects only the first 100 commits; squash or split the pull request before requesting CLA validation." >&2
+            exit 1
+          fi
+          echo "CLA preflight passed: ${commits} commits (maximum 100)."
+
       - name: "CLA Assistant"
         # The action handles signing and status updates. Merged pull requests
         # use the explicit lock step below because the archived action sends

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -122,12 +122,14 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Serialize signature writes per repository and Pull Request. GitHub keeps
+    # Serialize signature writes per repository, event class, and Pull Request.
+    # Keeping issue comments apart from pull-request lifecycle events prevents
+    # a comment run from replacing a pending lifecycle validation. GitHub keeps
     # one running and one pending run for this group; cancel-in-progress=false
     # preserves the running update while a newer event may replace the pending
     # update. The maintained action handles bounded ledger writes.
     concurrency:
-      group: "cla-signatures-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      group: "cla-signatures-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event_name }}"
       cancel-in-progress: false
     permissions:
       # The maintained in-organization action validates the live Pull Request

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: "CLA Assistant"
+name: "CLA Assistant v2"
 on:
   issue_comment:
     types: [created]
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   CLAAssistant:
-    name: "CLA Assistant"
+    name: "CLA Assistant v2"
     if: >-
       (
         github.event_name == 'pull_request_target' &&
@@ -163,7 +163,7 @@ jobs:
           fi
           echo "validated=true" >> "${GITHUB_OUTPUT}"
 
-      - name: "CLA Assistant"
+      - name: "CLA Assistant v2"
         # The action handles signing and status updates. Merged pull requests
         # use the separate lock job below because the archived action sends an
         # invalid lock request.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -219,9 +219,10 @@ jobs:
           expected-comment-created-at: "${{ needs.CLACommentGate.outputs.comment_created_at }}"
           expected-comment-author-id: "${{ needs.CLACommentGate.outputs.comment_author_id }}"
 
-  # This no-permission job owns the required v3 check context. A gate or writer
-  # failure, including a stale-base admission, is visible as a failed check
-  # instead of being hidden as a skipped privileged job.
+  # This no-permission job owns the required v3 check context for the
+  # pull_request_target lifecycle only. Issue-comment runs execute on the
+  # default branch SHA, so they must never publish this required context; the
+  # rerun job below updates the original pull-request check instead.
   CLAAssistant:
     name: "CLA Assistant v3"
     needs:
@@ -230,27 +231,12 @@ jobs:
     if: >-
       always() &&
       needs.CLACommentGate.outputs.ignored != 'true' &&
+      github.event_name == 'pull_request_target' &&
       (
-        (
-          github.event_name == 'pull_request_target' &&
-          (
-            github.event.action == 'opened' ||
-            github.event.action == 'edited' ||
-            github.event.action == 'reopened' ||
-            github.event.action == 'synchronize'
-          )
-        ) ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.action == 'created' &&
-          github.event.issue.state == 'open' &&
-          github.event.issue.pull_request &&
-          github.event.comment.user.type == 'User' &&
-          (
-            github.event.comment.body == 'recheck' ||
-            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
-          )
-        )
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize'
       )
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -271,12 +257,8 @@ jobs:
       # helper uses the rendered step name to reject older workflow runs.
       - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af-workflow-${{ github.workflow_sha }}"
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body || '' }}
           GATE_RESULT: ${{ needs.CLACommentGate.result }}
           ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
-          SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
-          SIGNER_DECISION: ${{ needs.CLACommentGate.outputs.signer_decision || '' }}
           BASE_STALE: ${{ needs.CLACommentGate.outputs.base_stale || '' }}
           WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
           CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
@@ -290,13 +272,6 @@ jobs:
               echo "::error::CLA trigger admission failed"
             fi
             exit 1
-          fi
-          if [[ "${EVENT_NAME}" == "issue_comment" &&
-                "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
-            if [[ "${SIGNER_AUTHORIZED}" != "true" || "${SIGNER_DECISION}" != "authorized" ]]; then
-              echo "::error::CLA signer preflight failed"
-              exit 1
-            fi
           fi
           if [[ "${WRITER_RESULT}" != "success" || "${CLA_PASSED}" != "true" ]]; then
             echo "::error::CLA ledger writer did not report cla_passed=true"
@@ -352,12 +327,10 @@ jobs:
     needs:
       - CLACommentGate
       - CLALedgerWriter
-      - CLAAssistant
     if: >-
       always() &&
       needs.CLACommentGate.result == 'success' &&
       needs.CLACommentGate.outputs.admitted == 'true' &&
-      needs.CLAAssistant.result != 'skipped' &&
       github.event_name == 'issue_comment' &&
       github.event.action == 'created' &&
       github.event.issue.state == 'open' &&

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,8 @@ on:
     types: [created]
   pull_request_target:
     branches: [main]
-    types: [opened,closed,reopened,synchronize]
+    # Retargeting and other edits must run the same fail-closed validation.
+    types: [opened,closed,edited,reopened,synchronize]
 
 # Keep the default token empty. Each job grants only the permissions it uses.
 permissions: {}
@@ -31,7 +32,7 @@ jobs:
     # Scope concurrency to this repository and Pull Request. GitHub keeps one
     # running and one pending run for this group; cancel-in-progress=false
     # preserves the running update while a newer event may replace the pending
-    # update. The maintained action retries bounded ledger conflicts.
+    # update. The maintained action handles bounded ledger writes.
     concurrency:
       group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
@@ -54,6 +55,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
           EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
           EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
           EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
@@ -64,6 +66,16 @@ jobs:
           if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error title=CLA preflight failed::Invalid pull request number."
             exit 1
+          fi
+          if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            case "${EVENT_ACTION}" in
+              opened|edited|reopened|synchronize)
+                ;;
+              *)
+                echo "::error title=CLA preflight failed::Unsupported pull_request_target action."
+                exit 1
+                ;;
+            esac
           fi
 
           pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
@@ -321,7 +333,10 @@ jobs:
       - name: "CLA Assistant v2"
         # The action handles signing and status updates. Merged pull requests
         # use the separate lock job below so lock writes share serialization
-        # and the workflow's live identity checks.
+        # and the workflow's live identity checks. All repository, base, head,
+        # and opener predicates run in the preflight step above. Keep this
+        # gate to event shape so malformed payloads fail in a running step,
+        # rather than becoming a skipped-success required check.
         if: >-
           steps.cla_preflight.outputs.validated == 'true' &&
           steps.cla_history.outputs.validated == 'true' &&
@@ -329,13 +344,7 @@ jobs:
           (
             (
               github.event_name == 'pull_request_target' &&
-              github.event.action != 'closed' &&
-              github.event.pull_request.state == 'open' &&
-              github.event.pull_request.base.ref == 'main' &&
-              github.event.pull_request.base.repo.full_name == github.repository &&
-              github.event.pull_request.head.repo.full_name != '' &&
-              github.event.pull_request.head.repo.id > 0 &&
-              github.event.pull_request.head.sha != ''
+              github.event.action != 'closed'
             ) ||
             (
               github.event_name == 'issue_comment' &&
@@ -347,7 +356,7 @@ jobs:
               )
             )
           )
-        uses: manaflow-ai/cla-github-action@a34b7274a1f68a0d7bcb11e62a5f1454ea15515c # reviewed maintained action
+        uses: manaflow-ai/cla-github-action@c327a6f4071730000bf03f9f85c87d30e1fe8084 # reviewed maintained runtime action, source and dist pinned together
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -379,6 +388,8 @@ jobs:
     # Locking a merged PR does not need signature or repository-write access.
     # Use the same repository-and-PR group so its lock and signature updates
     # cannot race for this Pull Request.
+    # The lock preflight keeps base and opener identity immutable while it
+    # permits a merged source head to advance or disappear.
     concurrency:
       group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
@@ -390,8 +401,122 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
+          EVENT_REPOSITORY: ${{ github.event.repository.full_name || '' }}
+          EVENT_REPOSITORY_ID: ${{ github.event.repository.id || '' }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          EVENT_PR_STATE: ${{ github.event.pull_request.state || '' }}
+          EVENT_PR_MERGED: ${{ github.event.pull_request.merged || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
+          EVENT_BASE_REPOSITORY_ID: ${{ github.event.pull_request.base.repo.id || '' }}
+          EVENT_OPENER_LOGIN: ${{ github.event.pull_request.user.login || '' }}
+          EVENT_OPENER_ID: ${{ github.event.pull_request.user.id || '' }}
         run: |
           set -euo pipefail
+          # The event is untrusted. Validate the immutable event identity and
+          # the live merged Pull Request before writing the lock. The live
+          # source head is intentionally not compared with the event head:
+          # GitHub can advance or delete that source after a merge.
+          is_safe_positive_integer() {
+            local value="$1"
+            [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
+            if (( ${#value} > 16 )); then
+              return 1
+            fi
+            if (( ${#value} == 16 )) && (( value > 9007199254740991 )); then
+              return 1
+            fi
+          }
+
+          fail_lock_preflight() {
+            echo "::error title=CLA lock preflight failed::The closed pull_request_target identity did not pass live validation." >&2
+            exit 1
+          }
+
+          is_safe_positive_integer "${PR_NUMBER}" || fail_lock_preflight
+          if [[ "${EVENT_NAME}" != "pull_request_target" ||
+                "${EVENT_ACTION}" != "closed" ||
+                "${EVENT_PR_STATE}" != "closed" ||
+                "${EVENT_PR_MERGED}" != "true" ||
+                "${EVENT_PR_NUMBER}" != "${PR_NUMBER}" ||
+                -z "${EVENT_REPOSITORY}" ||
+                "${EVENT_REPOSITORY,,}" != "${GH_REPO,,}" ||
+                -z "${EVENT_BASE_REF}" ||
+                -z "${EVENT_BASE_REPOSITORY}" ||
+                -z "${EVENT_BASE_REPOSITORY_ID}" ||
+                -z "${EVENT_OPENER_LOGIN}" ||
+                -z "${EVENT_OPENER_ID}" ]]; then
+            fail_lock_preflight
+          fi
+          is_safe_positive_integer "${EVENT_REPOSITORY_ID}" || fail_lock_preflight
+          is_safe_positive_integer "${EVENT_BASE_REPOSITORY_ID}" || fail_lock_preflight
+          is_safe_positive_integer "${EVENT_OPENER_ID}" || fail_lock_preflight
+
+          pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
+          if ! live_pr_json="$(gh api "${pr_endpoint}" --jq '
+            {
+              number: .number,
+              state: (.state // ""),
+              merged: (.merged_at != null),
+              base_ref: (.base.ref // ""),
+              base_repo: (if .base.repo == null then null else (.base.repo.full_name // "") end),
+              base_repo_id: (if .base.repo == null then null else (.base.repo.id // null) end),
+              head_sha: (.head.sha // ""),
+              head_ref: (.head.ref // ""),
+              head_repo: (if .head.repo == null then null else (.head.repo.full_name // "") end),
+              head_repo_id: (if .head.repo == null then null else (.head.repo.id // null) end),
+              opener_login: (if .user == null then "" else (.user.login // "") end),
+              opener_id: (if .user == null then null else (.user.id // null) end)
+            }
+          ' 2>/dev/null)"; then
+            fail_lock_preflight
+          fi
+
+          if ! jq -e --arg pr "${PR_NUMBER}" --arg repo "${GH_REPO}" '
+            def safe_id:
+              type == "number" and floor == . and . > 0 and . <= 9007199254740991;
+            def nonempty_string:
+              type == "string" and (gsub("^\\s+|\\s+$"; "") | length > 0);
+            (.number | type == "number") and
+            ((.number | tostring) == $pr) and
+            (.state == "closed") and
+            (.merged == true) and
+            (.base_ref | nonempty_string) and
+            (.base_repo | nonempty_string) and
+            ((.base_repo | ascii_downcase) == ($repo | ascii_downcase)) and
+            (.base_repo_id | safe_id) and
+            (.head_sha | nonempty_string) and
+            (.head_ref | nonempty_string) and
+            (if .head_repo == null then true else
+              (.head_repo | nonempty_string) and
+              (.head_repo_id | safe_id)
+            end) and
+            (.opener_login | nonempty_string) and
+            (.opener_id | safe_id)
+          ' <<<"${live_pr_json}" >/dev/null 2>&1; then
+            fail_lock_preflight
+          fi
+
+          if ! live_base_ref="$(jq -er '.base_ref | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
+             ! live_base_repo="$(jq -er '.base_repo | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
+             ! live_base_repo_id="$(jq -er '.base_repo_id | numbers | tostring' <<<"${live_pr_json}" 2>/dev/null)" ||
+             ! live_opener_login="$(jq -er '.opener_login | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
+             ! live_opener_id="$(jq -er '.opener_id | numbers | tostring' <<<"${live_pr_json}" 2>/dev/null)"; then
+            fail_lock_preflight
+          fi
+          is_safe_positive_integer "${live_base_repo_id}" || fail_lock_preflight
+          is_safe_positive_integer "${live_opener_id}" || fail_lock_preflight
+          if [[ "${EVENT_BASE_REF}" != "${live_base_ref}" ||
+                "${EVENT_BASE_REPOSITORY,,}" != "${live_base_repo,,}" ||
+                "${EVENT_BASE_REPOSITORY_ID}" != "${live_base_repo_id}" ||
+                "${EVENT_REPOSITORY_ID}" != "${live_base_repo_id}" ||
+                "${EVENT_OPENER_ID}" != "${live_opener_id}" ||
+                "${EVENT_OPENER_LOGIN,,}" != "${live_opener_login,,}" ]]; then
+            fail_lock_preflight
+          fi
+
           issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
           lock_endpoint="${issue_endpoint}/lock"
           if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
@@ -406,7 +531,7 @@ jobs:
             false)
             ;;
             *)
-            echo "::error title=CLA lock failed::GitHub returned an invalid lock state for pull request ${PR_NUMBER}: ${locked}." >&2
+            echo "::error title=CLA lock failed::GitHub returned an invalid lock state for this pull request." >&2
             exit 1
             ;;
           esac

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,42 +5,44 @@ on:
   pull_request_target:
     types: [opened,closed,reopened,synchronize]
 
-# Signature updates share one file and must not race.
-concurrency:
-  group: cla-signatures
-  cancel-in-progress: false
-
-# Keep the token scoped to the GitHub API operations used by this action.
-permissions:
-  # The action inspects prior runs; its optional rerun request is best-effort.
-  actions: read
-  contents: write
-  issues: write
-  # GitHub's pull_request_target token denied issue comments for fork PRs with
-  # this set to read, despite the endpoint documentation allowing issues:write.
-  # Keep write until that live behavior changes.
-  pull-requests: write
-  statuses: write
+# Keep the default token empty. Each job grants only the permissions it uses.
+permissions: {}
 
 jobs:
   CLAAssistant:
     name: "CLA Assistant"
+    if: >-
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.action != 'closed'
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        )
+      )
     runs-on: ubuntu-latest
+    # Signature updates share one file. Queue every pending validation instead
+    # of dropping all but the newest event.
+    concurrency:
+      group: cla-signatures
+      queue: max
+      cancel-in-progress: false
+    permissions:
+      # The action inspects prior runs; its optional rerun request is best-effort.
+      actions: read
+      contents: write
+      issues: write
+      # GitHub's pull_request_target token denied issue comments for fork PRs
+      # with this set to read, despite the endpoint documentation allowing
+      # issues:write. Keep write until that live behavior changes.
+      pull-requests: write
+      statuses: write
     steps:
       - name: "Check commit count before CLA validation"
-        if: >-
-          (
-            github.event_name == 'pull_request_target' &&
-            github.event.action != 'closed'
-          ) ||
-          (
-            github.event_name == 'issue_comment' &&
-            github.event.issue.pull_request &&
-            (
-              github.event.comment.body == 'recheck' ||
-              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
-            )
-          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -60,42 +62,35 @@ jobs:
 
       - name: "CLA Assistant"
         # The action handles signing and status updates. Merged pull requests
-        # use the explicit lock step below because the archived action sends
-        # an invalid lock request.
-        if: >-
-          (
-            github.event_name == 'pull_request_target' &&
-            github.event.action != 'closed'
-          ) ||
-          (
-            github.event_name == 'issue_comment' &&
-            github.event.issue.pull_request &&
-            (
-              github.event.comment.body == 'recheck' ||
-              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
-            )
-          )
+        # use the separate lock job below because the archived action sends an
+        # invalid lock request.
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/main/CLA.md'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           # The archived action calls the lock endpoint without the required
-          # lock_reason. Disable that broken path and use the explicit step
+          # lock_reason. Disable that broken path and use the explicit job
           # below, which supplies a valid reason and fails on API errors.
           lock-pullrequest-aftermerge: 'false'
-          # signatures live on the unprotected cla-signatures branch so required checks on main don't block the bot's signature commits
+          # signatures live on the unprotected cla-signatures branch so
+          # required checks on main don't block the bot's signature commits.
           branch: 'cla-signatures'
-          # Keep this list explicit. A username prefix is not proof that an
-          # account is a GitHub bot and would let a human bypass the CLA.
-          allowlist: lawrencecchen,github-actions[bot],chatmux-connections[bot]
 
+  LockMergedPullRequest:
+    name: "Lock merged pull request"
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    # Locking a merged PR does not need signature or repository-write access.
+    permissions:
+      issues: write
+    steps:
       - name: "Lock merged pull request"
-        if: >-
-          github.event_name == 'pull_request_target' &&
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -220,8 +220,8 @@ jobs:
           expected-comment-author-id: "${{ needs.CLACommentGate.outputs.comment_author_id }}"
 
   # This no-permission job owns the required v3 check context. A gate or writer
-  # failure is visible as a failed check instead of being hidden as a skipped
-  # privileged job.
+  # failure, including a stale-base admission, is visible as a failed check
+  # instead of being hidden as a skipped privileged job.
   CLAAssistant:
     name: "CLA Assistant v3"
     needs:
@@ -277,13 +277,18 @@ jobs:
           ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
           SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
           SIGNER_DECISION: ${{ needs.CLACommentGate.outputs.signer_decision || '' }}
+          BASE_STALE: ${{ needs.CLACommentGate.outputs.base_stale || '' }}
           WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
           CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
         run: |
           set -euo pipefail
           echo "CLA generation ${CLA_GENERATION}"
           if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
-            echo "::error::CLA trigger admission failed"
+            if [[ "${BASE_STALE}" == "true" ]]; then
+              echo "::error::CLA trigger snapshot is stale; wait for a synchronize event or post the exact CLA declaration again"
+            else
+              echo "::error::CLA trigger admission failed"
+            fi
             exit 1
           fi
           if [[ "${EVENT_NAME}" == "issue_comment" &&

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -381,6 +381,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       actions: write
+      checks: read
       contents: read
       issues: read
       pull-requests: read

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -67,6 +67,15 @@ jobs:
       comment_created_at: ${{ steps.signer_preflight.outputs.comment_created_at || '' }}
       comment_author_id: ${{ steps.signer_preflight.outputs.comment_author_id || '' }}
     steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment || '' }}
+        run: |
+          set -euo pipefail
+          [[ "${RUNNER_ENVIRONMENT}" == "github-hosted" ]] || {
+            echo "::error::CLA policy jobs require a GitHub-hosted runner"
+            exit 1
+          }
       - name: "Checkout trusted CLA admission policy"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -246,6 +255,15 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment || '' }}
+        run: |
+          set -euo pipefail
+          [[ "${RUNNER_ENVIRONMENT}" == "github-hosted" ]] || {
+            echo "::error::CLA policy jobs require a GitHub-hosted runner"
+            exit 1
+          }
       # Keep the generation marker on the required check's only step. The
       # marker must remain visible when this result fails because the writer
       # failed in the original pull_request_target run. The immutable rerun
@@ -299,6 +317,15 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment || '' }}
+        run: |
+          set -euo pipefail
+          [[ "${RUNNER_ENVIRONMENT}" == "github-hosted" ]] || {
+            echo "::error::CLA policy jobs require a GitHub-hosted runner"
+            exit 1
+          }
       - name: "Mirror CLA Assistant compatibility result"
         env:
           RESULT: ${{ needs.CLAAssistant.result }}
@@ -413,7 +440,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: "Require GitHub-hosted runner"
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,11 +9,11 @@ on:
 
 permissions: {}
 
-# This marker changes only when the policy or maintained action changes. It
-# gives the rerun worker a stable generation that is independent of unrelated
-# commits on main.
+# This marker includes the maintained action and the exact workflow revision.
+# The rerun worker uses the step name to reject a failed run that would replay
+# an older privileged workflow definition.
 env:
-  CLA_GENERATION: "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+  CLA_GENERATION: "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af-workflow-${{ github.workflow_sha }}"
 
 # Numeric IDs are immutable. They identify Austin Wang (@austinywang, 38676809)
 # and Abdulaziz Albahar (@azooz2003-bit, 67667005); names and e-mail addresses
@@ -269,7 +269,7 @@ jobs:
       # marker must remain visible when this result fails because the writer
       # failed in the original pull_request_target run. The immutable rerun
       # helper uses the rendered step name to reject older workflow runs.
-      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af-workflow-${{ github.workflow_sha }}"
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,6 @@ jobs:
       # with this set to read, despite the endpoint documentation allowing
       # issues:write. Keep write until that live behavior changes.
       pull-requests: write
-      statuses: write
     steps:
       - name: "Check commit count before CLA validation"
         env:
@@ -49,7 +48,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           set -euo pipefail
-          commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')"
+          if ! commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')"; then
+            echo "::error title=CLA preflight failed::Could not read pull request ${PR_NUMBER} from GitHub." >&2
+            exit 1
+          fi
           if ! [[ "${commits}" =~ ^[0-9]+$ ]]; then
             echo "::error title=CLA preflight failed::GitHub returned an invalid commit count for pull request ${PR_NUMBER}." >&2
             exit 1
@@ -69,7 +71,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/main/CLA.md'
+          # Pin the document to this workflow revision so later edits cannot
+          # change the terms shown for an existing signature request.
+          path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           # The archived action calls the lock endpoint without the required
           # lock_reason. Disable that broken path and use the explicit job
@@ -87,6 +91,11 @@ jobs:
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     # Locking a merged PR does not need signature or repository-write access.
+    # Share the signature queue so lock and signature updates cannot race.
+    concurrency:
+      group: cla-signatures
+      queue: max
+      cancel-in-progress: false
     permissions:
       issues: write
     steps:
@@ -99,13 +108,35 @@ jobs:
           set -euo pipefail
           issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
           lock_endpoint="${issue_endpoint}/lock"
-          if [[ "$(gh api "${issue_endpoint}" --jq '.locked')" == "true" ]]; then
+          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked')"; then
+            echo "::error title=CLA lock failed::Could not read lock state for pull request ${PR_NUMBER}." >&2
+            exit 1
+          fi
+          case "${locked}" in
+            true)
             echo "Pull request ${PR_NUMBER} is already locked"
             exit 0
-          fi
-          gh api --method PUT \
+            ;;
+            false)
+            ;;
+            *)
+            echo "::error title=CLA lock failed::GitHub returned an invalid lock state for pull request ${PR_NUMBER}: ${locked}." >&2
+            exit 1
+            ;;
+          esac
+          if ! gh api --method PUT \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             "${lock_endpoint}" \
-            --field lock_reason=resolved
-          [[ "$(gh api "${issue_endpoint}" --jq '.locked')" == "true" ]]
+            --field lock_reason=resolved; then
+            echo "::error title=CLA lock failed::Could not lock pull request ${PR_NUMBER}." >&2
+            exit 1
+          fi
+          if ! locked_after="$(gh api "${issue_endpoint}" --jq '.locked')"; then
+            echo "::error title=CLA lock failed::Could not verify lock state for pull request ${PR_NUMBER}." >&2
+            exit 1
+          fi
+          if [[ "${locked_after}" != "true" ]]; then
+            echo "::error title=CLA lock failed::GitHub did not report pull request ${PR_NUMBER} as locked after the lock request." >&2
+            exit 1
+          fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,493 +1,383 @@
-name: "CLA Assistant v2"
+name: "CLA Assistant v3"
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     branches: [main]
-    # Retargeting and other edits must run the same fail-closed validation.
-    types: [opened,closed,reopened,synchronize,edited]
+    types: [opened,closed,edited,reopened,synchronize]
 
-# Keep the default token empty. Each job grants only the permissions it uses.
 permissions: {}
 
-# Maintained action generation: v2.2, runtime and dist pinned at
-# bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e.
+# This marker changes only when the policy or maintained action changes. It
+# gives the rerun worker a stable generation that is independent of unrelated
+# commits on main.
+env:
+  CLA_GENERATION: "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+
+# Numeric IDs are immutable. They identify Austin Wang (@austinywang, 38676809)
+# and Abdulaziz Albahar (@azooz2003-bit, 67667005); names and e-mail addresses
+# are not safe identity inputs.
 
 jobs:
+  # This job has read-only permissions. It performs the exact event check and
+  # authenticates a new signing comment before any write-capable job starts.
   CLACommentGate:
     name: "Validate CLA trigger"
-    # This job is unprivileged. Its expression is coarse admission; the shell
-    # step is the exact, case-sensitive authority for comment text. Human
-    # comments that are not an exact command are ignored with admitted=false,
-    # while malformed event data fails closed. Keep the body predicate here so
-    # ordinary public comments do not enter the admission concurrency queue;
-    # the shell repeats the byte-exact check because expression equality is
-    # case-insensitive.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
-        github.event.action != 'closed'
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'edited' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize'
+        )
       ) ||
       (
         github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
+        github.event.action == 'created' &&
         github.event.issue.state == 'open' &&
+        github.event.issue.pull_request &&
         github.event.comment.user.type == 'User' &&
-        github.event.comment.user.id > 0 &&
         (
           github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
         )
       )
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # Bound admission by repository, event class, and Pull Request. This keeps
-    # public comment traffic from sharing a queue with pull request events.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     concurrency:
-      group: "cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      group: cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
-    permissions: {}
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     outputs:
-      admitted: ${{ steps.validate-trigger.outputs.admitted }}
+      admitted: ${{ steps.admission.outputs.admitted }}
+      trusted_recheck: ${{ steps.admission.outputs.trusted_recheck || '' }}
+      signing: ${{ steps.admission.outputs.signing || '' }}
+      signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized || '' }}
+      signer_decision: ${{ steps.signer_preflight.outputs.signer_decision || '' }}
+      head_sha: ${{ steps.signer_preflight.outputs.head_sha || steps.admission.outputs.head_sha || '' }}
+      base_sha: ${{ steps.signer_preflight.outputs.base_sha || steps.admission.outputs.base_sha || '' }}
+      comment_id: ${{ steps.signer_preflight.outputs.comment_id || '' }}
+      comment_created_at: ${{ steps.signer_preflight.outputs.comment_created_at || '' }}
+      comment_author_id: ${{ steps.signer_preflight.outputs.comment_author_id || '' }}
     steps:
-      - name: "Validate exact CLA trigger"
-        id: validate-trigger
+      - name: "Checkout trusted CLA admission policy"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: manaflow-ai/manaflow
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/validate-cla-trigger.sh
+          sparse-checkout-cone-mode: false
+      - name: "Validate exact CLA trigger against live pull request"
+        id: admission
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_REPOSITORY: ${{ github.event.repository.full_name || '' }}
+          EVENT_REPOSITORY_ID: ${{ github.event.repository.id || '' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action || '' }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || '' }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           EVENT_PR_STATE: ${{ github.event.pull_request.state || '' }}
           EVENT_ISSUE_STATE: ${{ github.event.issue.state || '' }}
           EVENT_ISSUE_PR_URL: ${{ github.event.issue.pull_request.url || '' }}
-          COMMENT_USER_TYPE: ${{ github.event.comment.user.type || '' }}
-          COMMENT_USER_ID: ${{ github.event.comment.user.id || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
+          EVENT_BASE_REPOSITORY_ID: ${{ github.event.pull_request.base.repo.id || '' }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          EVENT_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || '' }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
-        run: |
-          set -euo pipefail
-          shopt -u nocasematch
-          admitted=false
-          fail() {
-            echo "::error title=CLA trigger policy::${1}"
-            exit 1
-          }
+          COMMENT_ID: ${{ github.event.comment.id || '' }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at || '' }}
+          COMMENT_UPDATED_AT: ${{ github.event.comment.updated_at || '' }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id || '' }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || '' }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
+        run: bash .github/scripts/validate-cla-trigger.sh
 
-          sign_phrase='I have read the CLA Document and I hereby sign the CLA'
-          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
-            [[ "${EVENT_ISSUE_STATE}" == "open" && -n "${EVENT_ISSUE_PR_URL}" ]] || fail "The comment is not on an open pull request."
-            # Non-human and malformed commenter identities are ignored. They
-            # must never reach the maintained action, but they are ordinary
-            # public comment traffic rather than a workflow error.
-            if [[ "${COMMENT_USER_TYPE}" != "User" ]] ||
-               ! [[ "${COMMENT_USER_ID}" =~ ^[1-9][0-9]*$ ]] ||
-               (( ${#COMMENT_USER_ID} > 16 )) ||
-               (( ${#COMMENT_USER_ID} == 16 && COMMENT_USER_ID > 9007199254740991 )); then
-              printf 'admitted=%s\n' "${admitted}" >> "${GITHUB_OUTPUT}"
-              echo "CLA event ignored: commenter is not a safe human identity"
-              exit 0
-            fi
-            if [[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "${sign_phrase}" ]]; then
-              admitted=true
-            fi
-          elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
-            case "${EVENT_ACTION}" in
-              opened|reopened|synchronize|edited) ;;
-              *) fail "The pull request event is not an accepted CLA trigger." ;;
-            esac
-            [[ "${EVENT_PR_STATE}" == "open" ]] || fail "The pull request is not open for CLA signing."
-            admitted=true
-          else
-            fail "The event is not an accepted CLA trigger."
-          fi
+      - name: "Authenticate exact CLA signer"
+        id: signer_preflight
+        if: >-
+          success() &&
+          steps.admission.outputs.signing == 'true'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "signer-preflight"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          require-opener-as-author: "true"
+          allowlist-ids: "38676809,67667005"
 
-          printf 'admitted=%s\n' "${admitted}" >> "${GITHUB_OUTPUT}"
-          if [[ "${admitted}" != "true" ]]; then
-            echo "CLA event ignored: comment body is not an exact command"
-            exit 0
-          fi
-          echo "CLA event admitted"
-
-  CLAAssistant:
+  # This is the only job with ledger and comment write permissions. It has no
+  # shell step, so policy text cannot execute with its token. The action repeats
+  # live PR/comment validation and binds a signing write to the exact head SHA
+  # observed by the read-only gate.
+  CLALedgerWriter:
+    name: "CLA ledger writer"
     needs: CLACommentGate
-    name: "CLA Assistant v2"
+    if: >-
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            (
+              github.event.comment.body == 'recheck' &&
+              needs.CLACommentGate.outputs.trusted_recheck == 'true'
+            ) ||
+              (
+                github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+                needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+                needs.CLACommentGate.outputs.signer_decision == 'authorized' &&
+                needs.CLACommentGate.outputs.head_sha != '' &&
+                needs.CLACommentGate.outputs.base_sha != '' &&
+                needs.CLACommentGate.outputs.comment_id != '' &&
+                needs.CLACommentGate.outputs.comment_created_at != '' &&
+                needs.CLACommentGate.outputs.comment_author_id != ''
+            )
+          )
+        )
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    concurrency:
+      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
+      cla_passed: ${{ steps.cla_action.outputs.cla_passed }}
+    steps:
+      - name: "Write CLA result"
+        id: cla_action
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md"
+          path-to-signatures: "signatures/version2/cla.json"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "false"
+          expected-head-sha: "${{ needs.CLACommentGate.outputs.head_sha }}"
+          expected-base-sha: "${{ needs.CLACommentGate.outputs.base_sha }}"
+          expected-comment-id: "${{ needs.CLACommentGate.outputs.comment_id }}"
+          expected-comment-created-at: "${{ needs.CLACommentGate.outputs.comment_created_at }}"
+          expected-comment-author-id: "${{ needs.CLACommentGate.outputs.comment_author_id }}"
+
+  # This no-permission job owns the required v3 check context. A gate or writer
+  # failure is visible as a failed check instead of being hidden as a skipped
+  # privileged job.
+  CLAAssistant:
+    name: "CLA Assistant v3"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
     if: >-
       always() &&
       (
         (
           github.event_name == 'pull_request_target' &&
-          github.event.action != 'closed'
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize'
+          )
         ) ||
         (
           github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
+          github.event.action == 'created' &&
           github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
           github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id > 0 &&
           (
             github.event.comment.body == 'recheck' ||
-            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
           )
         )
-      ) &&
-      (
-        needs.CLACommentGate.result != 'success' ||
-        needs.CLACommentGate.outputs.admitted == 'true'
       )
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    # Serialize signature writes per repository, event class, and Pull Request.
-    # Keeping issue comments apart from pull-request lifecycle events prevents
-    # a comment run from replacing a pending lifecycle validation. GitHub keeps
-    # one running and one pending run for this group; cancel-in-progress=false
-    # preserves the running update while a newer event may replace the pending
-    # update. The maintained action handles bounded ledger writes.
-    concurrency:
-      group: "cla-signatures-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event_name }}"
-      cancel-in-progress: false
-    permissions:
-      # The maintained in-organization action validates the live Pull Request
-      # before it writes. This job has no Actions API access; required-check
-      # recovery is handled only by an exact, separately reviewed worker.
-      contents: write
-      issues: write
-      # GitHub's pull_request_target token denied issue comments for fork PRs
-      # with this set to read, despite the endpoint documentation allowing
-      # issues:write. Keep write until that live behavior changes.
-      pull-requests: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
     steps:
-      - name: "Require CLA admission gate"
-        env:
-          CLA_GATE_RESULT: ${{ needs.CLACommentGate.result || '' }}
-          CLA_GATE_ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
-        run: |
-          set -euo pipefail
-          if [[ "${CLA_GATE_RESULT}" != "success" || "${CLA_GATE_ADMITTED}" != "true" ]]; then
-            echo "::error title=CLA trigger policy::The unprivileged CLACommentGate did not admit this event; refusing CLA writes."
-            exit 1
-          fi
-
-      - name: "Validate live pull request before CLA validation"
-        id: cla_preflight
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action || '' }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
-          EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
-          EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          EVENT_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || '' }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-        run: |
-          set -euo pipefail
-          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error title=CLA preflight failed::Invalid pull request number."
-            exit 1
-          fi
-          if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
-            case "${EVENT_ACTION}" in
-              opened|edited|reopened|synchronize)
-                ;;
-              *)
-                echo "::error title=CLA preflight failed::Unsupported pull_request_target action."
-                exit 1
-                ;;
-            esac
-          fi
-
-          pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
-          if ! pr_json="$(gh api "${pr_endpoint}" --jq '{number: (.number | tostring), state: .state, merged: (.merged_at != null), base_ref: (.base.ref // ""), base_repo: (.base.repo.full_name // ""), head_sha: (.head.sha // ""), head_repo: (.head.repo.full_name // ""), head_repo_id: (.head.repo.id // 0), commits: .commits}' 2>/dev/null)"; then
-            echo "::error title=CLA preflight failed::Could not read live pull request ${PR_NUMBER} from GitHub."
-            exit 1
-          fi
-
-          if ! returned_number="$(jq -er '.number | strings' <<<"${pr_json}" 2>/dev/null)" || [[ "${returned_number}" != "${PR_NUMBER}" ]]; then
-            echo "::error title=CLA preflight failed::GitHub returned an invalid pull request identity."
-            exit 1
-          fi
-          if ! state="$(jq -er '.state | strings' <<<"${pr_json}" 2>/dev/null)" || [[ "${state}" != "open" ]]; then
-            echo "::error title=CLA state policy::Pull request ${PR_NUMBER} is not open."
-            exit 1
-          fi
-          if ! merged="$(jq -er '.merged | tostring' <<<"${pr_json}" 2>/dev/null)" || [[ "${merged}" != "false" ]]; then
-            echo "::error title=CLA state policy::Pull request ${PR_NUMBER} is already merged or has an invalid merge state."
-            exit 1
-          fi
-          if ! base_ref="$(jq -er '.base_ref | strings' <<<"${pr_json}" 2>/dev/null)" || [[ "${base_ref}" != "main" ]]; then
-            echo "::error title=CLA base branch policy::CLA checks only support pull requests targeting main."
-            exit 1
-          fi
-          if ! base_repo="$(jq -er '.base_repo | strings' <<<"${pr_json}" 2>/dev/null)" || [[ -z "${base_repo}" || "${base_repo,,}" != "${GH_REPO,,}" ]]; then
-            echo "::error title=CLA repository policy::The live pull request base repository does not match this workflow repository."
-            exit 1
-          fi
-          if ! head_repo="$(jq -er '.head_repo | strings' <<<"${pr_json}" 2>/dev/null)" || [[ -z "${head_repo}" ]]; then
-            echo "::error title=CLA repository policy::The live pull request has no head repository."
-            exit 1
-          fi
-          if ! head_repo_id="$(jq -er '.head_repo_id | numbers' <<<"${pr_json}" 2>/dev/null)" || ! [[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error title=CLA repository policy::The live pull request has no valid head repository ID."
-            exit 1
-          fi
-          if ! head_sha="$(jq -er '.head_sha | strings' <<<"${pr_json}" 2>/dev/null)" || [[ -z "${head_sha}" ]]; then
-            echo "::error title=CLA preflight failed::The live pull request has no head commit."
-            exit 1
-          fi
-
-          if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
-            if [[ -z "${EVENT_BASE_REF}" || -z "${EVENT_BASE_REPOSITORY}" ||
-                  -z "${EVENT_HEAD_REPOSITORY}" || -z "${EVENT_HEAD_REPOSITORY_ID}" ||
-                  -z "${EVENT_HEAD_SHA}" ]]; then
-              echo "::error title=CLA preflight failed::The pull_request_target payload is missing repository or commit identity."
-              exit 1
-            fi
-            if [[ "${EVENT_BASE_REF}" != "${base_ref}" ||
-                  "${EVENT_BASE_REPOSITORY,,}" != "${base_repo,,}" ||
-                  "${EVENT_HEAD_REPOSITORY,,}" != "${head_repo,,}" ||
-                  "${EVENT_HEAD_REPOSITORY_ID}" != "${head_repo_id}" ||
-                  "${EVENT_HEAD_SHA}" != "${head_sha}" ]]; then
-              echo "::error title=CLA preflight failed::The pull_request_target payload does not match the live pull request identity."
-              exit 1
-            fi
-          fi
-
-          if ! commits="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits' 2>/dev/null)"; then
-            echo "::error title=CLA preflight failed::Could not read pull request ${PR_NUMBER} from GitHub." >&2
-            exit 1
-          fi
-          if ! [[ "${commits}" =~ ^[0-9]+$ ]]; then
-            echo "::error title=CLA preflight failed::GitHub returned an invalid commit count for pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          if (( commits > 1000 )); then
-            echo "::error title=CLA preflight failed::Pull request ${PR_NUMBER} has ${commits} commits. The maintained CLA Assistant supports at most 1,000 commits; squash or split the pull request before requesting CLA validation." >&2
-            exit 1
-          fi
-          echo "CLA preflight passed: ${commits} commits (maximum 1,000)."
-          echo "validated=true" >> "${GITHUB_OUTPUT}"
-
-      - name: "Validate historical CLA declarations"
-        id: cla_history
-        if: success()
-        # Bound and shape-check comment history before the maintained action.
-        # The action owns exact raw signing matches and canonical bot-marker
-        # identity. Do not inspect marker or broad-match text here, because an
-        # ordinary public comment must not block later CLA checks.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          CLA_SIGN_PHRASE: 'I have read the CLA Document and I hereby sign the CLA'
-        run: |
-          set -euo pipefail
-          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error title=CLA history preflight failed::Invalid pull request number."
-            exit 1
-          fi
-          if [[ "${EVENT_NAME}" == "issue_comment" &&
-                "${EVENT_COMMENT_BODY}" != "recheck" &&
-                "${EVENT_COMMENT_BODY}" != "${CLA_SIGN_PHRASE}" ]]; then
-            echo "::error title=CLA comment policy::The issue comment must be exactly recheck or the approved CLA signature phrase."
-            exit 1
-          fi
-
-          comments_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}/comments"
-          page_size=100
-          page_limit=10
-          max_comments=1000
-          total_comments=0
-
-          scan_comments_page() {
-            local page_number="$1"
-
-            if ! jq -e '
-              def safe_id:
-                type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-              # GitHub can return a null user for deleted accounts and actor
-              # types beyond User/Bot (for example, Mannequin). The action
-              # skips null users and only calls string methods on named users.
-              def valid_comment:
-                type == "object" and
-                (.body == null or (.body | type) == "string") and
-                (
-                  .user == null or
-                  (
-                    (.user | type) == "object" and
-                    (.user.login | type) == "string" and
-                    (.user.login | length) > 0 and
-                    (.user.type == null or (.user.type | type) == "string") and
-                    (.user.id == null or (.user.id | safe_id))
-                  )
-                );
-              type == "array" and all(.[]; valid_comment)
-            ' <<<"${page_json}" >/dev/null 2>&1; then
-              echo "::error title=CLA history preflight failed::GitHub returned invalid comment data on page ${page_number}."
-              return 1
-            fi
-            if ! page_count="$(jq -er 'length | numbers' <<<"${page_json}" 2>/dev/null)" ||
-               ! [[ "${page_count}" =~ ^[0-9]+$ ]]; then
-              echo "::error title=CLA history preflight failed::Could not count comments on page ${page_number}."
-              return 1
-            fi
-            if (( page_count > page_size )); then
-              echo "::error title=CLA history preflight failed::GitHub returned more than ${page_size} comments on page ${page_number}."
-              return 1
-            fi
-            total_comments=$((total_comments + page_count))
-            if (( total_comments > max_comments )); then
-              echo "::error title=CLA history limit::This pull request has more than ${max_comments} comments. Remove old comments before requesting a CLA check."
-              return 1
-            fi
-          }
-
-          # Read every bounded page even after a short page. This avoids
-          # missing a comment if the API view changes while comments are
-          # edited during the run.
-          for ((page_number = 1; page_number <= page_limit; page_number++)); do
-            if ! page_json="$(gh api "${comments_endpoint}?per_page=${page_size}&page=${page_number}" --jq '.' 2>/dev/null)"; then
-              echo "::error title=CLA history preflight failed::Could not query pull request comments on page ${page_number}."
-              exit 1
-            fi
-            if ! scan_comments_page "${page_number}"; then
-              exit 1
-            fi
-          done
-
-          # Probe one page beyond the bounded scan. A non-empty page means the
-          # history exceeded the cap, even if an earlier page was short due to
-          # concurrent comment edits or an inconsistent API response.
-          overflow_page=11
-          if ! overflow_json="$(gh api "${comments_endpoint}?per_page=${page_size}&page=${overflow_page}" --jq '.' 2>/dev/null)"; then
-            echo "::error title=CLA history preflight failed::Could not query the pull request comment overflow probe."
-            exit 1
-          fi
-          if ! jq -e '
-               def safe_id:
-                 type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-               # Keep the overflow probe schema check identical to the page
-               # check, including deleted and non-human commenter records.
-               def valid_comment:
-                 type == "object" and
-                 (.body == null or (.body | type) == "string") and
-                 (
-                   .user == null or
-                   (
-                     (.user | type) == "object" and
-                     (.user.login | type) == "string" and
-                     (.user.login | length) > 0 and
-                     (.user.type == null or (.user.type | type) == "string") and
-                     (.user.id == null or (.user.id | safe_id))
-                   )
-                 );
-               type == "array" and all(.[]; valid_comment)
-             ' <<<"${overflow_json}" >/dev/null 2>&1 ||
-             ! overflow_count="$(jq -er 'length | numbers' <<<"${overflow_json}" 2>/dev/null)" ||
-             ! [[ "${overflow_count}" =~ ^[0-9]+$ ]]; then
-            echo "::error title=CLA history preflight failed::GitHub returned invalid comment data for the overflow probe."
-            exit 1
-          fi
-          if (( overflow_count > 0 )); then
-            echo "::error title=CLA history limit::This pull request has more than ${max_comments} comments. Remove old comments before requesting a CLA check."
-            exit 1
-          fi
-          echo "CLA historical comment validation passed: ${total_comments} comments checked."
-          echo "validated=true" >> "${GITHUB_OUTPUT}"
-
-      - name: "Validate exact CLA comment"
-        id: cla_comment
-        if: success()
+      # Keep the generation marker on the required check's only step. The
+      # marker must remain visible when this result fails because the writer
+      # failed in the original pull_request_target run. The immutable rerun
+      # helper uses the rendered step name to reject older workflow runs.
+      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
         env:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          GATE_RESULT: ${{ needs.CLACommentGate.result }}
+          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
+          SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
+          SIGNER_DECISION: ${{ needs.CLACommentGate.outputs.signer_decision || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
+          CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
         run: |
           set -euo pipefail
-          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
-            # GitHub expression equality is case-insensitive. Use a shell
-            # comparison here so the CLA action receives only the exact
-            # supported command or signature phrase.
-            shopt -u nocasematch
-            case "${COMMENT_BODY}" in
-              'recheck'|'I have read the CLA Document and I hereby sign the CLA')
-                ;;
-              *)
-                echo "::error title=CLA comment policy::The issue comment must be exactly recheck or the approved CLA signature phrase."
-                exit 1
-                ;;
-            esac
+          echo "CLA generation ${CLA_GENERATION}"
+          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
+            echo "::error::CLA trigger admission failed"
+            exit 1
           fi
-          echo "validated=true" >> "${GITHUB_OUTPUT}"
+          if [[ "${EVENT_NAME}" == "issue_comment" &&
+                "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+            if [[ "${SIGNER_AUTHORIZED}" != "true" || "${SIGNER_DECISION}" != "authorized" ]]; then
+              echo "::error::CLA signer preflight failed"
+              exit 1
+            fi
+          fi
+          if [[ "${WRITER_RESULT}" != "success" || "${CLA_PASSED}" != "true" ]]; then
+            echo "::error::CLA ledger writer did not report cla_passed=true"
+            exit 1
+          fi
 
-      - name: "CLA Assistant v2"
-        # The action handles signing and status updates. Merged pull requests
-        # use the separate lock job below so lock writes get their own
-        # serialization and the workflow's live identity checks. All repository,
-        # base, head, and opener predicates run in the preflight step above. Keep this
-        # gate to event shape so malformed payloads fail in a running step,
-        # rather than becoming a skipped-success required check.
-        # Issue-comment signatures are persisted by the maintained action. The
-        # required-check refresh remains advisory until a separately reviewed
-        # worker can target the exact live PR head, so this job has no Actions
-        # API permission by design.
-        if: >-
-          success() &&
-          steps.cla_preflight.outputs.validated == 'true' &&
-          steps.cla_history.outputs.validated == 'true' &&
-          steps.cla_comment.outputs.validated == 'true' &&
-          (
-            (
-              github.event_name == 'pull_request_target' &&
-              github.event.pull_request.state == 'open' &&
-              (
-                github.event.action == 'opened' ||
-                github.event.action == 'reopened' ||
-                github.event.action == 'synchronize' ||
-                github.event.action == 'edited'
-              )
-            ) ||
-            (
-              github.event_name == 'issue_comment' &&
-              github.event.issue.pull_request &&
-              github.event.issue.state == 'open' &&
-              github.event.comment.user.type == 'User' &&
-              github.event.comment.user.id > 0 &&
-              (
-                github.event.comment.body == 'recheck' ||
-                github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
-              )
-            )
-          )
-        uses: manaflow-ai/cla-github-action@bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e # reviewed maintained runtime action, source and dist pinned together
+  # Keep the old context during migration. It has no token and is not the
+  # required context after the v3 ruleset migration.
+  CLACompatibility:
+    name: "CLA Assistant"
+    needs:
+      - CLACommentGate
+      - CLAAssistant
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize'
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Mirror CLA Assistant compatibility result"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RESULT: ${{ needs.CLAAssistant.result }}
+        run: |
+          set -euo pipefail
+          [[ "${RESULT}" == "success" ]] || {
+            echo "::error::CLA Assistant v3 did not pass"
+            exit 1
+          }
+
+  # This job can refresh a failed check only through the immutable helper from
+  # the base workflow revision. It receives actions:write, never contents or
+  # comment write access, and its shell command and environment are fixed by
+  # the base-controlled policy validator.
+  RerunFailedCLA:
+    name: "Rerun failed CLA check"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+      - CLAAssistant
+    if: >-
+      always() &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      needs.CLAAssistant.result != 'skipped' &&
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
+      (
+        (
+          github.event.comment.body == 'recheck' &&
+          needs.CLACommentGate.outputs.trusted_recheck == 'true'
+        ) ||
+        (
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLACommentGate.outputs.signer_decision == 'authorized' &&
+          needs.CLACommentGate.outputs.head_sha != '' &&
+          needs.CLACommentGate.outputs.base_sha != '' &&
+          needs.CLACommentGate.outputs.comment_id != '' &&
+          needs.CLACommentGate.outputs.comment_created_at != '' &&
+          needs.CLACommentGate.outputs.comment_author_id != '' &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.signature_recorded == 'true' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true'
+        )
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
+      issues: read
+      pull-requests: read
+    concurrency:
+      group: cla-rerun-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: "Checkout trusted CLA rerun helper"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          # Pin the document to this workflow revision so later edits cannot
-          # change the terms shown for an existing signature request.
-          # If CLA terms change, use a new versioned ledger path and require
-          # contributors to re-consent before accepting new signatures.
-          path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md'
-          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
-          # Keep locking in the explicit job below so it uses its own
-          # concurrency group and live identity checks.
-          lock-pullrequest-aftermerge: 'false'
-          # signatures live on the unprotected cla-signatures branch so
-          # required checks on main don't block the bot's signature commits.
-          branch: 'cla-signatures'
-          required-base-ref: 'main'
-          # Keep the impersonation guard explicit. The action requires the
-          # authenticated Pull Request opener to appear as an author or
-          # co-author unless a maintainer deliberately opts out.
-          # Bot-opened Pull Requests remain fail-closed. Add a reviewed numeric
-          # allowlist-ids entry only for an approved automation opener; raw
-          # names and emails are never trusted.
-          require-opener-as-author: 'true'
-          # Verified in-organization maintainers Austin Wang (@austinywang,
-          # GitHub ID 38676809) and Abdulaziz Albahar (@azooz2003-bit, GitHub
-          # ID 67667005) may use the maintainer exemption. The action matches
-          # these numeric IDs only on authenticated Pull Request openers.
-          allowlist-ids: '38676809,67667005'
+          repository: manaflow-ai/manaflow
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/rerun-failed-cla.sh
+          sparse-checkout-cone-mode: false
+      - name: "Rerun exact failed pull_request_target run"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: manaflow-ai/manaflow
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          WORKFLOW_PATH: ".github/workflows/cla.yml"
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CLA_GENERATION: ${{ env.CLA_GENERATION }}
+          TARGET_EVENT: "pull_request_target"
+          TARGET_BASE_REF: "main"
+          SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
+          CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
+        run: bash .github/scripts/rerun-failed-cla.sh
 
   LockMergedPullRequest:
     name: "Lock merged pull request"
@@ -495,175 +385,26 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # Locking a merged PR does not need signature or repository-write access.
-    # Keep a distinct repository-and-PR group. A later edited event must not
-    # replace a pending merge-lock run in the signer queue.
-    # The lock preflight keeps base and opener identity immutable while it
-    # permits a merged source head to advance or disappear.
-    # Dependabot-created pull_request_target runs can receive a read-only token;
-    # a trusted post-merge worker or dedicated Dependabot secret may be needed
-    # to lock those merged conversations.
     concurrency:
-      group: "cla-lock-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+      group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
       issues: write
       pull-requests: read
     steps:
       - name: "Lock merged pull request"
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action || '' }}
-          EVENT_REPOSITORY: ${{ github.event.repository.full_name || '' }}
-          EVENT_REPOSITORY_ID: ${{ github.event.repository.id || '' }}
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-          EVENT_PR_STATE: ${{ github.event.pull_request.state || '' }}
-          EVENT_PR_MERGED: ${{ github.event.pull_request.merged || '' }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
-          EVENT_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
-          EVENT_BASE_REPOSITORY_ID: ${{ github.event.pull_request.base.repo.id || '' }}
-          EVENT_OPENER_LOGIN: ${{ github.event.pull_request.user.login || '' }}
-          EVENT_OPENER_ID: ${{ github.event.pull_request.user.id || '' }}
-        run: |
-          set -euo pipefail
-          # The event is untrusted. Validate the immutable event identity and
-          # the live merged Pull Request before writing the lock. The live
-          # source head is intentionally not compared with the event head:
-          # GitHub can advance or delete that source after a merge.
-          is_safe_positive_integer() {
-            local value="$1"
-            [[ "${value}" =~ ^[1-9][0-9]*$ ]] || return 1
-            if (( ${#value} > 16 )); then
-              return 1
-            fi
-            if (( ${#value} == 16 )) && (( value > 9007199254740991 )); then
-              return 1
-            fi
-          }
-
-          fail_lock_preflight() {
-            echo "::error title=CLA lock preflight failed::The closed pull_request_target identity did not pass live validation." >&2
-            exit 1
-          }
-
-          is_safe_positive_integer "${PR_NUMBER}" || fail_lock_preflight
-          if [[ "${EVENT_NAME}" != "pull_request_target" ||
-                "${EVENT_ACTION}" != "closed" ||
-                "${EVENT_PR_STATE}" != "closed" ||
-                "${EVENT_PR_MERGED}" != "true" ||
-                "${EVENT_PR_NUMBER}" != "${PR_NUMBER}" ||
-                -z "${EVENT_REPOSITORY}" ||
-                "${EVENT_REPOSITORY,,}" != "${GH_REPO,,}" ||
-                -z "${EVENT_BASE_REF}" ||
-                -z "${EVENT_BASE_REPOSITORY}" ||
-                -z "${EVENT_BASE_REPOSITORY_ID}" ||
-                -z "${EVENT_OPENER_LOGIN}" ||
-                -z "${EVENT_OPENER_ID}" ]]; then
-            fail_lock_preflight
-          fi
-          is_safe_positive_integer "${EVENT_REPOSITORY_ID}" || fail_lock_preflight
-          is_safe_positive_integer "${EVENT_BASE_REPOSITORY_ID}" || fail_lock_preflight
-          is_safe_positive_integer "${EVENT_OPENER_ID}" || fail_lock_preflight
-
-          pr_endpoint="repos/${GH_REPO}/pulls/${PR_NUMBER}"
-          if ! live_pr_json="$(gh api "${pr_endpoint}" --jq '
-            {
-              number: .number,
-              state: (.state // ""),
-              merged: (.merged_at != null),
-              base_ref: (.base.ref // ""),
-              base_repo: (if .base.repo == null then null else (.base.repo.full_name // "") end),
-              base_repo_id: (if .base.repo == null then null else (.base.repo.id // null) end),
-              head_sha: (.head.sha // ""),
-              head_ref: (.head.ref // ""),
-              head_repo: (if .head.repo == null then null else (.head.repo.full_name // "") end),
-              head_repo_id: (if .head.repo == null then null else (.head.repo.id // null) end),
-              opener_login: (if .user == null then "" else (.user.login // "") end),
-              opener_id: (if .user == null then null else (.user.id // null) end)
-            }
-          ' 2>/dev/null)"; then
-            fail_lock_preflight
-          fi
-
-          if ! jq -e --arg pr "${PR_NUMBER}" --arg repo "${GH_REPO}" '
-            def safe_id:
-              type == "number" and floor == . and . > 0 and . <= 9007199254740991;
-            def nonempty_string:
-              type == "string" and (gsub("^\\s+|\\s+$"; "") | length > 0);
-            (.number | type == "number") and
-            ((.number | tostring) == $pr) and
-            (.state == "closed") and
-            (.merged == true) and
-            (.base_ref | nonempty_string) and
-            (.base_repo | nonempty_string) and
-            ((.base_repo | ascii_downcase) == ($repo | ascii_downcase)) and
-            (.base_repo_id | safe_id) and
-            (.head_sha | nonempty_string) and
-            (.head_ref | nonempty_string) and
-            (if .head_repo == null then true else
-              (.head_repo | nonempty_string) and
-              (.head_repo_id | safe_id)
-            end) and
-            (.opener_login | nonempty_string) and
-            (.opener_id | safe_id)
-          ' <<<"${live_pr_json}" >/dev/null 2>&1; then
-            fail_lock_preflight
-          fi
-
-          if ! live_base_ref="$(jq -er '.base_ref | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_base_repo="$(jq -er '.base_repo | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_base_repo_id="$(jq -er '.base_repo_id | numbers | tostring' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_opener_login="$(jq -er '.opener_login | strings' <<<"${live_pr_json}" 2>/dev/null)" ||
-             ! live_opener_id="$(jq -er '.opener_id | numbers | tostring' <<<"${live_pr_json}" 2>/dev/null)"; then
-            fail_lock_preflight
-          fi
-          is_safe_positive_integer "${live_base_repo_id}" || fail_lock_preflight
-          is_safe_positive_integer "${live_opener_id}" || fail_lock_preflight
-          if [[ "${EVENT_BASE_REF}" != "${live_base_ref}" ||
-                "${EVENT_BASE_REPOSITORY,,}" != "${live_base_repo,,}" ||
-                "${EVENT_BASE_REPOSITORY_ID}" != "${live_base_repo_id}" ||
-                "${EVENT_REPOSITORY_ID}" != "${live_base_repo_id}" ||
-                "${EVENT_OPENER_ID}" != "${live_opener_id}" ||
-                "${EVENT_OPENER_LOGIN,,}" != "${live_opener_login,,}" ]]; then
-            fail_lock_preflight
-          fi
-
-          issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
-          lock_endpoint="${issue_endpoint}/lock"
-          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-            echo "::error title=CLA lock failed::Could not read lock state for pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          case "${locked}" in
-            true)
-            echo "Pull request ${PR_NUMBER} is already locked"
-            exit 0
-            ;;
-            false)
-            ;;
-            *)
-            echo "::error title=CLA lock failed::GitHub returned an invalid lock state for this pull request." >&2
-            exit 1
-            ;;
-          esac
-          if ! gh api --method PUT \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "${lock_endpoint}" \
-            --field lock_reason=resolved 2>/dev/null; then
-            echo "::error title=CLA lock failed::Could not lock pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          if ! locked_after="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-            echo "::error title=CLA lock failed::Could not verify lock state for pull request ${PR_NUMBER}." >&2
-            exit 1
-          fi
-          if [[ "${locked_after}" != "true" ]]; then
-            echo "::error title=CLA lock failed::GitHub did not report pull request ${PR_NUMBER} as locked after the lock request." >&2
-            exit 1
-          fi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "sign"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "true"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -56,6 +56,7 @@ jobs:
       pull-requests: read
     outputs:
       admitted: ${{ steps.admission.outputs.admitted }}
+      ignored: ${{ steps.admission.outputs.ignored || '' }}
       trusted_recheck: ${{ steps.admission.outputs.trusted_recheck || '' }}
       signing: ${{ steps.admission.outputs.signing || '' }}
       signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized || '' }}
@@ -209,6 +210,7 @@ jobs:
       - CLALedgerWriter
     if: >-
       always() &&
+      needs.CLACommentGate.outputs.ignored != 'true' &&
       (
         (
           github.event_name == 'pull_request_target' &&
@@ -391,6 +393,7 @@ jobs:
       group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
+      contents: read
       issues: write
       pull-requests: read
     steps:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,85 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,reopened,synchronize]
+
+# Signature updates share one file and must not race.
+concurrency:
+  group: cla-signatures
+  cancel-in-progress: false
+
+# Keep the token scoped to the GitHub API operations used by this action.
+permissions:
+  # The action inspects prior runs; its optional rerun request is best-effort.
+  actions: read
+  contents: write
+  issues: write
+  # GitHub's pull_request_target token denied issue comments for fork PRs with
+  # this set to read, despite the endpoint documentation allowing issues:write.
+  # Keep write until that live behavior changes.
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    name: "CLA Assistant"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        # The action handles signing and status updates. Merged pull requests
+        # use the explicit lock step below because the archived action sends
+        # an invalid lock request.
+        if: >-
+          (
+            github.event_name == 'pull_request_target' &&
+            github.event.action != 'closed'
+          ) ||
+          (
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            (
+              github.event.comment.body == 'recheck' ||
+              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            )
+          )
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/main/CLA.md'
+          # The archived action calls the lock endpoint without the required
+          # lock_reason. Disable that broken path and use the explicit step
+          # below, which supplies a valid reason and fails on API errors.
+          lock-pullrequest-aftermerge: 'false'
+          # signatures live on the unprotected cla-signatures branch so required checks on main don't block the bot's signature commits
+          branch: 'cla-signatures'
+          # Keep this list explicit. A username prefix is not proof that an
+          # account is a GitHub bot and would let a human bypass the CLA.
+          allowlist: lawrencecchen,github-actions[bot],chatmux-connections[bot]
+
+      - name: "Lock merged pull request"
+        if: >-
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
+          lock_endpoint="${issue_endpoint}/lock"
+          if [[ "$(gh api "${issue_endpoint}" --jq '.locked')" == "true" ]]; then
+            echo "Pull request ${PR_NUMBER} is already locked"
+            exit 0
+          fi
+          gh api --method PUT \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "${lock_endpoint}" \
+            --field lock_reason=resolved
+          [[ "$(gh api "${issue_endpoint}" --jq '.locked')" == "true" ]]

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   pull_request_target:
     branches: [main]
-    types: [opened,closed,edited,reopened,synchronize]
+    types: [opened,closed,edited,ready_for_review,reopened,synchronize]
 
 permissions: {}
 
@@ -30,6 +30,7 @@ jobs:
         (
           github.event.action == 'opened' ||
           github.event.action == 'edited' ||
+          github.event.action == 'ready_for_review' ||
           github.event.action == 'reopened' ||
           github.event.action == 'synchronize'
         )
@@ -150,6 +151,7 @@ jobs:
           (
             github.event.action == 'opened' ||
             github.event.action == 'edited' ||
+            github.event.action == 'ready_for_review' ||
             github.event.action == 'reopened' ||
             github.event.action == 'synchronize'
           )
@@ -235,6 +237,7 @@ jobs:
       (
         github.event.action == 'opened' ||
         github.event.action == 'edited' ||
+        github.event.action == 'ready_for_review' ||
         github.event.action == 'reopened' ||
         github.event.action == 'synchronize'
       )
@@ -292,6 +295,7 @@ jobs:
       (
         github.event.action == 'opened' ||
         github.event.action == 'edited' ||
+        github.event.action == 'ready_for_review' ||
         github.event.action == 'reopened' ||
         github.event.action == 'synchronize'
       )

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -418,6 +418,8 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           # Pin the document to this workflow revision so later edits cannot
           # change the terms shown for an existing signature request.
+          # If CLA terms change, use a new versioned ledger path and require
+          # contributors to re-consent before accepting new signatures.
           path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           # Keep locking in the explicit job below so it shares the signature
@@ -445,6 +447,9 @@ jobs:
     # replace a pending merge-lock run in the signer queue.
     # The lock preflight keeps base and opener identity immutable while it
     # permits a merged source head to advance or disappear.
+    # Dependabot-created pull_request_target runs can receive a read-only token;
+    # a trusted post-merge worker or dedicated Dependabot secret may be needed
+    # to lock those merged conversations.
     concurrency:
       group: "cla-lock-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
       cancel-in-progress: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -377,9 +377,9 @@ jobs:
 
       - name: "CLA Assistant v2"
         # The action handles signing and status updates. Merged pull requests
-        # use the separate lock job below so lock writes share serialization
-        # and the workflow's live identity checks. All repository, base, head,
-        # and opener predicates run in the preflight step above. Keep this
+        # use the separate lock job below so lock writes get their own
+        # serialization and the workflow's live identity checks. All repository,
+        # base, head, and opener predicates run in the preflight step above. Keep this
         # gate to event shape so malformed payloads fail in a running step,
         # rather than becoming a skipped-success required check.
         # Issue-comment signatures are persisted by the maintained action. The
@@ -422,8 +422,8 @@ jobs:
           # contributors to re-consent before accepting new signatures.
           path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
-          # Keep locking in the explicit job below so it shares the signature
-          # concurrency group and its live identity checks.
+          # Keep locking in the explicit job below so it uses its own
+          # concurrency group and live identity checks.
           lock-pullrequest-aftermerge: 'false'
           # signatures live on the unprotected cla-signatures branch so
           # required checks on main don't block the bot's signature commits.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -35,9 +35,9 @@ jobs:
       group: cla-signatures
       cancel-in-progress: false
     permissions:
-      # The archived action attempts a branch-based rerun after a contributor
-      # signs. That selection is unsafe. The exact-PR rerun worker is not
-      # deployed yet, so required-check recovery remains advisory.
+      # The maintained in-organization action validates the live Pull Request
+      # before it writes. Keep workflow rerun access out of this job; required
+      # check recovery is handled only by an exact, separately reviewed worker.
       actions: read
       contents: write
       issues: write
@@ -346,7 +346,7 @@ jobs:
               )
             )
           )
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: manaflow-ai/cla-github-action@a34b7274a1f68a0d7bcb11e62a5f1454ea15515c # reviewed maintained action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -355,9 +355,8 @@ jobs:
           # change the terms shown for an existing signature request.
           path-to-document: 'https://github.com/manaflow-ai/manaflow/blob/${{ github.workflow_sha }}/CLA.md'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
-          # The archived action calls the lock endpoint without the required
-          # lock_reason. Disable that broken path and use the explicit job
-          # below, which supplies a valid reason and fails on API errors.
+          # Keep locking in the explicit job below so it shares the signature
+          # concurrency group and its live identity checks.
           lock-pullrequest-aftermerge: 'false'
           # signatures live on the unprotected cla-signatures branch so
           # required checks on main don't block the bot's signature commits.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -180,6 +180,15 @@ jobs:
       signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
       cla_passed: ${{ steps.cla_action.outputs.cla_passed }}
     steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment || '' }}
+        run: |
+          set -euo pipefail
+          [[ "${RUNNER_ENVIRONMENT}" == "github-hosted" ]] || {
+            echo "::error::Privileged CLA jobs require a GitHub-hosted runner"
+            exit 1
+          }
       - name: "Write CLA result"
         id: cla_action
         uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
@@ -350,6 +359,15 @@ jobs:
       group: cla-rerun-${{ github.repository }}-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment || '' }}
+        run: |
+          set -euo pipefail
+          [[ "${RUNNER_ENVIRONMENT}" == "github-hosted" ]] || {
+            echo "::error::Privileged CLA jobs require a GitHub-hosted runner"
+            exit 1
+          }
       - name: "Checkout trusted CLA rerun helper"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -397,6 +415,15 @@ jobs:
       issues: write
       pull-requests: read
     steps:
+      - name: "Require GitHub-hosted runner"
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment || '' }}
+        run: |
+          set -euo pipefail
+          [[ "${RUNNER_ENVIRONMENT}" == "github-hosted" ]] || {
+            echo "::error::Privileged CLA jobs require a GitHub-hosted runner"
+            exit 1
+          }
       - name: "Lock merged pull request"
         uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -57,6 +57,7 @@ jobs:
     outputs:
       admitted: ${{ steps.admission.outputs.admitted }}
       ignored: ${{ steps.admission.outputs.ignored || '' }}
+      base_stale: ${{ steps.admission.outputs.base_stale || '' }}
       trusted_recheck: ${{ steps.admission.outputs.trusted_recheck || '' }}
       signing: ${{ steps.admission.outputs.signing || '' }}
       signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized || '' }}
@@ -306,6 +307,7 @@ jobs:
       - CLAAssistant
     if: >-
       always() &&
+      needs.CLACommentGate.outputs.ignored != 'true' &&
       github.event_name == 'pull_request_target' &&
       (
         github.event.action == 'opened' ||

--- a/CLA.md
+++ b/CLA.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Manaflow, an open-source project of Manaflow, Inc. (the "Company"). To clarify the intellectual property license granted with Contributions from any person or entity, the Company must have on file a signed Contributor License Agreement ("CLA") from each Contributor, indicating agreement with the license terms below. This agreement is for your protection as a Contributor as well as the protection of the Company and its users. It does not change your rights to use your own Contributions for any other purpose.
 
-Please read this Agreement carefully before signing and keep a copy for your records. For contributions submitted through GitHub, your electronic signature is the exact pull request comment: "I have read the CLA Document and I hereby sign the CLA". Posting that comment confirms your acceptance of this Agreement; you do not need to return a separate signed copy.
+Please read this Agreement carefully before signing and keep a copy for your records. For contributions submitted through GitHub, your electronic signature is the exact pull request comment: "I have read the CLA Document v2.2 and I hereby sign the CLA". Posting that comment confirms your acceptance of this Agreement; you do not need to return a separate signed copy.
 
 This Agreement is maintained in English and the English version controls. Any translation is provided for convenience only and does not change the terms of this Agreement.
 

--- a/CLA.md
+++ b/CLA.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Manaflow, an open-source project of Manaflow, Inc. (the "Company"). To clarify the intellectual property license granted with Contributions from any person or entity, the Company must have on file a signed Contributor License Agreement ("CLA") from each Contributor, indicating agreement with the license terms below. This agreement is for your protection as a Contributor as well as the protection of the Company and its users. It does not change your rights to use your own Contributions for any other purpose.
 
-Please complete and sign this Agreement, and return a signed copy to Manaflow, Inc. Read this document carefully before signing and keep a copy for your records.
+Please read this Agreement carefully before signing and keep a copy for your records. For contributions submitted through GitHub, your electronic signature is the exact pull request comment: "I have read the CLA Document and I hereby sign the CLA". Posting that comment confirms your acceptance of this Agreement; you do not need to return a separate signed copy.
 
 This Agreement is maintained in English and the English version controls. Any translation is provided for convenience only and does not change the terms of this Agreement.
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,43 @@
+# Individual Contributor License Agreement ("Agreement") v2.2
+
+Thank you for your interest in Manaflow, an open-source project of Manaflow, Inc. (the "Company"). To clarify the intellectual property license granted with Contributions from any person or entity, the Company must have on file a signed Contributor License Agreement ("CLA") from each Contributor, indicating agreement with the license terms below. This agreement is for your protection as a Contributor as well as the protection of the Company and its users. It does not change your rights to use your own Contributions for any other purpose.
+
+Please complete and sign this Agreement, and return a signed copy to Manaflow, Inc. Read this document carefully before signing and keep a copy for your records.
+
+This Agreement is maintained in English and the English version controls. Any translation is provided for convenience only and does not change the terms of this Agreement.
+
+| | |
+|---|---|
+| Full name: | _________________________________________________ |
+| Public name (optional): | _________________________________________________ |
+| Mailing address: | _________________________________________________ |
+| | _________________________________________________ |
+| Country: | _________________________________________________ |
+| E-Mail: | _________________________________________________ |
+| GitHub username (optional): | _________________________________________________ |
+
+You accept and agree to the following terms and conditions for Your Contributions (present and future) that you submit to the Company. Except for the license granted herein to the Company and recipients of software distributed by the Company, You reserve all right, title, and interest in and to Your Contributions.
+
+1. **Definitions.**
+
+   "You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with the Company. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Company for inclusion in, or documentation of, any of the products owned or managed by the Company (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Company or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Company for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+2. **Grant of Copyright License.** Subject to the terms and conditions of this Agreement, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+3. **Grant of Patent License.** Subject to the terms and conditions of this Agreement, You hereby grant to the Company and to recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to the Company, or that your employer has executed a separate Corporate CLA with the Company.
+
+5. You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+6. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You may submit it to the Company separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify the Company of any facts or circumstances of which you become aware that would make these representations inaccurate in any respect.
+
+&nbsp;
+
+Please sign: __________________________________  Date: ____________________

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="${repo_root}/.github/scripts/fixtures/fork-rerun.json"
+fake_gh="${repo_root}/.github/scripts/fixtures/cla-rerun-fake-gh"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf -- "${temp_dir}"' EXIT
+ln -s -- "${fake_gh}" "${temp_dir}/gh"
+
+jq -e '
+  .runs.workflow_runs[0].pull_requests == [] and
+  .runs.workflow_runs[0].head_sha != .pull_request.head.sha and
+  .runs.workflow_runs[0].head_repository.full_name == .pull_request.head.repo.full_name and
+  .source_check_runs.check_runs[0].head_sha == .pull_request.head.sha and
+  .jobs.jobs[0].head_sha == .pull_request.head.sha
+' "${fixture}" >/dev/null
+
+workflow_sha="$(git -C "${repo_root}" rev-parse HEAD)"
+common_env=(
+  "PATH=${temp_dir}:${PATH}"
+  "CLA_FIXTURE=${fixture}"
+  "CLA_POST_LOG=${temp_dir}/post.log"
+  "GH_REPO=manaflow-ai/manaflow"
+  "EVENT_NAME=issue_comment"
+  "TARGET_EVENT=pull_request_target"
+  "TARGET_BASE_REF=main"
+  "ISSUE_NUMBER=42"
+  "PR_NUMBER=42"
+  "COMMENT_BODY=recheck"
+  "COMMENT_CREATED_AT=2026-09-01T12:00:00Z"
+  "COMMENT_ID=9001"
+  "COMMENT_AUTHOR_ID=1234"
+  "COMMENT_AUTHOR_LOGIN=contributor"
+  "COMMENT_AUTHOR_TYPE=User"
+  "COMMENT_AUTHOR_ASSOCIATION=NONE"
+  "SIGNATURE_RECORDED="
+  "CLA_PASSED=true"
+  "CLA_GENERATION=v2.2-action-aaaaaaaaaaaaaaa"
+  "WORKFLOW_SHA=${workflow_sha}"
+  "WORKFLOW_PATH=.github/workflows/cla.yml"
+)
+
+rm -f -- "${temp_dir}/post.log"
+env "${common_env[@]}" bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >/dev/null
+[[ "$(<"${temp_dir}/post.log")" == "repos/manaflow-ai/manaflow/actions/jobs/8800/rerun" ]]
+
+rm -f -- "${temp_dir}/post.log"
+if env "${common_env[@]}" CLA_FIXTURE_NO_SOURCE_CHECK=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/negative.log" 2>&1; then
+  echo "unbound fork run was accepted" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'no pull request association|no check bound|unbound CLA workflow' "${temp_dir}/negative.log"
+
+rm -f -- "${temp_dir}/post.log"
+if env "${common_env[@]}" CLA_FIXTURE_WRONG_SOURCE_JOB=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/wrong-job.log" 2>&1; then
+  echo "source-bound check for a different job was accepted" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'job is not the job bound|job is no longer bound' "${temp_dir}/wrong-job.log"
+
+echo "CLA fork rerun fixture passed"

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -79,6 +79,17 @@ fi
 rg -q 'newer successful run superseded the failed attempt' "${temp_dir}/superseded.log"
 
 rm -f -- "${temp_dir}/post.log"
+if ! env "${common_env[@]}" \
+  CLA_FIXTURE_FINAL_NEWER_SUCCESS=true \
+  CLA_FIXTURE_RUNS_CALL_LOG="${temp_dir}/runs-call-count" \
+  bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/final-superseded.log" 2>&1; then
+  echo "a success that appeared during final recheck did not supersede the failed run" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'newer successful run superseded the failed attempt' "${temp_dir}/final-superseded.log"
+
+rm -f -- "${temp_dir}/post.log"
 if env "${common_env[@]}" CLA_FIXTURE_OVERSIZE_ENDPOINT='repos/manaflow-ai/manaflow/actions/runs/700/jobs' bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/oversize.log" 2>&1; then
   echo "oversized direct API response was accepted" >&2
   exit 1

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -94,6 +94,17 @@ fi
 rg -q 'newer successful run superseded the failed attempt' "${temp_dir}/final-superseded.log"
 
 rm -f -- "${temp_dir}/post.log"
+if env "${common_env[@]}" \
+  CLA_FIXTURE_ACTIVE_SOURCE_RUN=true \
+  CLA_FIXTURE_RUNS_CALL_LOG="${temp_dir}/active-runs-call-count" \
+  bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/active-run.log" 2>&1; then
+  echo "an in-progress source-bound CLA run was not blocked" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'another CLA workflow run.*still active' "${temp_dir}/active-run.log"
+
+rm -f -- "${temp_dir}/post.log"
 if env "${common_env[@]}" CLA_FIXTURE_OVERSIZE_ENDPOINT='repos/manaflow-ai/manaflow/actions/runs/700/jobs' bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/oversize.log" 2>&1; then
   echo "oversized direct API response was accepted" >&2
   exit 1

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -51,6 +51,17 @@ env "${common_env[@]}" CLA_FIXTURE_POPULATED_EXECUTION=true bash "${repo_root}/.
 [[ "$(<"${temp_dir}/post.log")" == "repos/manaflow-ai/manaflow/actions/jobs/8800/rerun" ]]
 
 rm -f -- "${temp_dir}/post.log"
+env "${common_env[@]}" \
+  CLA_FIXTURE_NO_SOURCE_CHECK=true \
+  CLA_FIXTURE_POPULATED_EXECUTION=true \
+  bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/populated-no-source-check.log" 2>&1
+[[ "$(<"${temp_dir}/post.log")" == "repos/manaflow-ai/manaflow/actions/jobs/8800/rerun" ]]
+
+rm -f -- "${temp_dir}/post.log"
+env "${common_env[@]}" CLA_FIXTURE_DEFAULT_SHA_COMMENT_RUN=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/default-sha-comment.log" 2>&1
+[[ "$(<"${temp_dir}/post.log")" == "repos/manaflow-ai/manaflow/actions/jobs/8800/rerun" ]]
+
+rm -f -- "${temp_dir}/post.log"
 if env "${common_env[@]}" CLA_FIXTURE_NO_SOURCE_CHECK=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/negative.log" 2>&1; then
   echo "unbound fork run was accepted" >&2
   exit 1

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -96,6 +96,7 @@ rg -q 'newer successful run superseded the failed attempt' "${temp_dir}/final-su
 rm -f -- "${temp_dir}/post.log"
 if env "${common_env[@]}" \
   CLA_FIXTURE_ACTIVE_SOURCE_RUN=true \
+  CLA_FIXTURE_POPULATED_EXECUTION=true \
   CLA_FIXTURE_RUNS_CALL_LOG="${temp_dir}/active-runs-call-count" \
   bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/active-run.log" 2>&1; then
   echo "an in-progress source-bound CLA run was not blocked" >&2

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -71,6 +71,14 @@ fi
 rg -q 'older workflow generation' "${temp_dir}/old-generation.log"
 
 rm -f -- "${temp_dir}/post.log"
+if ! env "${common_env[@]}" CLA_FIXTURE_NEWER_SUCCESS=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/superseded.log" 2>&1; then
+  echo "an older failure was not treated as superseded by a newer successful run" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'newer successful run superseded the failed attempt' "${temp_dir}/superseded.log"
+
+rm -f -- "${temp_dir}/post.log"
 if env "${common_env[@]}" CLA_FIXTURE_OVERSIZE_ENDPOINT='repos/manaflow-ai/manaflow/actions/runs/700/jobs' bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/oversize.log" 2>&1; then
   echo "oversized direct API response was accepted" >&2
   exit 1

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -47,6 +47,10 @@ env "${common_env[@]}" bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >
 [[ "$(<"${temp_dir}/post.log")" == "repos/manaflow-ai/manaflow/actions/jobs/8800/rerun" ]]
 
 rm -f -- "${temp_dir}/post.log"
+env "${common_env[@]}" CLA_FIXTURE_POPULATED_EXECUTION=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/populated-execution.log" 2>&1
+[[ "$(<"${temp_dir}/post.log")" == "repos/manaflow-ai/manaflow/actions/jobs/8800/rerun" ]]
+
+rm -f -- "${temp_dir}/post.log"
 if env "${common_env[@]}" CLA_FIXTURE_NO_SOURCE_CHECK=true bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/negative.log" 2>&1; then
   echo "unbound fork run was accepted" >&2
   exit 1

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -36,7 +36,7 @@ common_env=(
   "COMMENT_AUTHOR_ASSOCIATION=NONE"
   "SIGNATURE_RECORDED="
   "CLA_PASSED=true"
-  "CLA_GENERATION=v2.2-action-aaaaaaaaaaaaaaa"
+  "CLA_GENERATION=v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   "WORKFLOW_SHA=${workflow_sha}"
   "WORKFLOW_PATH=.github/workflows/cla.yml"
 )

--- a/scripts/test-cla-rerun-fork.sh
+++ b/scripts/test-cla-rerun-fork.sh
@@ -36,7 +36,8 @@ common_env=(
   "COMMENT_AUTHOR_ASSOCIATION=NONE"
   "SIGNATURE_RECORDED="
   "CLA_PASSED=true"
-  "CLA_GENERATION=v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  "CLA_GENERATION=v2.2-action-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-workflow-${workflow_sha}"
+  "CLA_FIXTURE_WORKFLOW_SHA=${workflow_sha}"
   "WORKFLOW_SHA=${workflow_sha}"
   "WORKFLOW_PATH=.github/workflows/cla.yml"
 )
@@ -60,5 +61,21 @@ if env "${common_env[@]}" CLA_FIXTURE_WRONG_SOURCE_JOB=true bash "${repo_root}/.
 fi
 [[ ! -e "${temp_dir}/post.log" ]]
 rg -q 'job is not the job bound|job is no longer bound' "${temp_dir}/wrong-job.log"
+
+rm -f -- "${temp_dir}/post.log"
+if env "${common_env[@]}" CLA_FIXTURE_WORKFLOW_SHA=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/old-generation.log" 2>&1; then
+  echo "failed run from an older workflow revision was accepted" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'older workflow generation' "${temp_dir}/old-generation.log"
+
+rm -f -- "${temp_dir}/post.log"
+if env "${common_env[@]}" CLA_FIXTURE_OVERSIZE_ENDPOINT='repos/manaflow-ai/manaflow/actions/runs/700/jobs' bash "${repo_root}/.github/scripts/rerun-failed-cla.sh" >"${temp_dir}/oversize.log" 2>&1; then
+  echo "oversized direct API response was accepted" >&2
+  exit 1
+fi
+[[ ! -e "${temp_dir}/post.log" ]]
+rg -q 'response exceeds 8000000 bytes' "${temp_dir}/oversize.log"
 
 echo "CLA fork rerun fixture passed"


### PR DESCRIPTION
## Summary

- Add a hardened CLA Assistant v3 workflow for `pull_request_target` lifecycle events on `main`.
- Pin `manaflow-ai/cla-github-action` to maintained commit `212a0f2dd659b24b48a30ba35966e06dc41736af`.
- Use the exact signing phrase for CLA Document v2.2, store signatures on `cla-signatures`, and use immutable maintainer IDs for Austin Wang (`38676809`) and Abdulaziz Albahar (`67667005`).
- Validate live pull request and comment identity, bind fork reruns to the source head, serialize rerun decisions, bound API responses, and require GitHub-hosted runners for policy jobs.
- Issue-comment events do not publish the required result. They validate the comment and rerun the original pull-request check.

## Verification

- PR head: `e0381be37af4a1ab67f007ce4a55ccd66ae9599f`.
- Local `bash -n`, ShellCheck, actionlint, JSON validation, and `scripts/test-cla-rerun-fork.sh` pass.
- Hosted `verify`, `Run tests on ubuntu-24.04`, Socket Security reports, `Vercel Preview Comments`, and CodeRabbit pass.
- Vercel `cmux-client` and `cmux-www` are still deploying at the time of this update.
- Required status context: `CLA Assistant v3`. `CLA Assistant` is compatibility-only. This PR does not change branch protection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved contributor agreement check reliability with queued validations, stricter pull-request checks, and clearer signing-comment handling.
  * Added stronger workflow permission controls and support for rerunning failed checks.
  * Improved merged pull-request locking with dedicated validation and API error handling.
  * Updated issue-comment validation to require open issues.

* **Documentation**
  * Added an Individual Contributor License Agreement with contributor rights, responsibilities, licensing terms, and signing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
