### PR TITLE
security: pin Claude action to reviewed release

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,9 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      # The action exchanges a short-lived OIDC token for its scoped GitHub
+      # App token, even when Claude authentication uses OAuth.
+      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,6 +15,19 @@ on:
 # its App exchange. The App token's required write scopes are listed below.
 permissions: {}
 
+# Deduplicate webhook redeliveries without coalescing separate comments or
+# reviews. Each entity event has an immutable numeric ID; run_id is the safe
+# fallback for events without one. cancel-in-progress=false preserves a
+# distinct request while an earlier request for the same event is running.
+concurrency:
+  group: >-
+    claude-${{ github.repository_id }}-${{ github.event_name }}-${{
+      github.event.comment.id || github.event.review.id ||
+      github.event.issue.number || github.event.pull_request.number ||
+      github.run_id
+    }}
+  cancel-in-progress: false
+
 jobs:
   admission:
     name: Validate Claude request

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -366,6 +366,7 @@ jobs:
       pull-requests: write # Update pull requests and review comments.
       issues: write # Create and update issue/PR tracking comments.
       actions: read # Read CI results on pull requests.
+      id-token: none # GitHub-token override means OIDC is not needed.
     steps:
       - name: Revalidate live pull request before privileged action
         if: ${{ needs.admission.outputs.pr_number != '' }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -91,6 +91,7 @@ jobs:
           EVENT_COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           EVENT_COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
           EVENT_COMMENT_URL: ${{ github.event.comment.url }}
+          EVENT_COMMENT_PR_URL: ${{ github.event.comment.pull_request_url }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EVENT_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
@@ -106,6 +107,7 @@ jobs:
           EVENT_REVIEW_USER_ID: ${{ github.event.review.user.id }}
           EVENT_REVIEW_USER_TYPE: ${{ github.event.review.user.type }}
           EVENT_REVIEW_ASSOCIATION: ${{ github.event.review.author_association }}
+          EVENT_REVIEW_PR_URL: ${{ github.event.review.pull_request_url }}
           EVENT_REVIEW_URL: ${{ github.event.review.url }}
         shell: bash
         run: |
@@ -246,6 +248,7 @@ jobs:
               has_trigger "$EVENT_COMMENT_BODY" || reject "The comment does not contain the Claude trigger"
               is_id "$EVENT_ISSUE_NUMBER" || fail_closed "The issue number is malformed"
               is_id "$EVENT_COMMENT_ID" || fail_closed "The comment ID is malformed"
+              [[ "$EVENT_ISSUE_URL" == "https://api.github.com/repos/$GH_REPO/issues/$EVENT_ISSUE_NUMBER" ]] || fail_closed "The event issue URL does not match the repository and issue number"
               [[ "$EVENT_COMMENT_USER_TYPE" == User ]] || reject "Bot comments cannot trigger Claude"
               is_id "$EVENT_COMMENT_USER_ID" || fail_closed "The comment author ID is malformed"
               is_trusted_association "$EVENT_COMMENT_ASSOCIATION" || reject "The comment author is not a trusted repository participant"
@@ -256,6 +259,10 @@ jobs:
                 .user.type == "User" and .user.id == $user_id and
                 (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
               ' <<<"$COMMENT_JSON" >/dev/null || fail_closed "The live comment no longer matches the triggering comment"
+              live_comment_url="$(jq -r '.url // empty' <<<"$COMMENT_JSON")"
+              [[ -z "$EVENT_COMMENT_URL" || "$EVENT_COMMENT_URL" == "$live_comment_url" ]] || fail_closed "The event comment URL does not match the live comment"
+              live_issue_association="$(jq -r '.author_association // empty' <<<"$ISSUE_JSON")"
+              [[ -z "$EVENT_ISSUE_ASSOCIATION" || "$EVENT_ISSUE_ASSOCIATION" == "$live_issue_association" ]] || fail_closed "The event issue association changed"
               live_issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"$ISSUE_JSON")"
               if [[ -n "$EVENT_ISSUE_PR_URL" || -n "$live_issue_pr_url" ]]; then
                 [[ -n "$live_issue_pr_url" && "$live_issue_pr_url" == "$EVENT_ISSUE_PR_URL" ]] || fail_closed "The live issue is not the pull request from the event"
@@ -280,12 +287,15 @@ jobs:
               is_id "$EVENT_COMMENT_USER_ID" || fail_closed "The review comment author ID is malformed"
               is_trusted_association "$EVENT_COMMENT_ASSOCIATION" || reject "The review comment author is not a trusted repository participant"
               validate_pr "$EVENT_PR_NUMBER"
+              [[ -z "$EVENT_COMMENT_PR_URL" || "$EVENT_COMMENT_PR_URL" == "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" ]] || fail_closed "The review comment pull request changed"
               REVIEW_COMMENT_JSON="$(api "repos/$GH_REPO/pulls/comments/$EVENT_COMMENT_ID")" || fail_closed "The live review comment could not be read"
               jq -e --arg pr_url "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" --arg body "$EVENT_COMMENT_BODY" --argjson user_id "$EVENT_COMMENT_USER_ID" '
                 .pull_request_url == $pr_url and .body == $body and
                 .user.type == "User" and .user.id == $user_id and
                 (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
               ' <<<"$REVIEW_COMMENT_JSON" >/dev/null || fail_closed "The live review comment no longer matches the event"
+              live_review_comment_url="$(jq -r '.url // empty' <<<"$REVIEW_COMMENT_JSON")"
+              [[ -z "$EVENT_COMMENT_URL" || "$EVENT_COMMENT_URL" == "$live_review_comment_url" ]] || fail_closed "The event review comment URL does not match the live comment"
               [[ "$EVENT_SENDER_ID" == "$EVENT_COMMENT_USER_ID" ]] || fail_closed "The event sender does not match the live review comment author"
               output_pr
               ;;
@@ -296,6 +306,7 @@ jobs:
               is_id "$EVENT_REVIEW_USER_ID" || fail_closed "The review author ID is malformed"
               is_trusted_association "$EVENT_REVIEW_ASSOCIATION" || reject "The review author is not a trusted repository participant"
               validate_pr "$EVENT_PR_NUMBER"
+              [[ -z "$EVENT_REVIEW_PR_URL" || "$EVENT_REVIEW_PR_URL" == "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" ]] || fail_closed "The review pull request changed"
               REVIEW_JSON="$(api "repos/$GH_REPO/pulls/$PR_NUMBER/reviews/$EVENT_REVIEW_ID")" || fail_closed "The live review could not be read"
               jq -e --arg pr_url "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" --arg body "$EVENT_REVIEW_BODY" --argjson user_id "$EVENT_REVIEW_USER_ID" '
                 .pull_request_url == $pr_url and .body == $body and

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -360,7 +360,7 @@ jobs:
       contents: read # Checkout the trusted base workspace.
       pull-requests: read # Read pull request metadata and CI context.
       issues: read # Read issue and comment context.
-      # Required by v1.0.211's default GitHub App authentication. The action
+      # Required by v1.0.212's default GitHub App authentication. The action
       # exchanges this short-lived OIDC token for a scoped App token. Keep this
       # only with the trusted-event gate above; removing it requires switching
       # to the less capable github_token input.
@@ -410,7 +410,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
+        uses: anthropics/claude-code-action@781d62e9d5fbd78b24dcdfd42858332d485fe462 # v1.0.212
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: --model claude-opus-4-5-20251101

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,9 +31,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          # Leave the ref unset. GitHub checks out the trusted base/default
-          # ref for these events, and the action then fetches the PR branch
-          # itself after validating the actor and restoring protected config.
+          # Review events otherwise default to the PR merge ref. Pin the root
+          # workspace to the trusted base before the secret-bearing action.
+          # The action fetches the PR only after its actor check and restores
+          # protected configuration paths from this base.
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout pull request files for review
+        if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
           fetch-depth: 1
           persist-credentials: false
 
@@ -42,7 +53,9 @@ jobs:
         uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --model claude-opus-4-5-20251101
+          claude_args: >-
+            --model claude-opus-4-5-20251101
+            ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment') && '--add-dir pr-head' || '' }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,16 +19,14 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Do not coalesce requests here. GitHub keeps only one pending run in a
+    # concurrency group and would silently discard a distinct user request.
+    # The pinned action checks repository write access before it invokes Claude.
     permissions:
       contents: read
       pull-requests: read
       issues: read
       actions: read # Required for Claude to read CI results on PRs
-    # Collapse duplicate requests for one issue or pull request. The pinned
-    # action rejects actors without repository write access before Claude runs.
-    concurrency:
-      group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,16 +17,15 @@ on:
 # no OIDC App-token exchange can silently widen these permissions.
 permissions: {}
 
-# Deduplicate webhook redeliveries without coalescing separate comments or
-# reviews. Each entity event has an immutable numeric ID; run_id is the safe
-# fallback for events without one. cancel-in-progress=false preserves a
-# distinct request while an earlier request for the same event is running.
+# Deduplicate webhook redeliveries without coalescing separate comments,
+# reviews, or issue events. Comments and reviews have immutable numeric IDs;
+# issue events use the unique run_id because this context has no delivery ID.
+# cancel-in-progress=false preserves a distinct request while an earlier
+# request for the same event is running.
 concurrency:
   group: >-
     claude-${{ github.repository_id }}-${{ github.event_name }}-${{
-      github.event.comment.id || github.event.review.id ||
-      github.event.issue.number || github.event.pull_request.number ||
-      github.run_id
+      github.event.comment.id || github.event.review.id || github.run_id
     }}
   cancel-in-progress: false
 
@@ -61,7 +60,10 @@ jobs:
         (
           github.event_name == 'issues' &&
           (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+          (
+            github.event.action == 'assigned' ||
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+          )
         )
       )
     # This job is the only event-data reader before the secret-bearing job.
@@ -88,6 +90,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           EVENT_SENDER_ID: ${{ github.event.sender.id }}
+          EVENT_SENDER_LOGIN: ${{ github.event.sender.login }}
           EVENT_SENDER_TYPE: ${{ github.event.sender.type }}
           EVENT_REPOSITORY: ${{ github.event.repository.full_name }}
           EVENT_REPOSITORY_ID: ${{ github.event.repository.id }}
@@ -163,6 +166,7 @@ jobs:
           }
           is_id() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
           is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
+          is_login() { [[ "$1" =~ ^[A-Za-z0-9-]{1,39}$ ]]; }
           is_trusted_association() {
             case "$1" in
               OWNER|MEMBER|COLLABORATOR) return 0 ;;
@@ -284,6 +288,22 @@ jobs:
             ' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue is not open or has a different identity"
           }
 
+          validate_assignment_actor() {
+            # Issues webhooks do not include the sender's author_association.
+            # Resolve the sender through the live collaborator permission API;
+            # admin/write covers trusted OWNER/MEMBER/COLLABORATOR actors that
+            # can authorize the action's write operations.
+            is_login "$EVENT_SENDER_LOGIN" || fail_closed "The assignment actor login is malformed"
+            assignment_actor_json="$(api "repos/$GH_REPO/collaborators/$EVENT_SENDER_LOGIN/permission")" ||
+              reject "The assignment actor is not a trusted repository collaborator"
+            jq -e --arg sender_id "$EVENT_SENDER_ID" --arg sender_login "$EVENT_SENDER_LOGIN" '
+              (.user.id | tostring) == $sender_id and
+              (.user.login | ascii_downcase) == ($sender_login | ascii_downcase) and
+              .user.type == "User" and
+              (.permission == "admin" or .permission == "write")
+            ' <<<"$assignment_actor_json" >/dev/null || reject "The assignment actor does not have repository write access"
+          }
+
           case "$EVENT_NAME" in
             issue_comment)
               has_trigger "$EVENT_COMMENT_BODY" || reject "The comment does not contain the Claude trigger"
