### PR TITLE
security: isolate untrusted CI and pin actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,18 +5,25 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
+    name: Verify
     runs-on: ubuntu-24.04
-    environment: dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.2.21
 
       - name: Cache Bun install cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.bun/install/cache
@@ -25,35 +32,25 @@ jobs:
             ${{ runner.os }}-bun-install-
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Checks and tests (parallel on one runner)
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          STACK_SECRET_SERVER_KEY: ${{ secrets.STACK_SECRET_SERVER_KEY }}
-          STACK_SUPER_SECRET_ADMIN_KEY: ${{ secrets.STACK_SUPER_SECRET_ADMIN_KEY }}
-          STACK_DATA_VAULT_SECRET: ${{ secrets.STACK_DATA_VAULT_SECRET }}
-          CMUX_GITHUB_APP_ID: ${{ secrets.CMUX_GITHUB_APP_ID }}
-          CMUX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CMUX_GITHUB_APP_PRIVATE_KEY }}
-          CMUX_TASK_RUN_JWT_SECRET: ${{ secrets.CMUX_TASK_RUN_JWT_SECRET }}
-          MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
-          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          CI: "true"
         run: |
           set -euo pipefail
           bun run check & pid1=$!
           (cd packages/cmux && bun run test) & pid2=$!
-          wait $pid1; s1=$?
-          wait $pid2; s2=$?
+          s1=0
+          s2=0
+          wait "$pid1" || s1=$?
+          wait "$pid2" || s2=$?
           if [ $s1 -ne 0 ] || [ $s2 -ne 0 ]; then
             echo "At least one task failed"
             exit 1

--- a/.github/workflows/cmux-env.yml
+++ b/.github/workflows/cmux-env.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/cmux-env.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rust-checks:
     name: Rust checks
@@ -20,15 +23,17 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: crates/cmux-env
 

--- a/.github/workflows/cmux-proxy.yml
+++ b/.github/workflows/cmux-proxy.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/cmux-proxy.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rust-checks:
     name: Rust checks
@@ -20,15 +23,17 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: crates/cmux-proxy
 

--- a/.github/workflows/cmux-pty.yml
+++ b/.github/workflows/cmux-pty.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/cmux-pty.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rust-checks:
     name: Rust checks
@@ -20,15 +23,17 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: crates/cmux-pty
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,9 @@ on:
       - prompt-wrapper.sh
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: manaflow/cmux
@@ -38,6 +41,11 @@ env:
 jobs:
   docker-build:
     name: Build Docker image (${{ matrix.platform }})
+    # The build pushes to Docker Hub with repository credentials. A manual
+    # dispatch must use the protected main ref, never arbitrary branch code.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -52,7 +60,7 @@ jobs:
 
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -63,16 +71,19 @@ jobs:
           swap-storage: true
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.11.1
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USER }}
@@ -80,7 +91,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -90,7 +101,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.18.0
         with:
           context: .
           file: Dockerfile