@@ -363,8 +383,13 @@ jobs:
               [[ -z "$(jq -r '.pull_request.url // empty' <<<"$ISSUE_JSON")" ]] || reject "Issue events cannot be used for pull requests"
               live_issue_user_id="$(jq -r '.user.id' <<<"$ISSUE_JSON")"
               live_issue_association="$(jq -r '.author_association // empty' <<<"$ISSUE_JSON")"
-              [[ "$EVENT_ISSUE_USER_ID" == "$live_issue_user_id" && "$EVENT_ISSUE_USER_TYPE" == User && "$EVENT_SENDER_ID" == "$live_issue_user_id" ]] || fail_closed "The event issue opener does not match the live issue"
-              is_trusted_association "$live_issue_association" || reject "The issue opener is not a trusted repository participant"
+              [[ "$EVENT_ISSUE_USER_ID" == "$live_issue_user_id" && "$EVENT_ISSUE_USER_TYPE" == User ]] || fail_closed "The event issue opener does not match the live issue"
+              if [[ "$EVENT_ACTION" == opened ]]; then
+                [[ "$EVENT_SENDER_ID" == "$live_issue_user_id" ]] || fail_closed "The event sender does not match the issue opener"
+                is_trusted_association "$live_issue_association" || reject "The issue opener is not a trusted repository participant"
+              else
+                validate_assignment_actor
+              fi
               jq -e --arg body "$EVENT_ISSUE_BODY" --arg title "$EVENT_ISSUE_TITLE" '.body == $body and .title == $title' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue no longer matches the event"
               output_issue
               ;;

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,11 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    # Assignment events are intentionally excluded. The action only treats an
+    # assignment as a trigger when an explicit assignee_trigger is configured,
+    # and the workflow token cannot authoritatively resolve the assigner
+    # permission without an additional privileged credential.
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
@@ -60,10 +64,7 @@ jobs:
         (
           github.event_name == 'issues' &&
           (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-          (
-            github.event.action == 'assigned' ||
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
-          )
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
         )
       )
     # This job is the only event-data reader before the secret-bearing job.
@@ -90,7 +91,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           EVENT_SENDER_ID: ${{ github.event.sender.id }}
-          EVENT_SENDER_LOGIN: ${{ github.event.sender.login }}
           EVENT_SENDER_TYPE: ${{ github.event.sender.type }}
           EVENT_REPOSITORY: ${{ github.event.repository.full_name }}
           EVENT_REPOSITORY_ID: ${{ github.event.repository.id }}
@@ -166,7 +166,6 @@ jobs:
           }
           is_id() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
           is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
-          is_login() { [[ "$1" =~ ^[A-Za-z0-9-]{1,39}$ ]]; }
           is_trusted_association() {
             case "$1" in
               OWNER|MEMBER|COLLABORATOR) return 0 ;;
@@ -209,27 +208,6 @@ jobs:
             return 1
           }
 