@@ -101,13 +112,15 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="$BUILD_DIGEST"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: worker-digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -116,23 +129,26 @@ jobs:
 
   docker-merge:
     name: Create multi-arch manifest
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     needs: docker-build
     permissions:
       contents: read
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: /tmp/digests
           pattern: worker-digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.11.1
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USER }}
@@ -140,7 +156,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -151,9 +167,27 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          shopt -s nullglob
+          digest_files=(*)
+          if (( ${#digest_files[@]} == 0 )); then
+            echo "No image digests were uploaded" >&2
+            exit 1
+          fi
+
+          metadata_args=()
+          while IFS= read -r tag; do
+            metadata_args+=("-t" "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+          digest_args=()
+          for digest_file in "${digest_files[@]}"; do
+            digest_args+=("${REGISTRY}/${IMAGE_NAME}@sha256:${digest_file}")
+          done
+
+          docker buildx imagetools create "${metadata_args[@]}" "${digest_args[@]}"
 
       - name: Inspect image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "$IMAGE_REF"

--- a/.github/workflows/global-proxy.yml
+++ b/.github/workflows/global-proxy.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/global-proxy.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rust-checks:
     name: Rust checks
@@ -20,15 +23,17 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: apps/global-proxy
 

--- a/.github/workflows/host-screenshot-collector.yml
+++ b/.github/workflows/host-screenshot-collector.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/host-screenshot-collector.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: host-screenshot-collector-${{ github.ref }}
   cancel-in-progress: false
@@ -18,14 +21,20 @@ env:
 jobs:
   build-and-sync:
     name: Build and Sync to Convex
+    # This job publishes to Convex with the electron environment secret. A
+    # manual run must use the protected main revision, never branch code.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: electron
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.21
 

--- a/.github/workflows/morph-snapshot.yml
+++ b/.github/workflows/morph-snapshot.yml
@@ -10,8 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   NODE_VERSION: "24"
@@ -21,32 +20,41 @@ env:
 jobs:
   morph-snapshot:
     name: Build Morph Snapshot
+    # This job has write permissions and a Morph API credential. Always run
+    # the checked-in main revision, including for a manual dispatch.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: dev
+    permissions:
+      contents: write # Push the generated snapshot branch.
+      pull-requests: write # Open the generated snapshot pull request.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.5.0
 
       - name: Cache Bun install cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.bun/install/cache
@@ -99,6 +107,12 @@ jobs:
       - name: Create branch and commit
         if: steps.changes.outputs.has_changes == 'true'
         id: commit
+        env:
+          # Supply GitHub authentication through process environment config,
+          # not a command-line argument that other local processes can read.
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: http.https://github.com/.extraheader
+          GIT_CONFIG_VALUE_0: "AUTHORIZATION: bearer ${{ github.token }}"
         run: |
           BRANCH_NAME="morph-snapshot-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH_NAME"
@@ -111,6 +125,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_BRANCH: ${{ steps.commit.outputs.branch }}
         run: |
           gh pr create \
             --title "chore: daily morph snapshot update" \
@@ -122,5 +137,5 @@ jobs:
 
           ## Test plan
           - [ ] Verify new snapshots work by starting a sandbox session" \
-            --head "${{ steps.commit.outputs.branch }}" \
+            --head "$SNAPSHOT_BRANCH" \
             --base main

--- a/.github/workflows/native-core.yml
+++ b/.github/workflows/native-core.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/native-core.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rust-checks:
     name: Rust checks
@@ -20,15 +23,17 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: apps/server/native/core
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,9 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
+  contents: read
 
 env:
   NODE_VERSION: "24"
@@ -22,13 +20,24 @@ env:
 jobs:
   open-release-pr:
     name: Open draft release PR
+    # The job creates a branch and dispatches a publishing workflow. Restrict
+    # manual runs to the protected main revision so a caller cannot execute a
+    # modified branch with write-capable credentials.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Create the generated release branch.
+      pull-requests: write # Create the draft release pull request.
+      actions: write # Dispatch the signed electron build workflow.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
+          # release-pr.ts supplies a transient auth header for git pushes.
+          persist-credentials: false
 
       - name: Check for changes since last release
         id: release_changes
@@ -51,13 +60,13 @@ jobs:
 
       - name: Setup Node.js
         if: steps.release_changes.outputs.proceed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
         if: steps.release_changes.outputs.proceed == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
@@ -81,11 +90,13 @@ jobs:
 
       - name: Trigger electron build workflow
         if: steps.release_changes.outputs.proceed == 'true' && steps.create_release_pr.outputs.release_pr_state == 'created'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        env:
+          RELEASE_BRANCH: ${{ steps.create_release_pr.outputs.release_branch }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const branch = '${{ steps.create_release_pr.outputs.release_branch }}';
+            const branch = process.env.RELEASE_BRANCH;
             if (!branch) {
               core.setFailed('Release branch output missing; cannot dispatch electron build workflow.');
               return;

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,11 +33,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.sha }}
+          # Keep a local branch because release-pr.ts creates a child branch.
+          ref: refs/heads/main
           fetch-depth: 0
           fetch-tags: true
           # release-pr.ts supplies a transient auth header for git pushes.
           persist-credentials: false
+
+      - name: Verify main revision
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_sha" != "$EXPECTED_SHA" ]]; then
+            echo "main advanced while the workflow was starting" >&2
+            echo "expected $EXPECTED_SHA, checked out $actual_sha" >&2
+            exit 1
+          fi
 
       - name: Check for changes since last release
         id: release_changes

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -703,7 +703,9 @@ jobs:
       - name: Build native Rust addon
         working-directory: apps/server/native/core
         shell: pwsh
-        run: bunx --bun @napi-rs/cli build --platform --release
+        run: |
+          bunx --bun @napi-rs/cli build --platform --release
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Generate icons
         working-directory: apps/client
         run: bun run ./scripts/generate-icons.mjs
@@ -716,7 +718,9 @@ jobs:
         working-directory: apps/client
         run: |
           bunx electron-vite build -c electron.vite.config.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bunx electron-builder --config electron-builder.json --win --x64 --publish always --config.publish.provider=github --config.publish.owner="$env:RELEASE_OWNER" --config.publish.repo="$env:RELEASE_REPOSITORY"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   linux-x64:
     name: Linux x64

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   NODE_VERSION: "24"
@@ -23,14 +23,24 @@ env:
 jobs:
   prepare-release:
     name: Prepare Release
+    # Publishing uses repository write access and signing credentials. Permit
+    # only main, generated release branches, and version tags.
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release/v') ||
+      startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.resolve.outputs.tag }}
     permissions:
+      # Required to create the draft release record.
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Resolve release tag
@@ -101,18 +111,18 @@ jobs:
   #     run:
   #       working-directory: ./
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
   #       with:
   #         ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-  #     - uses: actions/setup-node@v4
+  #     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
   #       with:
   #         node-version: ${{ env.NODE_VERSION }}
   #     - name: Setup Bun
-  #       uses: oven-sh/setup-bun@v2
+  #       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
   #       with:
   #         bun-version: 1.2.21
   #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  #       uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
   #       with:
   #         toolchain: stable
   #         profile: minimal
@@ -213,16 +223,24 @@ jobs:
   mac-arm64:
     name: macOS arm64
     needs: prepare-release
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release/v') ||
+      startsWith(github.ref, 'refs/tags/v')
     environment: electron
+    permissions:
+      # Required to upload signed artifacts to the GitHub release.
+      contents: write
     runs-on: self-hosted
     defaults:
       run:
         working-directory: ./
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-      - uses: actions/setup-node@v4
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Configure Cargo home
@@ -236,10 +254,12 @@ jobs:
           cargo_target_dir="$temp_dir/cargo-target-${GITHUB_RUN_ID}-${GITHUB_JOB}"
           mkdir -p "$cargo_home/bin"
           mkdir -p "$cargo_target_dir"
-          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_DIR=$cargo_target_dir" >> "$GITHUB_ENV"
-          echo "RUSTUP_HOME=$cargo_home" >> "$GITHUB_ENV"
-          echo "PATH=$cargo_home/bin:$PATH" >> "$GITHUB_ENV"
+          {
+            echo "CARGO_HOME=$cargo_home"
+            echo "CARGO_TARGET_DIR=$cargo_target_dir"
+            echo "RUSTUP_HOME=$cargo_home"
+            echo "PATH=$cargo_home/bin:$PATH"
+          } >> "$GITHUB_ENV"
       - name: Configure Bun install dir
         run: |
           set -euo pipefail
@@ -251,12 +271,12 @@ jobs:
           mkdir -p "$bun_install"
           echo "BUN_INSTALL=$bun_install" >> "$GITHUB_ENV"
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.21
           no-cache: true
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
           targets: aarch64-apple-darwin
@@ -267,14 +287,21 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Write .env for build
         shell: bash
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
+          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
         run: |
-          cat > .env <<EOF
-          NEXT_PUBLIC_CONVEX_URL=${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
-          NEXT_PUBLIC_STACK_PROJECT_ID=${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
-          NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
-          NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
-          EOF
+          set -euo pipefail
+          {
+            printf 'NEXT_PUBLIC_CONVEX_URL=%s\n' "$NEXT_PUBLIC_CONVEX_URL"
+            printf 'NEXT_PUBLIC_STACK_PROJECT_ID=%s\n' "$NEXT_PUBLIC_STACK_PROJECT_ID"
+            printf 'NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=%s\n' "$NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"
+            printf 'NEXT_PUBLIC_WWW_ORIGIN=%s\n' "$NEXT_PUBLIC_WWW_ORIGIN"
+            printf 'NEXT_PUBLIC_GITHUB_APP_SLUG=%s\n' "$NEXT_PUBLIC_GITHUB_APP_SLUG"
+          } > .env
       - name: Build native Rust addon
         working-directory: apps/server/native/core
         shell: bash
@@ -338,17 +365,25 @@ jobs:
   mac-universal:
     name: macOS universal
     needs: prepare-release
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release/v') ||
+      startsWith(github.ref, 'refs/tags/v')
     environment: electron
+    permissions:
+      # Required to upload signed artifacts to the GitHub release.
+      contents: write
     runs-on: self-hosted
     defaults:
       run:
         working-directory: ./
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -363,10 +398,12 @@ jobs:
           cargo_target_dir="$temp_dir/cargo-target-${GITHUB_RUN_ID}-${GITHUB_JOB}"
           mkdir -p "$cargo_home/bin"
           mkdir -p "$cargo_target_dir"
-          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_DIR=$cargo_target_dir" >> "$GITHUB_ENV"
-          echo "RUSTUP_HOME=$cargo_home" >> "$GITHUB_ENV"
-          echo "PATH=$cargo_home/bin:$PATH" >> "$GITHUB_ENV"
+          {
+            echo "CARGO_HOME=$cargo_home"
+            echo "CARGO_TARGET_DIR=$cargo_target_dir"
+            echo "RUSTUP_HOME=$cargo_home"
+            echo "PATH=$cargo_home/bin:$PATH"
+          } >> "$GITHUB_ENV"
 
       - name: Configure Bun install dir
         run: |
@@ -379,7 +416,7 @@ jobs:
           mkdir -p "$bun_install"
           echo "BUN_INSTALL=$bun_install" >> "$GITHUB_ENV"
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.21
           no-cache: true
@@ -392,7 +429,7 @@ jobs:
           /usr/sbin/softwareupdate --install-rosetta --agree-to-license || true
 
       - name: Install Rust toolchain and mac targets
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
           targets: aarch64-apple-darwin, x86_64-apple-darwin
@@ -409,14 +446,21 @@ jobs:
 
       - name: Write .env for build
         shell: bash
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
+          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
         run: |
-          cat > .env <<EOF
-          NEXT_PUBLIC_CONVEX_URL=${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
-          NEXT_PUBLIC_STACK_PROJECT_ID=${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
-          NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
-          NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
-          EOF
+          set -euo pipefail
+          {
+            printf 'NEXT_PUBLIC_CONVEX_URL=%s\n' "$NEXT_PUBLIC_CONVEX_URL"
+            printf 'NEXT_PUBLIC_STACK_PROJECT_ID=%s\n' "$NEXT_PUBLIC_STACK_PROJECT_ID"
+            printf 'NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=%s\n' "$NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"
+            printf 'NEXT_PUBLIC_WWW_ORIGIN=%s\n' "$NEXT_PUBLIC_WWW_ORIGIN"
+            printf 'NEXT_PUBLIC_GITHUB_APP_SLUG=%s\n' "$NEXT_PUBLIC_GITHUB_APP_SLUG"
+          } > .env
 
       - name: Remove stale macOS native binaries
         working-directory: apps/server/native/core
@@ -489,7 +533,6 @@ jobs:
       - name: Prepare signing credentials
         env:
           MAC_CERT_BASE64: ${{ secrets.MAC_CERT_BASE64 }}
-          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -500,7 +543,6 @@ jobs:
           cert_path="$tmpdir_cert/mac_signing_cert.p12"
           node -e "process.stdout.write(Buffer.from(process.env.MAC_CERT_BASE64,'base64'))" > "$cert_path"
           echo "CSC_LINK=$cert_path" >> "$GITHUB_ENV"
-          echo "CSC_KEY_PASSWORD=${MAC_CERT_PASSWORD}" >> "$GITHUB_ENV"
           if [[ -n "${APPLE_API_KEY:-}" && ! -f "${APPLE_API_KEY}" ]]; then
             tmpdir_key="$(mktemp -d)"
             key_path="$tmpdir_key/AuthKey_${APPLE_API_KEY_ID:-api}.p8"
@@ -511,6 +553,8 @@ jobs:
       - name: Build universal DMG/ZIP with electron-builder
         working-directory: apps/client
         shell: bash
+        env:
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
         run: |
           set -euo pipefail
           ENTITLEMENTS="$PWD/build/entitlements.mac.plist"
@@ -537,17 +581,26 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          DMG="$(ls -1 *.dmg | head -n1 || true)"
+          dmg_files=(./*.dmg)
+          DMG=""
+          if (( ${#dmg_files[@]} > 0 )); then
+            DMG="${dmg_files[0]#./}"
+          fi
           if [[ -z "$DMG" ]]; then
             echo "No DMG found in $(pwd)" >&2
             exit 1
           fi
           echo "Submitting $DMG for notarization..."
-          set +e
-          OUT=$(xcrun notarytool submit "$DMG" --wait --output-format json --key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" 2>&1)
-          CODE=$?
-          set -e
-          echo "$OUT" | sed -e 's/^/notarytool: /'
+          if ! OUT=$(xcrun notarytool submit "$DMG" --wait --output-format json --key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" 2>&1); then
+            while IFS= read -r line; do
+              printf 'notarytool: %s\n' "$line"
+            done <<< "$OUT"
+            echo "Notarization command failed" >&2
+            exit 1
+          fi
+          while IFS= read -r line; do
+            printf 'notarytool: %s\n' "$line"
+          done <<< "$OUT"
           echo "$OUT" | grep -qi '"status" *: *"Accepted"\|status: Accepted\|Accepted' || { echo "Notarization failed"; exit 1; }
 
       - name: Staple and prepare update manifest
@@ -556,7 +609,12 @@ jobs:
         run: |
           set -euo pipefail
           APP="$(find . -maxdepth 2 -type d -name '*.app' | head -n1 || true)"
-          DMG="$(ls -1 *.dmg 2>/dev/null | head -n1 || true)"
+          shopt -s nullglob
+          dmg_files=(./*.dmg)
+          DMG=""
+          if (( ${#dmg_files[@]} > 0 )); then
+            DMG="${dmg_files[0]#./}"
+          fi
           if [[ -n "$APP" ]]; then xcrun stapler staple "$APP" || true; fi
           if [[ -n "$DMG" ]]; then xcrun stapler staple "$DMG" || true; fi
           if [[ -f "latest-mac.yml" ]]; then
@@ -594,24 +652,32 @@ jobs:
   windows-x64:
     name: Windows x64
     needs: prepare-release
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release/v') ||
+      startsWith(github.ref, 'refs/tags/v')
     environment: electron
+    permissions:
+      # Required to publish the Windows artifact to the GitHub release.
+      contents: write
     runs-on: windows-latest
     defaults:
       run:
         working-directory: ./
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-      - uses: actions/setup-node@v4
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.21
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
@@ -619,14 +685,21 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Write .env for build
         shell: bash
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
+          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
         run: |
-          cat > .env <<EOF
-          NEXT_PUBLIC_CONVEX_URL=${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
-          NEXT_PUBLIC_STACK_PROJECT_ID=${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
-          NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
-          NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
-          EOF
+          set -euo pipefail
+          {
+            printf 'NEXT_PUBLIC_CONVEX_URL=%s\n' "$NEXT_PUBLIC_CONVEX_URL"
+            printf 'NEXT_PUBLIC_STACK_PROJECT_ID=%s\n' "$NEXT_PUBLIC_STACK_PROJECT_ID"
+            printf 'NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=%s\n' "$NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"
+            printf 'NEXT_PUBLIC_WWW_ORIGIN=%s\n' "$NEXT_PUBLIC_WWW_ORIGIN"
+            printf 'NEXT_PUBLIC_GITHUB_APP_SLUG=%s\n' "$NEXT_PUBLIC_GITHUB_APP_SLUG"
+          } > .env
       - name: Build native Rust addon
         working-directory: apps/server/native/core
         shell: pwsh
@@ -638,27 +711,39 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_FLAG: ${{ github.event_name == 'release' && 'always' || 'never' }}
+          RELEASE_OWNER: ${{ github.repository_owner }}
+          RELEASE_REPOSITORY: ${{ github.event.repository.name }}
         working-directory: apps/client
-        run: bunx electron-vite build -c electron.vite.config.ts && bunx electron-builder --config electron-builder.json --win --x64 --publish always --config.publish.provider=github --config.publish.owner="${{ github.repository_owner }}" --config.publish.repo="${{ github.event.repository.name }}"
+        run: |
+          bunx electron-vite build -c electron.vite.config.ts
+          bunx electron-builder --config electron-builder.json --win --x64 --publish always --config.publish.provider=github --config.publish.owner="$env:RELEASE_OWNER" --config.publish.repo="$env:RELEASE_REPOSITORY"
 
   linux-x64:
     name: Linux x64
     needs: prepare-release
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release/v') ||
+      startsWith(github.ref, 'refs/tags/v')
     environment: electron
+    permissions:
+      # Required to publish the Linux artifact to the GitHub release.
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-      - uses: actions/setup-node@v4
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.21
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
           targets: x86_64-unknown-linux-gnu
@@ -666,14 +751,21 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Write .env for build
         shell: bash
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
+          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
         run: |
-          cat > .env <<EOF
-          NEXT_PUBLIC_CONVEX_URL=${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
-          NEXT_PUBLIC_STACK_PROJECT_ID=${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
-          NEXT_PUBLIC_WWW_ORIGIN=${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
-          NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
-          EOF
+          set -euo pipefail
+          {
+            printf 'NEXT_PUBLIC_CONVEX_URL=%s\n' "$NEXT_PUBLIC_CONVEX_URL"
+            printf 'NEXT_PUBLIC_STACK_PROJECT_ID=%s\n' "$NEXT_PUBLIC_STACK_PROJECT_ID"
+            printf 'NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=%s\n' "$NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"
+            printf 'NEXT_PUBLIC_WWW_ORIGIN=%s\n' "$NEXT_PUBLIC_WWW_ORIGIN"
+            printf 'NEXT_PUBLIC_GITHUB_APP_SLUG=%s\n' "$NEXT_PUBLIC_GITHUB_APP_SLUG"
+          } > .env
       - name: Build native Rust addon
         working-directory: apps/server/native/core
         shell: bash
@@ -685,5 +777,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_FLAG: ${{ github.event_name == 'release' && 'always' || 'never' }}
+          RELEASE_OWNER: ${{ github.repository_owner }}
+          RELEASE_REPOSITORY: ${{ github.event.repository.name }}
         working-directory: apps/client
-        run: bunx electron-vite build -c electron.vite.config.ts && bunx electron-builder --config electron-builder.json --linux AppImage --x64 --publish always --config.publish.provider=github --config.publish.owner="${{ github.repository_owner }}" --config.publish.repo="${{ github.event.repository.name }}"
+        run: |
+          bunx electron-vite build -c electron.vite.config.ts
+          bunx electron-builder --config electron-builder.json --linux AppImage --x64 --publish always --config.publish.provider=github --config.publish.owner="$RELEASE_OWNER" --config.publish.repo="$RELEASE_REPOSITORY"

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/sandbox.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-sandbox
@@ -24,15 +27,17 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: packages/sandbox
 
@@ -52,10 +57,12 @@ jobs:
     name: Build Docker image (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: rust-checks
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
-      packages: write
+      packages: write # Publish the image to GHCR from protected main only.
     strategy:
       fail-fast: false
       matrix:
@@ -67,16 +74,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.11.1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -84,7 +94,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -93,7 +103,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build image for testing
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.18.0
         with:
           context: .
           file: packages/sandbox/Dockerfile
@@ -105,8 +115,10 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
 
       - name: Test coding agent CLIs
+        env:
+          TEST_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
         run: |
-          docker run --rm --entrypoint /bin/bash ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test -c '
+          docker run --rm --entrypoint /bin/bash "$TEST_IMAGE" -c '
             pids=()
             claude --version & pids+=($!)
             codex --version & pids+=($!)
@@ -118,7 +130,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.18.0
         with:
           context: .
           file: packages/sandbox/Dockerfile
@@ -129,13 +141,15 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="$BUILD_DIGEST"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -146,23 +160,25 @@ jobs:
     name: Create multi-arch manifest
     runs-on: ubuntu-24.04
     needs: docker-build
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
-      packages: write
+      packages: write # Publish the manifest to GHCR from protected main only.
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.11.1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -170,7 +186,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -181,9 +197,27 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          shopt -s nullglob
+          digest_files=(*)
+          if (( ${#digest_files[@]} == 0 )); then
+            echo "No image digests were uploaded" >&2
+            exit 1
+          fi
+
+          metadata_args=()
+          while IFS= read -r tag; do
+            metadata_args+=("-t" "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+          digest_args=()
+          for digest_file in "${digest_files[@]}"; do
+            digest_args+=("${REGISTRY}/${IMAGE_NAME}@sha256:${digest_file}")
+          done
+
+          docker buildx imagetools create "${metadata_args[@]}" "${digest_args[@]}"
 
       - name: Inspect image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "$IMAGE_REF"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests on ${{ matrix.os }}
+    # Full tests use the dev environment and service credentials. Never run
+    # this job for a pull request whose head repository is outside this repo.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.id == github.repository_id &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     environment: dev
     strategy:
       fail-fast: false
@@ -20,23 +31,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.21
 
       - name: Setup Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Bun install cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.bun/install/cache
@@ -45,7 +58,7 @@ jobs:
             ${{ runner.os }}-bun-install-
 
       - name: Cache Cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
         with:
           workspaces: apps/server/native/core
 
@@ -86,3 +99,42 @@ jobs:
           NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
           NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
         run: bun run test
+
+  test-untrusted:
+    name: Run read-only tests on ubuntu-24.04
+    # Fork pull requests still receive useful feedback, but never receive the
+    # dev environment or any repository secret. Keep this suite limited to
+    # deterministic unit tests that do not require external services.
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.pull_request.head.repo.id != github.repository_id ||
+      github.event.pull_request.head.repo.full_name != github.repository)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.2.21
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run deterministic unit tests
+        run: |
+          set -euo pipefail
+          bunx vitest run --config apps/client/vitest.config.ts apps/client/src apps/client/electron
+          (cd packages/convex && bunx vitest run _shared convex/mobileInbox.test.ts)
+          bunx vitest run packages/shared/src

--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -23,6 +23,7 @@ type IncrementMode = "major" | "minor" | "patch";
 type RunOptions = {
   allowNonZeroExit?: boolean;
   stdio?: "pipe" | "inherit";
+  env?: NodeJS.ProcessEnv;
 };
 
 type RunResult = {
@@ -51,16 +52,23 @@ function writeGithubOutput(key: string, value: string): void {
 
 function usage(): never {
   console.error(
-    `Usage: ./scripts/${scriptName} [major|minor|patch|<semver>]\nExamples:\n  ./scripts/${scriptName}\n  ./scripts/${scriptName} minor\n  ./scripts/${scriptName} 1.2.3`
+    `Usage: ./scripts/${scriptName} [major|minor|patch|<semver>]\nExamples:\n  ./scripts/${scriptName}\n  ./scripts/${scriptName} minor\n  ./scripts/${scriptName} 1.2.3`,
   );
   return process.exit(1);
 }
 
-function run(command: string, args: string[], options: RunOptions = {}): RunResult {
+function run(
+  command: string,
+  args: string[],
+  options: RunOptions = {},
+): RunResult {
   const spawnOptions: SpawnSyncOptions = {
     cwd: process.cwd(),
     stdio: options.stdio ?? "pipe",
   };
+  if (options.env) {
+    spawnOptions.env = options.env;
+  }
 
   if ((options.stdio ?? "pipe") === "pipe") {
     spawnOptions.encoding = "utf8";
@@ -77,11 +85,41 @@ function run(command: string, args: string[], options: RunOptions = {}): RunResu
   const status = typeof result.status === "number" ? result.status : 0;
 
   if (status !== 0 && !options.allowNonZeroExit) {
-    const errorMessage = stderr.trim() || stdout.trim() || `${command} ${args.join(" ")}`;
-    throw new Error(`Command failed (${command} ${args.join(" ")}): ${errorMessage}`);
+    const errorMessage =
+      stderr.trim() || stdout.trim() || `${command} ${args.join(" ")}`;
+    throw new Error(
+      `Command failed (${command} ${args.join(" ")}): ${errorMessage}`,
+    );
   }
 
   return { stdout, stderr, status };
+}
+
+function runGit(args: string[], options: RunOptions = {}): RunResult {
+  const baseEnv = { ...process.env, ...options.env };
+  const token = baseEnv.GITHUB_TOKEN;
+  if (!token) {
+    return run("git", args, options);
+  }
+
+  const configuredCount = Number.parseInt(
+    baseEnv.GIT_CONFIG_COUNT ?? "0",
+    10,
+  );
+  const configIndex =
+    Number.isSafeInteger(configuredCount) && configuredCount >= 0
+      ? configuredCount
+      : 0;
+
+  return run("git", args, {
+    ...options,
+    env: {
+      ...baseEnv,
+      GIT_CONFIG_COUNT: String(configIndex + 1),
+      [`GIT_CONFIG_KEY_${configIndex}`]: "http.https://github.com/.extraheader",
+      [`GIT_CONFIG_VALUE_${configIndex}`]: `AUTHORIZATION: bearer ${token}`,
+    },
+  });
 }
 
 function ensureGitAvailable(): void {
@@ -103,7 +141,9 @@ function parseSemverParts(value: string): [number, number, number] {
   if (!isSemver(value)) {
     throw new Error(`Version "${value}" is not a valid semver (x.y.z).`);
   }
-  const [major, minor, patch] = value.split(".").map((part) => Number.parseInt(part, 10));
+  const [major, minor, patch] = value
+    .split(".")
+    .map((part) => Number.parseInt(part, 10));
   return [major, minor, patch];
 }
 
@@ -145,11 +185,15 @@ function loadCurrentVersion(): string {
   const parsed: PackageJson = JSON.parse(raw);
 
   if (typeof parsed.version !== "string" || !parsed.version) {
-    throw new Error("Unable to read current version from apps/client/package.json.");
+    throw new Error(
+      "Unable to read current version from apps/client/package.json.",
+    );
   }
 
   if (!isSemver(parsed.version)) {
-    throw new Error(`Current version "${parsed.version}" is not in the expected x.y.z format.`);
+    throw new Error(
+      `Current version "${parsed.version}" is not in the expected x.y.z format.`,
+    );
   }
 
   return parsed.version;
@@ -188,7 +232,9 @@ function updateVersionFile(version: string): void {
 function resolveRepository(): Repository {
   const repository = process.env.GITHUB_REPOSITORY ?? "";
   if (!repository.includes("/")) {
-    throw new Error("GITHUB_REPOSITORY is not set. This script must run in GitHub Actions.");
+    throw new Error(
+      "GITHUB_REPOSITORY is not set. This script must run in GitHub Actions.",
+    );
   }
   const [owner, name] = repository.split("/");
   return { owner, name };
@@ -210,8 +256,14 @@ function getBaseBranch(): string {
   return process.env.RELEASE_BASE_BRANCH?.trim() || defaultBaseBranch;
 }
 
-async function findExistingPullRequest(branchName: string, repo: Repository, token: string): Promise<PullRequest | null> {
-  const url = new URL(`https://api.github.com/repos/${repo.owner}/${repo.name}/pulls`);
+async function findExistingPullRequest(
+  branchName: string,
+  repo: Repository,
+  token: string,
+): Promise<PullRequest | null> {
+  const url = new URL(
+    `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls`,
+  );
   url.searchParams.set("head", `${repo.owner}:${branchName}`);
   url.searchParams.set("state", "open");
 
@@ -237,28 +289,31 @@ async function createPullRequest(
   token: string,
   branchName: string,
   version: string,
-  baseBranch: string
+  baseBranch: string,
 ): Promise<PullRequest> {
-  const response = await fetch(`https://api.github.com/repos/${repo.owner}/${repo.name}/pulls`, {
-    method: "POST",
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "X-GitHub-Api-Version": "2022-11-28",
+  const response = await fetch(
+    `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({
+        title: `chore: release v${version}`,
+        head: branchName,
+        base: baseBranch,
+        draft: true,
+        body: [
+          `Automated release for v${version}.`,
+          "- Bumps the app version in apps/client/package.json.",
+          "- Please review and merge to publish the release.",
+        ].join("\n"),
+      }),
     },
-    body: JSON.stringify({
-      title: `chore: release v${version}`,
-      head: branchName,
-      base: baseBranch,
-      draft: true,
-      body: [
-        `Automated release for v${version}.`,
-        "- Bumps the app version in apps/client/package.json.",
-        "- Please review and merge to publish the release.",
-      ].join("\n"),
-    }),
-  });
+  );
 
   if (!response.ok) {
     const message = await response.text();
@@ -282,18 +337,30 @@ async function main(): Promise<void> {
 
   ensureGitAvailable();
 
-  const statusOutput = run("git", ["status", "--porcelain", "--untracked-files=no"]).stdout.trim();
+  const statusOutput = run("git", [
+    "status",
+    "--porcelain",
+    "--untracked-files=no",
+  ]).stdout.trim();
   if (statusOutput) {
-    throw new Error("Working tree has tracked changes. Commit or stash them before releasing.");
+    throw new Error(
+      "Working tree has tracked changes. Commit or stash them before releasing.",
+    );
   }
 
-  const currentBranch = run("git", ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.trim();
+  const currentBranch = run("git", [
+    "rev-parse",
+    "--abbrev-ref",
+    "HEAD",
+  ]).stdout.trim();
   if (currentBranch === "HEAD") {
-    throw new Error("You are in a detached HEAD state. Check out a branch before releasing.");
+    throw new Error(
+      "You are in a detached HEAD state. Check out a branch before releasing.",
+    );
   }
 
-  const remotes = run("git", ["remote"]).stdout
-    .split(/\r?\n/)
+  const remotes = run("git", ["remote"])
+    .stdout.split(/\r?\n/)
     .map((remote) => remote.trim())
     .filter(Boolean);
 
@@ -303,7 +370,7 @@ async function main(): Promise<void> {
 
   const firstRemote = remotes[0] ?? "";
 
-  run("git", ["fetch", "--tags", firstRemote], { stdio: "inherit" });
+  runGit(["fetch", "--tags", firstRemote], { stdio: "inherit" });
 
   const packageVersion = loadCurrentVersion();
   const highestTagVersion = determineHighestTagVersion();
@@ -319,10 +386,16 @@ async function main(): Promise<void> {
 
   if (!bumpTarget) {
     newVersion = incrementVersion("patch", baseVersion);
-  } else if (bumpTarget === "major" || bumpTarget === "minor" || bumpTarget === "patch") {
+  } else if (
+    bumpTarget === "major" ||
+    bumpTarget === "minor" ||
+    bumpTarget === "patch"
+  ) {
     newVersion = incrementVersion(bumpTarget, baseVersion);
   } else {
-    const manualTarget = bumpTarget.startsWith("v") ? bumpTarget.slice(1) : bumpTarget;
+    const manualTarget = bumpTarget.startsWith("v")
+      ? bumpTarget.slice(1)
+      : bumpTarget;
     newVersion = manualTarget;
   }
 
@@ -331,32 +404,46 @@ async function main(): Promise<void> {
   }
 
   if (compareSemver(newVersion, baseVersion) <= 0) {
-    throw new Error(`New version ${newVersion} must be greater than existing version ${baseVersion}.`);
+    throw new Error(
+      `New version ${newVersion} must be greater than existing version ${baseVersion}.`,
+    );
   }
 
-  const localTagCheck = run("git", ["rev-parse", "-q", "--verify", `refs/tags/v${newVersion}`], {
-    allowNonZeroExit: true,
-  });
+  const localTagCheck = run(
+    "git",
+    ["rev-parse", "-q", "--verify", `refs/tags/v${newVersion}`],
+    {
+      allowNonZeroExit: true,
+    },
+  );
   if (localTagCheck.status === 0) {
     throw new Error(`Tag v${newVersion} already exists locally.`);
   }
 
-  const remoteTagCheck = run("git", ["ls-remote", "--tags", firstRemote, `refs/tags/v${newVersion}`], {
-    allowNonZeroExit: true,
-  });
+  const remoteTagCheck = runGit(
+    ["ls-remote", "--tags", firstRemote, `refs/tags/v${newVersion}`],
+    {
+      allowNonZeroExit: true,
+    },
+  );
   if (remoteTagCheck.stdout.trim()) {
     throw new Error(`Tag v${newVersion} already exists on ${firstRemote}.`);
   }
 
   const branchName = buildReleaseBranch(newVersion);
 
-  const branchCheck = run("git", ["ls-remote", "--heads", firstRemote, branchName], { allowNonZeroExit: true });
+  const branchCheck = runGit(
+    ["ls-remote", "--heads", firstRemote, branchName],
+    { allowNonZeroExit: true },
+  );
   if (branchCheck.stdout.trim()) {
     const repo = resolveRepository();
     const token = ensureToken();
     const existing = await findExistingPullRequest(branchName, repo, token);
     if (existing) {
-      console.log(`Release branch ${branchName} already has open PR #${existing.number}: ${existing.html_url}`);
+      console.log(
+        `Release branch ${branchName} already has open PR #${existing.number}: ${existing.html_url}`,
+      );
       writeGithubOutput("release_branch", branchName);
       writeGithubOutput("release_version", newVersion);
       writeGithubOutput("release_pr_state", "existing");
@@ -367,7 +454,7 @@ async function main(): Promise<void> {
     }
     // Branch exists but no open PR - delete the stale branch and continue
     console.log(`Deleting stale branch ${branchName} (no open PR found)`);
-    run("git", ["push", firstRemote, "--delete", branchName], { stdio: "inherit" });
+    runGit(["push", firstRemote, "--delete", branchName], { stdio: "inherit" });
   }
 
   updateVersionFile(newVersion);
@@ -376,9 +463,11 @@ async function main(): Promise<void> {
 
   run("git", ["checkout", "-b", branchName], { stdio: "inherit" });
 
-  run("git", ["commit", "-m", `chore: release v${newVersion}`], { stdio: "inherit" });
+  run("git", ["commit", "-m", `chore: release v${newVersion}`], {
+    stdio: "inherit",
+  });
 
-  run("git", ["push", "-u", firstRemote, branchName], { stdio: "inherit" });
+  runGit(["push", "-u", firstRemote, branchName], { stdio: "inherit" });
 
   writeGithubOutput("release_branch", branchName);
   writeGithubOutput("release_version", newVersion);
@@ -388,13 +477,21 @@ async function main(): Promise<void> {
   const token = ensureToken();
   const baseBranch = getBaseBranch();
 
-  const pullRequest = await createPullRequest(repo, token, branchName, newVersion, baseBranch);
+  const pullRequest = await createPullRequest(
+    repo,
+    token,
+    branchName,
+    newVersion,
+    baseBranch,
+  );
 
   writeGithubOutput("release_pr_state", "created");
   writeGithubOutput("release_pr_number", pullRequest.number.toString());
   writeGithubOutput("release_pr_url", pullRequest.html_url);
 
-  console.log(`Created draft release PR #${pullRequest.number}: ${pullRequest.html_url}`);
+  console.log(
+    `Created draft release PR #${pullRequest.number}: ${pullRequest.html_url}`,
+  );
 }
 
 void (async () => {


### PR DESCRIPTION
## Summary

- Remove secrets and the `dev` environment from the public `Checks` workflow.
- Run full integration tests only for pushes and same-repository pull requests. Fork pull requests get a read-only hosted unit-test suite.
- Restrict Docker, Morph, Convex sync, and release jobs to approved repository refs, and check out the immutable event commit.
- Pin active non-Claude third-party actions to full commit SHAs and disable persisted checkout credentials.
- Replace shell expression interpolation with environment handoff, safe arrays, and transient Git authentication.

## Scope coordination

`.github/workflows/claude.yml` is owned by https://github.com/manaflow-ai/manaflow/pull/1909. That PR pins checkout and `anthropics/claude-code-action`, removes persisted checkout credentials, and keeps repository permissions read-only apart from the OIDC token exchange required by the action. Merge it with this PR to remove the remaining scanner findings.

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `bunx tsgo --noEmit -p scripts/tsconfig.json`
- `bun run check`, lint and typecheck pass. The optional OpenAPI precheck reports missing local secrets and is non-fatal by design.
- Fork-safe Vitest set, 23 files and 165 tests pass.
- `zizmor --min-severity medium .github/workflows`, no medium or high findings outside `claude.yml`.

## Trade-offs and residual risk

- Same-repository pull request branches remain trusted for the full secret-backed test suite. Fork code runs without repository secrets or write permissions on GitHub-hosted runners.
- Release jobs still accept generated `release/v*` branches and `v*` tags to preserve the current release flow. A repository writer can create such a ref, so environment approval and repository access remain part of the trust boundary.
- Full SHA pins prevent tag movement but require deliberate update work when action releases change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI against untrusted fork code and supply-chain tampering: fork PRs now run a read-only unit-test suite without repository secrets, privileged jobs only run on protected refs, and third-party actions are pinned to full commit SHAs.

**Security boundaries**
- Full secret-backed tests now run only for pushes and same-repository PRs; fork PRs get a deterministic read-only Vitest suite with no secrets or write permissions.
- Docker, Morph, Convex sync, and release jobs now require `main`, `release/v*`, or `v*` refs and check out the immutable event commit.
- Release PR workflow checks out `main` and verifies the event SHA before creating the release branch.
- Workflow-wide permissions default to read-only, with write scopes granted only to jobs that need them.

**Hardening mechanics**
- Pins non-Claude third-party actions to commit SHAs and disables persisted checkout credentials.
- Moves secrets, digests, tags, and git auth out of shell interpolation into environment handoff and safe arrays.
- `release-pr.ts` supplies transient git authentication via env config instead of CLI arguments.
- Windows release builds now fail on non-zero exit codes.

Trade-offs: same-repo PR branches remain trusted for the full suite, and release refs can be created by repository writers so environment approval stays part of the trust boundary. SHA pins require deliberate updates when action releases change.

<sup>Written for commit f7cce53d5a6c055316bb74958c9ddc51af6e488f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened automated workflows with least-privilege access, secured checkouts, and pinned build tools.
  - Reduced credential and secret exposure during testing, releases, and image publishing.

- **Reliability**
  - Improved validation for container image manifests and build artifacts.
  - Made automated checks more consistent, including safer testing for contributions from external repositories.

- **Release Management**
  - Restricted publishing and snapshot operations to approved branches and commits.
  - Added safer authentication handling for release operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->