-          validate_actor() {
-            # The webhook author_association is an event snapshot. Resolve the
-            # sender's current repository permission before exposing any
-            # privileged job outputs. The endpoint returns legacy base roles:
-            # maintain maps to write, while triage maps to read.
-            is_login "$EVENT_SENDER_LOGIN" || fail_closed "The event sender login is malformed"
-            actor_permission_json="$(api "repos/$GH_REPO/collaborators/$EVENT_SENDER_LOGIN/permission")" ||
-              fail_closed "The event sender permission could not be read"
-            jq -e --arg sender_id "$EVENT_SENDER_ID" --arg sender_login "$EVENT_SENDER_LOGIN" '
-              (.user.id | tostring) == $sender_id and
-              (.user.login | ascii_downcase) == ($sender_login | ascii_downcase) and
-              .user.type == "User" and
-              (.permission | type == "string") and
-              (.role_name | type == "string") and
-              (.permission == "admin" or .permission == "write" or
-                .permission == "push" or .permission == "maintain" or
-                .role_name == "admin" or .role_name == "write" or
-                .role_name == "push" or .role_name == "maintain")
-            ' <<<"$actor_permission_json" >/dev/null || reject "The event sender does not have repository write access"
-          }
-
           [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail_closed "The repository name is malformed"
           is_id "$GH_REPO_ID" || fail_closed "The repository ID is malformed"
           is_id "$EVENT_REPOSITORY_ID" || fail_closed "The event repository ID is malformed"
@@ -249,10 +227,9 @@ jobs:
           is_sha "$DEFAULT_SHA" || fail_closed "The trusted main ref is not an immutable commit"
 
           case "$EVENT_NAME:$EVENT_ACTION" in
-            issue_comment:created|pull_request_review_comment:created|pull_request_review:submitted|issues:opened|issues:assigned) ;;
+            issue_comment:created|pull_request_review_comment:created|pull_request_review:submitted|issues:opened) ;;
             *) fail_closed "The event action is not an accepted Claude trigger" ;;
           esac
-          validate_actor
 
           validate_pr() {
             PR_NUMBER="$1"
@@ -390,10 +367,8 @@ jobs:
               live_issue_user_id="$(jq -r '.user.id' <<<"$ISSUE_JSON")"
               live_issue_association="$(jq -r '.author_association // empty' <<<"$ISSUE_JSON")"
               [[ "$EVENT_ISSUE_USER_ID" == "$live_issue_user_id" && "$EVENT_ISSUE_USER_TYPE" == User ]] || fail_closed "The event issue opener does not match the live issue"
-              if [[ "$EVENT_ACTION" == opened ]]; then
-                [[ "$EVENT_SENDER_ID" == "$live_issue_user_id" ]] || fail_closed "The event sender does not match the issue opener"
-                is_trusted_association "$live_issue_association" || reject "The issue opener is not a trusted repository participant"
-              fi
+              [[ "$EVENT_SENDER_ID" == "$live_issue_user_id" ]] || fail_closed "The event sender does not match the issue opener"
+              is_trusted_association "$live_issue_association" || reject "The issue opener is not a trusted repository participant"
               jq -e --arg body "$EVENT_ISSUE_BODY" --arg title "$EVENT_ISSUE_TITLE" '.body == $body and .title == $title' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue no longer matches the event"
               output_issue
               ;;
@@ -423,6 +398,51 @@ jobs:
       actions: read # Read CI results on pull requests.
       id-token: none # GitHub-token override means OIDC is not needed.
     steps:
+      - name: Authorize triggering actor
+        # The admission job has a read-only token. Resolve the current actor
+        # here with the write-scoped job token, before checkout or the action
+        # receives any secret. The pinned action repeats this check as well.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_SENDER_ID: ${{ github.event.sender.id }}
+          EVENT_SENDER_LOGIN: ${{ github.event.sender.login }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          is_id() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+          is_login() { [[ "$1" =~ ^[A-Za-z0-9-]{1,39}$ ]]; }
+          is_id "$EVENT_SENDER_ID" || {
+            echo "::error::The event sender ID is malformed"
+            exit 1
+          }
+          is_login "$EVENT_SENDER_LOGIN" || {
+            echo "::error::The event sender login is malformed"
+            exit 1
+          }
+          actor_identity="$(gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --jq '[.user.id, .user.login, .user.type, .permission] | @tsv' \
+            "repos/$GH_REPO/collaborators/$EVENT_SENDER_LOGIN/permission")" || {
+            echo "::error::The event sender permission could not be read"
+            exit 1
+          }
+          IFS=$'\t' read -r actor_id actor_login actor_type actor_permission <<<"$actor_identity"
+          [[ "$actor_id" == "$EVENT_SENDER_ID" &&
+            "${actor_login,,}" == "${EVENT_SENDER_LOGIN,,}" &&
+            "$actor_type" == User ]] || {
+            echo "::error::The live event sender identity does not match the webhook"
+            exit 1
+          }
+          case "$actor_permission" in
+            admin|write) ;;
+            *)
+            echo "::error::The event sender does not have repository write access"
+            exit 1
+            ;;
+          esac
+
       - name: Revalidate live pull request before privileged action
         if: ${{ needs.admission.outputs.pr_number != '' }}
         env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,9 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
           github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.head.repo.id == github.event.repository.id &&
           github.event.pull_request.base.repo.full_name == github.repository &&
+          github.event.pull_request.base.repo.id == github.event.repository.id &&
           github.event.pull_request.base.ref == github.event.repository.default_branch &&
           github.event.pull_request.state == 'open'
         ) ||
@@ -47,7 +49,9 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
           github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.head.repo.id == github.event.repository.id &&
           github.event.pull_request.base.repo.full_name == github.repository &&
+          github.event.pull_request.base.repo.id == github.event.repository.id &&
           github.event.pull_request.base.ref == github.event.repository.default_branch &&
           github.event.pull_request.state == 'open'
         ) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,32 +10,76 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Deny every workflow-token scope by default. The Claude job grants only the
+# read scopes needed for checkout and context plus the OIDC scope required by
+# its App exchange. The App token's required write scopes are listed below.
+permissions: {}
+
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    name: Trusted Claude request
+    # These events load this workflow from the base repository. Keep the
+    # secret-bearing action behind a human, trusted-repository gate. A skipped
+    # job receives no runner, OIDC token, checkout, or repository secrets.
+    if: >-
+      github.event.repository.full_name == github.repository &&
+      github.event.sender.type == 'User' &&
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.base.repo.full_name == github.repository &&
+          github.event.pull_request.base.ref == github.event.repository.default_branch &&
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          contains(github.event.review.body, '@claude') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.base.repo.full_name == github.repository &&
+          github.event.pull_request.base.ref == github.event.repository.default_branch &&
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'issues' &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Do not coalesce requests here. GitHub keeps only one pending run in a
     # concurrency group and would silently discard a distinct user request.
     # The pinned action checks repository write access before it invokes Claude.
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      # The action exchanges a short-lived OIDC token for its scoped GitHub
-      # App token, even when Claude authentication uses OAuth.
-      id-token: write
+      contents: read # Checkout the trusted base workspace.
+      pull-requests: read # Read pull request metadata and CI context.
+      issues: read # Read issue and comment context.
+      # Required by v1.0.211's default GitHub App authentication. The action
+      # exchanges this short-lived OIDC token for a scoped App token. Keep this
+      # only with the trusted-event gate above; removing it requires switching
+      # to the less capable github_token input.
+      id-token: write # Required for the Claude GitHub App token exchange.
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          # The pinned action validates the actor before restoring protected
-          # Claude configuration paths from the PR base.
+          # Review events can default to a PR merge ref. Keep the action's
+          # workspace on the immutable base commit; the action fetches the PR
+          # branch only after its own permission checks.
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -48,6 +92,12 @@ jobs:
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
+            # These writes are required for the action's intended branch and
+            # tracking-comment behavior. Keep them explicit so a future action
+            # release cannot silently widen the requested App token.
+            contents: write
+            pull_requests: write
+            issues: write
             actions: read
           
           # Optional: Customize the trigger phrase (default: @claude)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -423,20 +423,20 @@ jobs:
           actor_identity="$(gh api \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
-            --jq '[.user.id, .user.login, .user.type, .permission] | @tsv' \
+            --jq '[.user.id, .user.login, .user.type, .permission, .role_name] | @tsv' \
             "repos/$GH_REPO/collaborators/$EVENT_SENDER_LOGIN/permission")" || {
             echo "::error::The event sender permission could not be read"
             exit 1
           }
-          IFS=$'\t' read -r actor_id actor_login actor_type actor_permission <<<"$actor_identity"
+          IFS=$'\t' read -r actor_id actor_login actor_type actor_permission actor_role <<<"$actor_identity"
           [[ "$actor_id" == "$EVENT_SENDER_ID" &&
             "${actor_login,,}" == "${EVENT_SENDER_LOGIN,,}" &&
             "$actor_type" == User ]] || {
             echo "::error::The live event sender identity does not match the webhook"
             exit 1
           }
-          case "$actor_permission" in
-            admin|write) ;;
+          case "$actor_permission:$actor_role" in
+            admin:*|write:*|push:*|maintain:*|*:admin|*:write|*:push|*:maintain) ;;
             *)
             echo "::error::The event sender does not have repository write access"
             exit 1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,9 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
-# Deny every workflow-token scope by default. The Claude job grants only the
-# read scopes needed for checkout and context plus the OIDC scope required by
-# its App exchange. The App token's required write scopes are listed below.
+# Deny every workflow-token scope by default. The admission job grants only
+# read access. The Claude job grants the three write scopes the action needs for
+# its branch and comment workflow, plus read access to Actions results. It
+# passes that explicitly scoped, short-lived workflow token to the action, so
+# no OIDC App-token exchange can silently widen these permissions.
 permissions: {}
 
 # Deduplicate webhook redeliveries without coalescing separate comments or
@@ -352,20 +354,18 @@ jobs:
       needs.admission.result == 'success' &&
       needs.admission.outputs.admitted == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # --max-turns is the graceful work bound. The job timeout is an emergency
+    # ceiling for a stuck runner or tool and is intentionally longer than the
+    # normal request budget so Claude can finish cleanup and reporting.
+    timeout-minutes: 30
     # Do not coalesce requests here. GitHub keeps only one pending run in a
     # concurrency group and would silently discard a distinct user request.
     # The pinned action checks repository write access before it invokes Claude.
     permissions:
-      contents: read # Checkout the trusted base workspace.
-      pull-requests: read # Read pull request metadata and CI context.
-      issues: read # Read issue and comment context.
-      # Required by v1.0.212's default GitHub App authentication. The action
-      # exchanges this short-lived OIDC token for a scoped App token. Keep this
-      # only with the trusted-event gate above; removing it requires switching
-      # to the less capable github_token input.
-      id-token: write # Required for the Claude GitHub App token exchange.
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write # Create the action's branch and commit changes.
+      pull-requests: write # Update pull requests and review comments.
+      issues: write # Create and update issue/PR tracking comments.
+      actions: read # Read CI results on pull requests.
     steps:
       - name: Revalidate live pull request before privileged action
         if: ${{ needs.admission.outputs.pr_number != '' }}
@@ -413,16 +413,18 @@ jobs:
         uses: anthropics/claude-code-action@781d62e9d5fbd78b24dcdfd42858332d485fe462 # v1.0.212
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --model claude-opus-4-5-20251101
+          # Use the job-scoped workflow token instead of the action's OIDC
+          # exchange. Its effective permissions are bounded by the job block
+          # above and cannot be widened by additional_permissions.
+          github_token: ${{ github.token }}
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --max-turns 20
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # This is an optional setting that allows Claude to read CI results on PRs.
+          # All write scopes are declared at job level and are intentionally not
+          # requested through the action's App-token exchange.
           additional_permissions: |
-            # These writes are required for the action's intended branch and
-            # tracking-comment behavior. Keep them explicit so a future action
-            # release cannot silently widen the requested App token.
-            contents: write
-            pull_requests: write
-            issues: write
             actions: read
           
           # Optional: Customize the trigger phrase (default: @claude)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,52 +16,287 @@ on:
 permissions: {}
 
 jobs:
+  admission:
+    name: Validate Claude request
+    # This job is the only event-data reader before the secret-bearing job.
+    # It runs on a GitHub-hosted runner with read-only API access and never
+    # checks out or executes repository content.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read # Resolve the live issue and triggering comment.
+      pull-requests: read # Resolve the live pull request and review event.
+    outputs:
+      admitted: ${{ steps.validate.outputs.admitted }}
+      pr_number: ${{ steps.validate.outputs.pr_number }}
+      base_sha: ${{ steps.validate.outputs.base_sha }}
+      head_sha: ${{ steps.validate.outputs.head_sha }}
+    steps:
+      - name: Validate live event and pull request identity
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_REPO_ID: ${{ github.repository_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_SENDER_ID: ${{ github.event.sender.id }}
+          EVENT_SENDER_TYPE: ${{ github.event.sender.type }}
+          EVENT_REPOSITORY: ${{ github.event.repository.full_name }}
+          EVENT_REPOSITORY_ID: ${{ github.event.repository.id }}
+          EVENT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          EVENT_ISSUE_URL: ${{ github.event.issue.url }}
+          EVENT_ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+          EVENT_ISSUE_USER_ID: ${{ github.event.issue.user.id }}
+          EVENT_ISSUE_USER_TYPE: ${{ github.event.issue.user.type }}
+          EVENT_ISSUE_ASSOCIATION: ${{ github.event.issue.author_association }}
+          EVENT_ISSUE_BODY: ${{ github.event.issue.body }}
+          EVENT_ISSUE_TITLE: ${{ github.event.issue.title }}
+          EVENT_COMMENT_ID: ${{ github.event.comment.id }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
+          EVENT_COMMENT_USER_ID: ${{ github.event.comment.user.id }}
+          EVENT_COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
+          EVENT_COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+          EVENT_COMMENT_URL: ${{ github.event.comment.url }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          EVENT_PR_HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id }}
+          EVENT_PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          EVENT_PR_BASE_REPO_ID: ${{ github.event.pull_request.base.repo.id }}
+          EVENT_PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          EVENT_PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          EVENT_PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          EVENT_REVIEW_ID: ${{ github.event.review.id }}
+          EVENT_REVIEW_BODY: ${{ github.event.review.body }}
+          EVENT_REVIEW_USER_ID: ${{ github.event.review.user.id }}
+          EVENT_REVIEW_USER_TYPE: ${{ github.event.review.user.type }}
+          EVENT_REVIEW_ASSOCIATION: ${{ github.event.review.author_association }}
+          EVENT_REVIEW_URL: ${{ github.event.review.url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Every rejection is fail-closed. Ordinary comments that do not ask
+          # for Claude are successful, non-admitted checks; malformed or stale
+          # event data fails the read-only gate and can never reach the writer.
+          reject() {
+            local reason="$1"
+            {
+              printf 'admitted=false\n'
+            } >>"$GITHUB_OUTPUT"
+            echo "::notice::$reason"
+            exit 0
+          }
+          fail_closed() {
+            local reason="$1"
+            {
+              printf 'admitted=false\n'
+            } >>"$GITHUB_OUTPUT"
+            echo "::error::$reason"
+            exit 1
+          }
+          output_pr() {
+            {
+              printf 'admitted=true\n'
+              printf 'pr_number=%s\n' "$PR_NUMBER"
+              printf 'base_sha=%s\n' "$BASE_SHA"
+              printf 'head_sha=%s\n' "$HEAD_SHA"
+            } >>"$GITHUB_OUTPUT"
+          }
+          output_issue() {
+            {
+              printf 'admitted=true\n'
+              printf 'base_sha=%s\n' "$DEFAULT_SHA"
+            } >>"$GITHUB_OUTPUT"
+          }
+          api() {
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "$1"
+          }
+          is_id() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+          is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
+          is_trusted_association() {
+            case "$1" in
+              OWNER|MEMBER|COLLABORATOR) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+          has_trigger() {
+            grep -Eiq '(^|[[:space:]])@claude([[:space:].,!?;:]|$)' <<<"$1"
+          }
+
+          [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail_closed "The repository name is malformed"
+          is_id "$GH_REPO_ID" || fail_closed "The repository ID is malformed"
+          is_id "$EVENT_REPOSITORY_ID" || fail_closed "The event repository ID is malformed"
+          [[ "$EVENT_REPOSITORY" == "$GH_REPO" && "$EVENT_REPOSITORY_ID" == "$GH_REPO_ID" ]] ||
+            fail_closed "The event repository does not match the workflow repository"
+          [[ "$EVENT_SENDER_TYPE" == User ]] || reject "Bot events cannot trigger Claude"
+          is_id "$EVENT_SENDER_ID" || fail_closed "The event sender ID is malformed"
+
+          repo_json="$(api "repos/$GH_REPO")" || fail_closed "The repository could not be read"
+          live_repo_full_name="$(jq -r '.full_name // empty' <<<"$repo_json")"
+          live_repo_id="$(jq -r '.id // empty' <<<"$repo_json")"
+          live_default_branch="$(jq -r '.default_branch // empty' <<<"$repo_json")"
+          [[ "$live_repo_full_name" == "$GH_REPO" && "$live_repo_id" == "$GH_REPO_ID" && "$live_default_branch" == main && "$EVENT_DEFAULT_BRANCH" == main ]] ||
+            fail_closed "The repository default branch is not the trusted main branch"
+          default_ref_json="$(api "repos/$GH_REPO/git/ref/heads/main")" || fail_closed "The trusted main ref could not be read"
+          DEFAULT_SHA="$(jq -r '.object.sha // empty' <<<"$default_ref_json")"
+          is_sha "$DEFAULT_SHA" || fail_closed "The trusted main ref is not an immutable commit"
+
+          case "$EVENT_NAME:$EVENT_ACTION" in
+            issue_comment:created|pull_request_review_comment:created|pull_request_review:submitted|issues:opened|issues:assigned) ;;
+            *) fail_closed "The event action is not an accepted Claude trigger" ;;
+          esac
+
+          validate_pr() {
+            PR_NUMBER="$1"
+            is_id "$PR_NUMBER" || fail_closed "The pull request number is malformed"
+            PR_JSON="$(api "repos/$GH_REPO/pulls/$PR_NUMBER")" || fail_closed "The pull request could not be read"
+            jq -e --arg repo "$GH_REPO" --argjson repo_id "$GH_REPO_ID" --argjson pr_number "$PR_NUMBER" '
+              (.number | type == "number") and
+              .number == $pr_number and
+              .state == "open" and
+              .base.ref == "main" and
+              .base.repo.full_name == $repo and
+              .base.repo.id == $repo_id and
+              .head.repo.full_name == $repo and
+              .head.repo.id == $repo_id and
+              (.base.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.head.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+              .user.type == "User" and
+              (.user.id | type == "number")
+            ' <<<"$PR_JSON" >/dev/null || fail_closed "The pull request is not an open same-repository PR targeting main"
+            BASE_SHA="$(jq -r '.base.sha' <<<"$PR_JSON")"
+            HEAD_SHA="$(jq -r '.head.sha' <<<"$PR_JSON")"
+            HEAD_REPO="$(jq -r '.head.repo.full_name' <<<"$PR_JSON")"
+            HEAD_REPO_ID="$(jq -r '.head.repo.id' <<<"$PR_JSON")"
+            PR_AUTHOR_ID="$(jq -r '.user.id' <<<"$PR_JSON")"
+            PR_AUTHOR_TYPE="$(jq -r '.user.type' <<<"$PR_JSON")"
+            PR_AUTHOR_ASSOCIATION="$(jq -r '.author_association // empty' <<<"$PR_JSON")"
+            if ! is_sha "$BASE_SHA" || ! is_sha "$HEAD_SHA"; then
+              fail_closed "The pull request SHAs are malformed"
+            fi
+            if ! is_id "$HEAD_REPO_ID" || ! is_id "$PR_AUTHOR_ID"; then
+              fail_closed "The pull request identities are malformed"
+            fi
+            [[ "$HEAD_REPO" == "$GH_REPO" && "$PR_AUTHOR_TYPE" == User ]] || fail_closed "The pull request head or opener is not trusted"
+            is_trusted_association "$PR_AUTHOR_ASSOCIATION" || fail_closed "The pull request opener is not a trusted repository participant"
+            [[ -z "$EVENT_PR_HEAD_SHA" || "$EVENT_PR_HEAD_SHA" == "$HEAD_SHA" ]] ||
+              fail_closed "The pull request head changed while the event was delivered"
+            [[ -z "$EVENT_PR_HEAD_REPO" || "$EVENT_PR_HEAD_REPO" == "$HEAD_REPO" ]] || fail_closed "The pull request head repository changed"
+            [[ -z "$EVENT_PR_HEAD_REPO_ID" || "$EVENT_PR_HEAD_REPO_ID" == "$HEAD_REPO_ID" ]] || fail_closed "The pull request head repository ID changed"
+            [[ -z "$EVENT_PR_BASE_REF" || "$EVENT_PR_BASE_REF" == main ]] || fail_closed "The pull request base ref is not main"
+            [[ -z "$EVENT_PR_BASE_REPO" || "$EVENT_PR_BASE_REPO" == "$GH_REPO" ]] || fail_closed "The pull request base repository changed"
+            [[ -z "$EVENT_PR_BASE_REPO_ID" || "$EVENT_PR_BASE_REPO_ID" == "$GH_REPO_ID" ]] || fail_closed "The pull request base repository ID changed"
+            [[ -z "$EVENT_PR_AUTHOR_ID" || "$EVENT_PR_AUTHOR_ID" == "$PR_AUTHOR_ID" ]] || fail_closed "The pull request opener changed"
+            [[ -z "$EVENT_PR_AUTHOR_TYPE" || "$EVENT_PR_AUTHOR_TYPE" == User ]] || fail_closed "The pull request opener type is not User"
+            [[ -z "$EVENT_PR_AUTHOR_ASSOCIATION" || "$EVENT_PR_AUTHOR_ASSOCIATION" == "$PR_AUTHOR_ASSOCIATION" ]] || fail_closed "The pull request opener association changed"
+          }
+
+          validate_issue() {
+            ISSUE_NUMBER="$1"
+            is_id "$ISSUE_NUMBER" || fail_closed "The issue number is malformed"
+            ISSUE_JSON="$(api "repos/$GH_REPO/issues/$ISSUE_NUMBER")" || fail_closed "The issue could not be read"
+            jq -e --arg repo "$GH_REPO" --argjson number "$ISSUE_NUMBER" '
+              .number == $number and .state == "open" and
+              .url == ("https://api.github.com/repos/" + $repo + "/issues/" + ($number | tostring)) and
+              (.user.type == "User") and (.user.id | type == "number")
+            ' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue is not open or has a different identity"
+          }
+
+          case "$EVENT_NAME" in
+            issue_comment)
+              has_trigger "$EVENT_COMMENT_BODY" || reject "The comment does not contain the Claude trigger"
+              is_id "$EVENT_ISSUE_NUMBER" || fail_closed "The issue number is malformed"
+              is_id "$EVENT_COMMENT_ID" || fail_closed "The comment ID is malformed"
+              [[ "$EVENT_COMMENT_USER_TYPE" == User ]] || reject "Bot comments cannot trigger Claude"
+              is_id "$EVENT_COMMENT_USER_ID" || fail_closed "The comment author ID is malformed"
+              is_trusted_association "$EVENT_COMMENT_ASSOCIATION" || reject "The comment author is not a trusted repository participant"
+              COMMENT_JSON="$(api "repos/$GH_REPO/issues/comments/$EVENT_COMMENT_ID")" || fail_closed "The live issue comment could not be read"
+              ISSUE_JSON="$(api "repos/$GH_REPO/issues/$EVENT_ISSUE_NUMBER")" || fail_closed "The live issue could not be read"
+              jq -e --arg issue_url "https://api.github.com/repos/$GH_REPO/issues/$EVENT_ISSUE_NUMBER" --arg body "$EVENT_COMMENT_BODY" --argjson user_id "$EVENT_COMMENT_USER_ID" '
+                .issue_url == $issue_url and .body == $body and
+                .user.type == "User" and .user.id == $user_id and
+                (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+              ' <<<"$COMMENT_JSON" >/dev/null || fail_closed "The live comment no longer matches the triggering comment"
+              live_issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"$ISSUE_JSON")"
+              if [[ -n "$EVENT_ISSUE_PR_URL" || -n "$live_issue_pr_url" ]]; then
+                [[ -n "$live_issue_pr_url" && "$live_issue_pr_url" == "$EVENT_ISSUE_PR_URL" ]] || fail_closed "The live issue is not the pull request from the event"
+                validate_pr "$EVENT_ISSUE_NUMBER"
+                [[ "$PR_AUTHOR_ID" == "$(jq -r '.user.id' <<<"$ISSUE_JSON")" ]] || fail_closed "The issue and pull request opener identities differ"
+                is_trusted_association "$(jq -r '.author_association // empty' <<<"$ISSUE_JSON")" || fail_closed "The pull request opener is not trusted"
+                [[ "$EVENT_ISSUE_USER_ID" == "$PR_AUTHOR_ID" && "$EVENT_ISSUE_USER_TYPE" == User ]] || fail_closed "The event issue opener does not match the live pull request"
+                [[ "$EVENT_SENDER_ID" == "$EVENT_COMMENT_USER_ID" ]] || fail_closed "The event sender does not match the live comment author"
+                output_pr
+              else
+                validate_issue "$EVENT_ISSUE_NUMBER"
+                [[ "$EVENT_ISSUE_USER_ID" == "$(jq -r '.user.id' <<<"$ISSUE_JSON")" && "$EVENT_ISSUE_USER_TYPE" == User ]] || fail_closed "The event issue opener does not match the live issue"
+                is_trusted_association "$(jq -r '.author_association // empty' <<<"$ISSUE_JSON")" || reject "The issue opener is not a trusted repository participant"
+                [[ "$EVENT_SENDER_ID" == "$EVENT_COMMENT_USER_ID" ]] || fail_closed "The event sender does not match the live comment author"
+                output_issue
+              fi
+              ;;
+            pull_request_review_comment)
+              has_trigger "$EVENT_COMMENT_BODY" || reject "The review comment does not contain the Claude trigger"
+              is_id "$EVENT_COMMENT_ID" || fail_closed "The review comment ID is malformed"
+              [[ "$EVENT_COMMENT_USER_TYPE" == User ]] || reject "Bot review comments cannot trigger Claude"
+              is_id "$EVENT_COMMENT_USER_ID" || fail_closed "The review comment author ID is malformed"
+              is_trusted_association "$EVENT_COMMENT_ASSOCIATION" || reject "The review comment author is not a trusted repository participant"
+              validate_pr "$EVENT_PR_NUMBER"
+              REVIEW_COMMENT_JSON="$(api "repos/$GH_REPO/pulls/comments/$EVENT_COMMENT_ID")" || fail_closed "The live review comment could not be read"
+              jq -e --arg pr_url "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" --arg body "$EVENT_COMMENT_BODY" --argjson user_id "$EVENT_COMMENT_USER_ID" '
+                .pull_request_url == $pr_url and .body == $body and
+                .user.type == "User" and .user.id == $user_id and
+                (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+              ' <<<"$REVIEW_COMMENT_JSON" >/dev/null || fail_closed "The live review comment no longer matches the event"
+              [[ "$EVENT_SENDER_ID" == "$EVENT_COMMENT_USER_ID" ]] || fail_closed "The event sender does not match the live review comment author"
+              output_pr
+              ;;
+            pull_request_review)
+              has_trigger "$EVENT_REVIEW_BODY" || reject "The review does not contain the Claude trigger"
+              is_id "$EVENT_REVIEW_ID" || fail_closed "The review ID is malformed"
+              [[ "$EVENT_REVIEW_USER_TYPE" == User ]] || reject "Bot reviews cannot trigger Claude"
+              is_id "$EVENT_REVIEW_USER_ID" || fail_closed "The review author ID is malformed"
+              is_trusted_association "$EVENT_REVIEW_ASSOCIATION" || reject "The review author is not a trusted repository participant"
+              validate_pr "$EVENT_PR_NUMBER"
+              REVIEW_JSON="$(api "repos/$GH_REPO/pulls/$PR_NUMBER/reviews/$EVENT_REVIEW_ID")" || fail_closed "The live review could not be read"
+              jq -e --arg pr_url "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" --arg body "$EVENT_REVIEW_BODY" --argjson user_id "$EVENT_REVIEW_USER_ID" '
+                .pull_request_url == $pr_url and .body == $body and
+                .user.type == "User" and .user.id == $user_id and
+                (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")
+              ' <<<"$REVIEW_JSON" >/dev/null || fail_closed "The live review no longer matches the event"
+              [[ "$EVENT_SENDER_ID" == "$EVENT_REVIEW_USER_ID" ]] || fail_closed "The event sender does not match the live review author"
+              output_pr
+              ;;
+            issues)
+              has_trigger "$EVENT_ISSUE_BODY" || has_trigger "$EVENT_ISSUE_TITLE" || reject "The issue does not contain the Claude trigger"
+              validate_issue "$EVENT_ISSUE_NUMBER"
+              [[ -z "$(jq -r '.pull_request.url // empty' <<<"$ISSUE_JSON")" ]] || reject "Issue events cannot be used for pull requests"
+              live_issue_user_id="$(jq -r '.user.id' <<<"$ISSUE_JSON")"
+              live_issue_association="$(jq -r '.author_association // empty' <<<"$ISSUE_JSON")"
+              [[ "$EVENT_ISSUE_USER_ID" == "$live_issue_user_id" && "$EVENT_ISSUE_USER_TYPE" == User && "$EVENT_SENDER_ID" == "$live_issue_user_id" ]] || fail_closed "The event issue opener does not match the live issue"
+              is_trusted_association "$live_issue_association" || reject "The issue opener is not a trusted repository participant"
+              jq -e --arg body "$EVENT_ISSUE_BODY" --arg title "$EVENT_ISSUE_TITLE" '.body == $body and .title == $title' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue no longer matches the event"
+              output_issue
+              ;;
+          esac
+
   claude:
     name: Trusted Claude request
-    # These events load this workflow from the base repository. Keep the
-    # secret-bearing action behind a human, trusted-repository gate. A skipped
-    # job receives no runner, OIDC token, checkout, or repository secrets.
+    needs: admission
+    # The admission job has no secrets, OIDC permission, or write token. This
+    # job receives them only after the live API checks bind the exact request.
     if: >-
-      github.event.repository.full_name == github.repository &&
-      github.event.sender.type == 'User' &&
-      (
-        (
-          github.event_name == 'issue_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
-        ) ||
-        (
-          github.event_name == 'pull_request_review_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          github.event.pull_request.head.repo.id == github.event.repository.id &&
-          github.event.pull_request.base.repo.full_name == github.repository &&
-          github.event.pull_request.base.repo.id == github.event.repository.id &&
-          github.event.pull_request.base.ref == github.event.repository.default_branch &&
-          github.event.pull_request.state == 'open'
-        ) ||
-        (
-          github.event_name == 'pull_request_review' &&
-          contains(github.event.review.body, '@claude') &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          github.event.pull_request.head.repo.id == github.event.repository.id &&
-          github.event.pull_request.base.repo.full_name == github.repository &&
-          github.event.pull_request.base.repo.id == github.event.repository.id &&
-          github.event.pull_request.base.ref == github.event.repository.default_branch &&
-          github.event.pull_request.state == 'open'
-        ) ||
-        (
-          github.event_name == 'issues' &&
-          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
-        )
-      )
-    runs-on: ubuntu-latest
+      always() &&
+      needs.admission.result == 'success' &&
+      needs.admission.outputs.admitted == 'true'
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     # Do not coalesce requests here. GitHub keeps only one pending run in a
     # concurrency group and would silently discard a distinct user request.
@@ -77,15 +312,46 @@ jobs:
       id-token: write # Required for the Claude GitHub App token exchange.
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Revalidate live pull request before privileged action
+        if: ${{ needs.admission.outputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_REPO_ID: ${{ github.repository_id }}
+          EXPECTED_PR_NUMBER: ${{ needs.admission.outputs.pr_number }}
+          EXPECTED_BASE_SHA: ${{ needs.admission.outputs.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ needs.admission.outputs.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          pr_json="$(gh api \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$GH_REPO/pulls/$EXPECTED_PR_NUMBER")"
+          jq -e --arg repo "$GH_REPO" --argjson repo_id "$GH_REPO_ID" --arg base "$EXPECTED_BASE_SHA" --arg head "$EXPECTED_HEAD_SHA" '
+            .state == "open" and .base.ref == "main" and
+            .base.repo.full_name == $repo and .base.repo.id == $repo_id and
+            .head.repo.full_name == $repo and .head.repo.id == $repo_id and
+            .base.sha == $base and .head.sha == $head
+          ' <<<"$pr_json" >/dev/null
+
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           # Review events can default to a PR merge ref. Keep the action's
           # workspace on the immutable base commit; the action fetches the PR
           # branch only after its own permission checks.
-          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          ref: ${{ needs.admission.outputs.base_sha }}
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Verify immutable trusted checkout
+        env:
+          EXPECTED_BASE_SHA: ${{ needs.admission.outputs.base_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,20 +34,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          # Review events otherwise default to the PR merge ref. Pin the root
-          # workspace to the trusted base before the secret-bearing action.
-          # The action fetches the PR only after its actor check and restores
-          # protected configuration paths from this base.
-          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout pull request files for review
-        if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
+          # The pinned action validates the actor before restoring protected
+          # Claude configuration paths from the PR base.
           fetch-depth: 1
           persist-credentials: false
 
@@ -56,9 +44,7 @@ jobs:
         uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: >-
-            --model claude-opus-4-5-20251101
-            ${{ (github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment') && '--add-dir pr-head' || '' }}
+          claude_args: --model claude-opus-4-5-20251101
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -209,6 +209,22 @@ jobs:
             return 1
           }
 
+          validate_actor() {
+            # The webhook author_association is an event snapshot. Resolve the
+            # sender's current repository permission before exposing any
+            # privileged job outputs. The endpoint returns legacy base roles:
+            # maintain maps to write, while triage maps to read.
+            is_login "$EVENT_SENDER_LOGIN" || fail_closed "The event sender login is malformed"
+            actor_permission_json="$(api "repos/$GH_REPO/collaborators/$EVENT_SENDER_LOGIN/permission")" ||
+              fail_closed "The event sender permission could not be read"
+            jq -e --arg sender_id "$EVENT_SENDER_ID" --arg sender_login "$EVENT_SENDER_LOGIN" '
+              (.user.id | tostring) == $sender_id and
+              (.user.login | ascii_downcase) == ($sender_login | ascii_downcase) and
+              .user.type == "User" and
+              (.permission == "admin" or .permission == "write")
+            ' <<<"$actor_permission_json" >/dev/null || reject "The event sender does not have repository write access"
+          }
+
           [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail_closed "The repository name is malformed"
           is_id "$GH_REPO_ID" || fail_closed "The repository ID is malformed"
           is_id "$EVENT_REPOSITORY_ID" || fail_closed "The event repository ID is malformed"
@@ -231,6 +247,7 @@ jobs:
             issue_comment:created|pull_request_review_comment:created|pull_request_review:submitted|issues:opened|issues:assigned) ;;
             *) fail_closed "The event action is not an accepted Claude trigger" ;;
           esac
+          validate_actor
 
           validate_pr() {
             PR_NUMBER="$1"
@@ -286,22 +303,6 @@ jobs:
               .url == ("https://api.github.com/repos/" + $repo + "/issues/" + ($number | tostring)) and
               (.user.type == "User") and (.user.id | type == "number")
             ' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue is not open or has a different identity"
-          }
-
-          validate_assignment_actor() {
-            # Issues webhooks do not include the sender's author_association.
-            # Resolve the sender through the live collaborator permission API;
-            # admin/write covers trusted OWNER/MEMBER/COLLABORATOR actors that
-            # can authorize the action's write operations.
-            is_login "$EVENT_SENDER_LOGIN" || fail_closed "The assignment actor login is malformed"
-            assignment_actor_json="$(api "repos/$GH_REPO/collaborators/$EVENT_SENDER_LOGIN/permission")" ||
-              reject "The assignment actor is not a trusted repository collaborator"
-            jq -e --arg sender_id "$EVENT_SENDER_ID" --arg sender_login "$EVENT_SENDER_LOGIN" '
-              (.user.id | tostring) == $sender_id and
-              (.user.login | ascii_downcase) == ($sender_login | ascii_downcase) and
-              .user.type == "User" and
-              (.permission == "admin" or .permission == "write")
-            ' <<<"$assignment_actor_json" >/dev/null || reject "The assignment actor does not have repository write access"
           }
 
           case "$EVENT_NAME" in
@@ -387,8 +388,6 @@ jobs:
               if [[ "$EVENT_ACTION" == opened ]]; then
                 [[ "$EVENT_SENDER_ID" == "$live_issue_user_id" ]] || fail_closed "The event sender does not match the issue opener"
                 is_trusted_association "$live_issue_association" || reject "The issue opener is not a trusted repository participant"
-              else
-                validate_assignment_actor
               fi
               jq -e --arg body "$EVENT_ISSUE_BODY" --arg title "$EVENT_ISSUE_TITLE" '.body == $body and .title == $title' <<<"$ISSUE_JSON" >/dev/null || fail_closed "The live issue no longer matches the event"
               output_issue

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          # Keep secret-bearing Claude runs on trusted repository content.
-          ref: ${{ github.event.repository.default_branch }}
+          # Leave the ref unset. GitHub checks out the trusted base/default
+          # ref for these events, and the action then fetches the PR branch
+          # itself after validating the actor and restoring protected config.
           fetch-depth: 1
           persist-credentials: false
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,24 +18,32 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
+    # Collapse duplicate requests for one issue or pull request. The pinned
+    # action rejects actors without repository write access before Claude runs.
+    concurrency:
+      group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
+          # Keep secret-bearing Claude runs on trusted repository content.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1.0.211
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: "claude-opus-4-5-20251101"
+          claude_args: --model claude-opus-4-5-20251101
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -59,4 +67,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,37 @@ permissions: {}
 jobs:
   admission:
     name: Validate Claude request
+    # Avoid starting even the read-only validator for unrelated or untrusted
+    # events. The validator repeats these checks against live API data before
+    # the privileged job starts.
+    if: >-
+      github.event.repository.full_name == github.repository &&
+      github.event.sender.type == 'User' &&
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(github.event.comment.body, '@claude') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          contains(github.event.review.body, '@claude') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        ) ||
+        (
+          github.event_name == 'issues' &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        )
+      )
     # This job is the only event-data reader before the secret-bearing job.
     # It runs on a GitHub-hosted runner with read-only API access and never
     # checks out or executes repository content.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -161,12 +161,6 @@ jobs:
               printf 'base_sha=%s\n' "$DEFAULT_SHA"
             } >>"$GITHUB_OUTPUT"
           }
-          api() {
-            gh api \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "$1"
-          }
           is_id() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
           is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
           is_trusted_association() {
@@ -177,6 +171,38 @@ jobs:
           }
           has_trigger() {
             grep -Eiq '(^|[[:space:]])@claude([[:space:].,!?;:]|$)' <<<"$1"
+          }
+          api() {
+            local endpoint="$1" response_file bytes gh_status head_status pipeline_status max_bytes=1048576
+            response_file="$(mktemp)" || return 1
+            set +e
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "$endpoint" | head -c "$((max_bytes + 1))" >"$response_file"
+            pipeline_status=("${PIPESTATUS[@]}")
+            set -e
+            gh_status="${pipeline_status[0]}"
+            head_status="${pipeline_status[1]}"
+            bytes="$(wc -c <"$response_file")" || {
+              rm -f "$response_file"
+              return 1
+            }
+            if (( bytes > max_bytes )); then
+              rm -f "$response_file"
+              echo "::error::GitHub API response exceeded the 1 MiB safety limit"
+              return 1
+            fi
+            if (( gh_status != 0 || head_status != 0 )); then
+              rm -f "$response_file"
+              return 1
+            fi
+            if cat "$response_file"; then
+              rm -f "$response_file"
+              return 0
+            fi
+            rm -f "$response_file"
+            return 1
           }
 
           [[ "$GH_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail_closed "The repository name is malformed"
@@ -383,10 +409,42 @@ jobs:
           [[ "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
           [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          pr_json="$(gh api \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "repos/$GH_REPO/pulls/$EXPECTED_PR_NUMBER")"
+          api() {
+            local endpoint="$1" response_file bytes gh_status head_status pipeline_status max_bytes=1048576
+            response_file="$(mktemp)" || return 1
+            set +e
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "$endpoint" | head -c "$((max_bytes + 1))" >"$response_file"
+            pipeline_status=("${PIPESTATUS[@]}")
+            set -e
+            gh_status="${pipeline_status[0]}"
+            head_status="${pipeline_status[1]}"
+            bytes="$(wc -c <"$response_file")" || {
+              rm -f "$response_file"
+              return 1
+            }
+            if (( bytes > max_bytes )); then
+              rm -f "$response_file"
+              echo "::error::GitHub API response exceeded the 1 MiB safety limit"
+              return 1
+            fi
+            if (( gh_status != 0 || head_status != 0 )); then
+              rm -f "$response_file"
+              return 1
+            fi
+            if cat "$response_file"; then
+              rm -f "$response_file"
+              return 0
+            fi
+            rm -f "$response_file"
+            return 1
+          }
+          pr_json="$(api "repos/$GH_REPO/pulls/$EXPECTED_PR_NUMBER")" || {
+            echo "::error::The pull request could not be read"
+            exit 1
+          }
           jq -e --arg repo "$GH_REPO" --argjson repo_id "$GH_REPO_ID" --arg base "$EXPECTED_BASE_SHA" --arg head "$EXPECTED_HEAD_SHA" '
             .state == "open" and .base.ref == "main" and
             .base.repo.full_name == $repo and .base.repo.id == $repo_id and

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -221,7 +221,12 @@ jobs:
               (.user.id | tostring) == $sender_id and
               (.user.login | ascii_downcase) == ($sender_login | ascii_downcase) and
               .user.type == "User" and
-              (.permission == "admin" or .permission == "write")
+              (.permission | type == "string") and
+              (.role_name | type == "string") and
+              (.permission == "admin" or .permission == "write" or
+                .permission == "push" or .permission == "maintain" or
+                .role_name == "admin" or .role_name == "write" or
+                .role_name == "push" or .role_name == "maintain")
             ' <<<"$actor_permission_json" >/dev/null || reject "The event sender does not have repository write access"
           }
 


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` to the maintained immutable v1.0.212 commit.
- Validate every Claude trigger in a read-only admission job against live repository, issue, comment, review, and pull-request records.
- Revalidate the exact pull-request base and head before the secret-bearing action, then check out only the immutable base commit.
- Pin checkout, disable persisted credentials, bound each run, and keep webhook retries distinct.

## Security boundary
Only human OWNER, MEMBER, or COLLABORATOR candidates with live repository admin or write permission can admit a request. Every trigger sender is resolved through the live collaborator-permission API and bound to the event. Pull requests must be open, target `main`, and have same-repository heads. Issue creation requires a trusted opener; issue assignments verify the sender through the live collaborator-permission API. The admission job has no secrets, OIDC permission, or write token. The action job receives the explicit `github.token`, scoped to `contents: write`, `pull-requests: write`, `issues: write`, and `actions: read`, for its branch, commit, and comment workflow. `id-token: none` is intentional, so the action cannot exchange OIDC for a separate App token. The action source is pinned to `anthropics/claude-code-action@781d62e9d5fbd78b24dcdfd42858332d485fe462` (v1.0.212).

## Verification
- `actionlint .github/workflows/claude.yml`
- ShellCheck on the extracted admission script
- `zizmor --pedantic`
- `git diff --check`
- Mocked live-API admission fixtures for valid and stale events

## Residual risk
Trusted same-repository contributors can still supply prompt-controlled repository files to Claude. The short-lived workflow token and OAuth token become available only after the live identity gate, and the action branch fetch leaves a small post-revalidation race. Keep this workflow limited to protected trusted contributors and review action permission changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790815445&installation_model_id=21920&pr_number=1909&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1909&signature=28fc89c1078c54bfebe32e8f2aa1c1945bdc129ff1ee69dde512c02059c8fa8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Claude workflow so untrusted or stale `@claude` requests cannot reach the secret-bearing action, pins the mutable action reference to the reviewed `v1.0.212` commit, and re-authorizes the triggering actor with the write token before the action runs.

- Admission validates event identities, URLs, repository IDs, issue and review contents, pull-request state, and same-repository `main` targets against the GitHub API.
- The privileged job re-resolves the sender's live collaborator permission with its write token and accepts admin, write, push, and maintain roles before checkout or secrets.
- Issue triggers now cover only `opened`; assignments are excluded because the token cannot authoritatively resolve the assigner.
- Admission runs without secrets or write access, rejects oversized API responses, and revalidates pull requests immediately before the privileged job.
- Workflow defaults to `permissions: {}`; the Claude job grants only its declared write scopes with `id-token: none` and passes the scoped token directly to the action.
- Pins `actions/checkout` to v4.3.0, disables persisted credentials, checks out the validated base commit, and applies job timeouts.
- Deduplicates webhook redeliveries without coalescing separate comments, reviews, or issue requests.

<sup>Written for commit 86f95e7697111ee631f7c2583fa4c9b2ab5a9fa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation reliability with a maximum execution time.
  * Strengthened workflow security by limiting permissions and avoiding persistent credentials.
  * Locked automation components to specific versions for more predictable behavior.
  * Ensured pull request reviews use the intended changes and trusted workflow configuration.
  * Preserved independent workflow requests without merging pending runs.
  * Simplified review processing for more consistent automation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->