### PR TITLE
security: keep pull-request tests free of secrets

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,15 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install dependencies
+      - name: Verify workflow secret boundary
+        run: ruby scripts/ci/verify-workflow-secret-boundary.rb
+
+      - name: Install dependencies without lifecycle scripts (pull request)
+        if: github.event_name == 'pull_request'
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Install dependencies (main)
+        if: github.event_name != 'pull_request'
         run: bun install --frozen-lockfile
 
       - name: Checks and tests (parallel on one runner)

--- a/.github/workflows/tests-trusted.yml
+++ b/.github/workflows/tests-trusted.yml
@@ -1,0 +1,86 @@
+name: Tests (trusted main)
+
+on:
+  # A push to the protected default branch is the only automatic event allowed
+  # to execute code with the development environment secrets. Pull requests,
+  # including same-repository pull requests, are handled by tests.yml.
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # Keep the status context identical to the pull-request workflow. Only one
+    # of these workflows runs for a given event, so required checks stay stable.
+    name: Run tests on ubuntu-24.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    environment: dev
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout immutable main commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.2.21
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Cache Bun install cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-install-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-install-
+
+      - name: Cache Cargo registry + build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
+        with:
+          workspaces: apps/server/native/core
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build native-core addon
+        run: bun run build
+        working-directory: apps/server/native/core
+
+      - name: Run full tests
+        env:
+          CI: "true"
+          CMUX_BUILD_LINUX: "0"
+          CMUX_SKIP_DOCKER_TESTS: "1"
+          CMUX_SKIP_CARGO_CRATES: "sandbox,cmux-env,cmux-pty,cmux-proxy,global-proxy,server/native/core"
+          STACK_SECRET_SERVER_KEY: ${{ secrets.STACK_SECRET_SERVER_KEY }}
+          STACK_SUPER_SECRET_ADMIN_KEY: ${{ secrets.STACK_SUPER_SECRET_ADMIN_KEY }}
+          STACK_DATA_VAULT_SECRET: ${{ secrets.STACK_DATA_VAULT_SECRET }}
+          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          CMUX_GITHUB_APP_ID: ${{ secrets.CMUX_GITHUB_APP_ID }}
+          CMUX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CMUX_GITHUB_APP_PRIVATE_KEY }}
+          CMUX_TASK_RUN_JWT_SECRET: ${{ secrets.CMUX_TASK_RUN_JWT_SECRET }}
+          MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
+          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
+        run: bun run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,24 @@ jobs:
           node-version: 24
 
       - name: Install dependencies without lifecycle scripts
-        env:
-          CI: "true"
-          NPM_CONFIG_IGNORE_SCRIPTS: "true"
-          NPM_CONFIG_USERCONFIG: /dev/null
-        run: bun install --frozen-lockfile --ignore-scripts
+        run: |
+          set -euo pipefail
+          install_home="${RUNNER_TEMP:-/tmp}/cmux-untrusted-install-home"
+          mkdir -p "${install_home}"
+          env -i \
+            PATH="${PATH}" \
+            HOME="${install_home}" \
+            TMPDIR="${TMPDIR:-/tmp}" \
+            CI=true \
+            NPM_CONFIG_IGNORE_SCRIPTS=true \
+            NPM_CONFIG_USERCONFIG=/dev/null \
+            bun install --frozen-lockfile --ignore-scripts
 
       - name: Run pull-request tests without secrets
-        run: bash scripts/ci/run-untrusted-tests.sh
+        run: |
+          set -euo pipefail
+          env -i \
+            PATH="${PATH}" \
+            RUNNER_TEMP="${RUNNER_TEMP:-/tmp}" \
+            TMPDIR="${TMPDIR:-/tmp}" \
+            bash scripts/ci/run-untrusted-tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
-name: Tests (pull requests)
+# Keep the workflow identity used by existing branch-protection rules. The job
+# below is pull-request-only; the trusted main workflow has a separate name.
+name: Tests (Linux + macOS)
 
 on:
   # This workflow is intentionally limited to pull requests. It checks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -37,13 +37,11 @@ jobs:
           node-version: 24
 
       - name: Install dependencies without lifecycle scripts
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Run deterministic unit tests
         env:
           CI: "true"
-        run: |
-          set -euo pipefail
-          bunx vitest run --config apps/client/vitest.config.ts apps/client/src apps/client/electron
-          (cd packages/convex && bunx vitest run _shared convex/mobileInbox.test.ts)
-          bunx vitest run packages/shared/src
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          NPM_CONFIG_USERCONFIG: /dev/null
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Run pull-request tests without secrets
+        run: bash scripts/ci/run-untrusted-tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,10 @@
-name: Tests (Linux + macOS)
+name: Tests (pull requests)
 
 on:
-  push:
-    branches: [main]
+  # This workflow is intentionally limited to pull requests. It checks
+  # contributor code with a read-only token and no repository or environment
+  # secrets. Secret-backed tests live in tests-trusted.yml, which only runs
+  # after code has landed on main.
   pull_request:
 
 permissions:
@@ -10,109 +12,14 @@ permissions:
 
 jobs:
   test:
-    name: Run tests on ${{ matrix.os }}
-    # Full tests use the dev environment and service credentials. Never run
-    # this job for a pull request whose head repository is outside this repo.
-    if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request.head.repo.id == github.repository_id &&
-      github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-    environment: dev
-    strategy:
-      fail-fast: false
-      matrix:
-        # os: [ubuntu-24.04, macos-13]
-        # os: [ubuntu-24.04, macos-13-large]
-        # TODO: enable macos when we can make it fast
-        os: [ubuntu-24.04]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
-        with:
-          persist-credentials: false
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.2.21
-
-      - name: Setup Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-
-      - name: Cache Bun install cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-install-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-install-
-
-      - name: Cache Cargo registry + build
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.7.8
-        with:
-          workspaces: apps/server/native/core
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build native-core addon
-        run: bun run build
-        working-directory: apps/server/native/core
-
-      - name: Run tests
-        env:
-          # CI environment flag
-          CI: "true"
-          # Keep default; set to 1 only if you want cross-builds for Linux
-          CMUX_BUILD_LINUX: "0"
-          # Skip Docker E2E tests in CI for stability/speed
-          CMUX_SKIP_DOCKER_TESTS: "1"
-          # Skip cargo crates handled in dedicated workflows
-          CMUX_SKIP_CARGO_CRATES: "sandbox,cmux-env,cmux-pty,cmux-proxy,global-proxy,server/native/core"
-          # Stack Auth env vars
-          STACK_SECRET_SERVER_KEY: ${{ secrets.STACK_SECRET_SERVER_KEY }}
-          STACK_SUPER_SECRET_ADMIN_KEY: ${{ secrets.STACK_SUPER_SECRET_ADMIN_KEY }}
-          STACK_DATA_VAULT_SECRET: ${{ secrets.STACK_DATA_VAULT_SECRET }}
-          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
-          # GitHub App
-          CMUX_GITHUB_APP_ID: ${{ secrets.CMUX_GITHUB_APP_ID }}
-          CMUX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CMUX_GITHUB_APP_PRIVATE_KEY }}
-          CMUX_TASK_RUN_JWT_SECRET: ${{ secrets.CMUX_TASK_RUN_JWT_SECRET }}
-          # API Keys
-          MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-          # Next.js public env vars
-          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
-          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
-          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
-        run: bun run test
-
-  test-untrusted:
-    name: Run read-only tests on ubuntu-24.04
-    # Fork pull requests still receive useful feedback, but never receive the
-    # dev environment or any repository secret. Keep this suite limited to
-    # deterministic unit tests that do not require external services.
-    if: >-
-      github.event_name == 'pull_request' &&
-      (github.event.pull_request.head.repo.id != github.repository_id ||
-      github.event.pull_request.head.repo.full_name != github.repository)
+    # Keep this context stable for branch-protection rules. Every pull request
+    # gets this no-secrets job, including pull requests from forks.
+    name: Run tests on ubuntu-24.04
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 15
+
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
@@ -129,10 +36,12 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Install dependencies without lifecycle scripts
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run deterministic unit tests
+        env:
+          CI: "true"
         run: |
           set -euo pipefail
           bunx vitest run --config apps/client/vitest.config.ts apps/client/src apps/client/electron

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -1,0 +1,19 @@
+# CI security boundary
+
+Pull requests run `.github/workflows/tests.yml`. That workflow uses the
+read-only `pull_request` event, grants only `contents: read`, disables package
+lifecycle scripts, and does not bind an environment or a secret.
+
+The full integration suite runs from
+`.github/workflows/tests-trusted.yml`. It is triggered only by a push to
+`main`, checks out the immutable push SHA, and is the only test workflow that
+uses the `dev` environment. A pull request must therefore be merged before its
+code can run with development credentials.
+
+Do not change the trusted workflow to `pull_request_target`, or check out a
+pull request head from a secret-bearing job. Those patterns execute
+contributor-controlled code with repository credentials.
+
+The workflow contract is verified by
+`scripts/ci/verify-workflow-secret-boundary.rb` from the read-only `Checks`
+workflow. Keep that test green when adding a workflow trigger or a secret.

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -2,7 +2,11 @@
 
 Pull requests run `.github/workflows/tests.yml`. That workflow uses the
 read-only `pull_request` event, grants only `contents: read`, disables package
-lifecycle scripts, and does not bind an environment or a secret.
+lifecycle scripts, and does not bind an environment or a secret. It invokes
+`scripts/ci/run-untrusted-tests.sh`, which runs the workspace unit suites with
+an isolated, allowlisted environment. Native-core tests and authenticated
+GitHub, Morph, and Sandbox integration tests stay in the trusted suite because
+they require service credentials or a native build.
 
 The full integration suite runs from
 `.github/workflows/tests-trusted.yml`. It is triggered only by a push to
@@ -17,3 +21,5 @@ contributor-controlled code with repository credentials.
 The workflow contract is verified by
 `scripts/ci/verify-workflow-secret-boundary.rb` from the read-only `Checks`
 workflow. Keep that test green when adding a workflow trigger or a secret.
+Protect `.github/workflows` with required owner review so a pull request cannot
+change this policy and its verifier in the same change.

--- a/scripts/ci/run-untrusted-tests.sh
+++ b/scripts/ci/run-untrusted-tests.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the JavaScript/TypeScript test suites that do not need a service account.
+# The command environment is rebuilt from an allowlist so a runner credential
+# cannot reach contributor-controlled test code by accident.
+
+readonly temp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+readonly temp_prefix="${temp_root%/}"
+readonly test_home="${temp_prefix}/cmux-untrusted-test-home"
+readonly test_tmp="${temp_prefix}/cmux-untrusted-test-tmp"
+readonly path_value="${PATH:-/usr/bin:/bin}"
+
+mkdir -p "${test_home}/.config" "${test_tmp}"
+
+cleanup() {
+  rm -rf -- "${test_home}" "${test_tmp}"
+}
+trap cleanup EXIT
+
+run_untrusted() {
+  local working_directory="$1"
+  shift
+
+  (
+    cd "${working_directory}"
+    env -i \
+      PATH="${path_value}" \
+      HOME="${test_home}" \
+      TMPDIR="${test_tmp}" \
+      XDG_CONFIG_HOME="${test_home}/.config" \
+      LANG=C.UTF-8 \
+      LC_ALL=C.UTF-8 \
+      CI=true \
+      NO_COLOR=1 \
+      GIT_TERMINAL_PROMPT=0 \
+      NPM_CONFIG_IGNORE_SCRIPTS=true \
+      GITHUB_TOKEN= \
+      ACTIONS_RUNTIME_TOKEN= \
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN= \
+      AWS_ACCESS_KEY_ID= \
+      AWS_SECRET_ACCESS_KEY= \
+      AWS_SESSION_TOKEN= \
+      NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:9 \
+      NEXT_PUBLIC_WWW_ORIGIN=http://127.0.0.1:9 \
+      NEXT_PUBLIC_STACK_PROJECT_ID=11111111-1111-4111-8111-111111111111 \
+      NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=pck_pt4nwry6sdskews2pxk4g2fbe861ak2zvaf3mqendspa0 \
+      NEXT_PUBLIC_GITHUB_APP_SLUG=cmux-test \
+      STACK_SECRET_SERVER_KEY=ssk_untrusted_test \
+      STACK_SUPER_SECRET_ADMIN_KEY=ssk_untrusted_test \
+      STACK_DATA_VAULT_SECRET=01234567890123456789012345678901 \
+      CMUX_GITHUB_APP_ID=1 \
+      CMUX_GITHUB_APP_PRIVATE_KEY=untrusted-test-key \
+      CMUX_TASK_RUN_JWT_SECRET=untrusted-test-jwt \
+      MORPH_API_KEY=untrusted-test-morph \
+      MORPH_API_BASE_URL=http://127.0.0.1:9 \
+      CONVEX_DEPLOY_KEY=untrusted-test-convex \
+      ANTHROPIC_API_KEY=untrusted-test-anthropic \
+      AWS_BEARER_TOKEN_BEDROCK=untrusted-test-bedrock \
+      OPENAI_API_KEY= \
+      GEMINI_API_KEY= \
+      "$@"
+  )
+}
+
+# Client, Convex, and shared tests are deterministic and run in full.
+run_untrusted . bunx vitest run --config apps/client/vitest.config.ts apps/client/src apps/client/electron
+run_untrusted packages/convex bunx vitest run --config vitest.config.ts
+run_untrusted . bunx vitest run packages/shared/src
+
+# Server tests that depend on a locally built native-core addon are covered by
+# the dedicated native-core workflow. The remaining server tests run here.
+run_untrusted apps/server bunx vitest run --exclude '**/compareRefs.test.ts'
+
+# Worker tests use local temporary repositories and do not need credentials.
+run_untrusted apps/worker bunx vitest run
+
+# The authenticated GitHub-repository tests and live Morph/Sandbox tests need
+# service credentials. Keep the unauthenticated route assertion in this job.
+run_untrusted apps/www bunx vitest run --config vitest.config.ts --exclude '**/github.repos.route.test.ts'
+run_untrusted apps/www bunx vitest run --config vitest.config.ts lib/routes/github.repos.route.test.ts --testNamePattern 'rejects unauthenticated requests'
+
+# This package checks that its publishable artifact does not leak environment
+# values and does not require a service account.
+run_untrusted packages/cmux bun run test

--- a/scripts/ci/run-untrusted-tests.sh
+++ b/scripts/ci/run-untrusted-tests.sh
@@ -35,6 +35,9 @@ run_untrusted() {
       NO_COLOR=1 \
       GIT_TERMINAL_PROMPT=0 \
       NPM_CONFIG_IGNORE_SCRIPTS=true \
+      CMUX_BUILD_LINUX=0 \
+      CMUX_SKIP_DOCKER_TESTS=1 \
+      CMUX_SKIP_CARGO_CRATES=sandbox,cmux-env,cmux-pty,cmux-proxy,global-proxy,server/native/core \
       GITHUB_TOKEN= \
       ACTIONS_RUNTIME_TOKEN= \
       ACTIONS_ID_TOKEN_REQUEST_TOKEN= \

--- a/scripts/ci/verify-workflow-secret-boundary.rb
+++ b/scripts/ci/verify-workflow-secret-boundary.rb
@@ -57,7 +57,7 @@ end
 def contains_secret_reference?(value)
   found = false
   walk(value) do |node|
-    found ||= node.is_a?(String) && node.match?(/\$\{\{\s*secrets(?:\.|\[)/)
+    found ||= node.is_a?(String) && node.match?(/\$\{\{[^}]*\bsecrets\b/)
   end
   found
 end

--- a/scripts/ci/verify-workflow-secret-boundary.rb
+++ b/scripts/ci/verify-workflow-secret-boundary.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 # Validate the event boundary for workflows that execute repository code. This
-# is a policy test, not a source-shape test: it parses the workflow documents,
-# classifies their events, and rejects any pull-request workflow that can carry
-# a secret or environment binding.
+# security-contract test parses the workflow documents, classifies their events,
+# and rejects any pull-request workflow that can carry a secret or environment
+# binding.
 
 require "yaml"
 
@@ -57,7 +57,7 @@ end
 def contains_secret_reference?(value)
   found = false
   walk(value) do |node|
-    found ||= node.is_a?(String) && node.match?(/\$\{\{\s*secrets\./)
+    found ||= node.is_a?(String) && node.match?(/\$\{\{\s*secrets(?:\.|\[)/)
   end
   found
 end
@@ -124,7 +124,8 @@ def assert_pull_request_workflow_is_untrusted(document, filename)
     checkouts = checkout_steps(job)
     fail_contract("#{filename}:#{job_name} has no checkout credential hardening") if checkouts.empty?
     checkouts.each do |step|
-      persist = step.fetch("with", {})["persist-credentials"]
+      with = step["with"]
+      persist = with.is_a?(Hash) ? with["persist-credentials"] : nil
       fail_contract("#{filename}:#{job_name} persists checkout credentials") unless persist == false
     end
 
@@ -153,7 +154,8 @@ def assert_trusted_main_workflow(document, filename)
   jobs(document, filename).each do |job_name, job|
     fail_contract("#{filename}:#{job_name} grants write permission") if contains_write_permission?(job)
     checkout_steps(job).each do |step|
-      persist = step.fetch("with", {})["persist-credentials"]
+      with = step["with"]
+      persist = with.is_a?(Hash) ? with["persist-credentials"] : nil
       fail_contract("#{filename}:#{job_name} persists checkout credentials") unless persist == false
     end
   end
@@ -162,7 +164,7 @@ end
 def assert_checks_workflow_is_read_only(document, filename)
   names = trigger_names(trigger_config(document, filename), filename)
   expected = %w[push pull_request]
-  fail_contract("#{filename} trigger set changed: #{names.inspect}") unless names == expected
+  fail_contract("#{filename} trigger set changed: #{names.inspect}") unless names.sort == expected.sort
   fail_contract("#{filename} contains a secret reference") if contains_secret_reference?(document)
   fail_contract("#{filename} binds an environment") if contains_environment_binding?(document)
   fail_contract("#{filename} grants write permission") if contains_write_permission?(document)

--- a/scripts/ci/verify-workflow-secret-boundary.rb
+++ b/scripts/ci/verify-workflow-secret-boundary.rb
@@ -57,7 +57,7 @@ end
 def contains_secret_reference?(value)
   found = false
   walk(value) do |node|
-    found ||= node.is_a?(String) && node.match?(/\$\{\{[^}]*\bsecrets\b/)
+    found ||= node.is_a?(String) && node.match?(/\$\{\{[^}]*\bsecrets(?:\b|\s*\[)/)
   end
   found
 end
@@ -76,12 +76,36 @@ def contains_write_permission?(value)
     next unless node.is_a?(Hash) && node.key?("permissions")
 
     permissions = node["permissions"]
-    found ||= permissions == "write" || permissions == "admin"
+    found ||= %w[write admin write-all].include?(permissions.to_s)
     if permissions.is_a?(Hash)
-      found ||= permissions.values.any? { |permission| %w[write admin].include?(permission.to_s) }
+      found ||= permissions.values.any? { |permission| %w[write admin write-all].include?(permission.to_s) }
     end
   end
   found
+end
+
+READ_ONLY_PERMISSION_VALUES = %w[read none].freeze
+
+def read_only_permissions?(permissions)
+  case permissions
+  when Hash
+    !permissions.empty? && permissions.values.all? { |value| READ_ONLY_PERMISSION_VALUES.include?(value.to_s) }
+  when String
+    permissions == "read-all" || permissions == "none"
+  else
+    false
+  end
+end
+
+def assert_read_only_permissions(document, filename)
+  permissions = document["permissions"]
+  fail_contract("#{filename} must declare top-level read-only permissions") unless read_only_permissions?(permissions)
+
+  jobs(document, filename).each do |job_name, job|
+    next unless job.is_a?(Hash) && job.key?("permissions")
+
+    fail_contract("#{filename}:#{job_name} has non-read-only permissions") unless read_only_permissions?(job["permissions"])
+  end
 end
 
 def jobs(document, filename)
@@ -115,6 +139,9 @@ end
 def assert_pull_request_workflow_is_untrusted(document, filename)
   names = trigger_names(trigger_config(document, filename), filename)
   fail_contract("#{filename} must only run for pull_request") unless names == ["pull_request"]
+  assert_read_only_permissions(document, filename)
+  fail_contract("#{filename} contains a secret reference") if contains_secret_reference?(document)
+  fail_contract("#{filename} binds an environment") if contains_environment_binding?(document)
 
   jobs(document, filename).each do |job_name, job|
     fail_contract("#{filename}:#{job_name} contains a secret reference") if contains_secret_reference?(job)
@@ -145,6 +172,7 @@ def assert_trusted_main_workflow(document, filename)
   push = config["push"]
   branches = push.is_a?(Hash) ? push["branches"] : nil
   fail_contract("#{filename} must be restricted to main") unless branches == ["main"]
+  assert_read_only_permissions(document, filename)
 
   secret_jobs = jobs(document, filename).select do |_job_name, job|
     contains_secret_reference?(job) || contains_environment_binding?(job)
@@ -165,6 +193,7 @@ def assert_checks_workflow_is_read_only(document, filename)
   names = trigger_names(trigger_config(document, filename), filename)
   expected = %w[push pull_request]
   fail_contract("#{filename} trigger set changed: #{names.inspect}") unless names.sort == expected.sort
+  assert_read_only_permissions(document, filename)
   fail_contract("#{filename} contains a secret reference") if contains_secret_reference?(document)
   fail_contract("#{filename} binds an environment") if contains_environment_binding?(document)
   fail_contract("#{filename} grants write permission") if contains_write_permission?(document)

--- a/scripts/ci/verify-workflow-secret-boundary.rb
+++ b/scripts/ci/verify-workflow-secret-boundary.rb
@@ -1,0 +1,199 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Validate the event boundary for workflows that execute repository code. This
+# is a policy test, not a source-shape test: it parses the workflow documents,
+# classifies their events, and rejects any pull-request workflow that can carry
+# a secret or environment binding.
+
+require "yaml"
+
+ROOT = File.expand_path("../..", __dir__)
+WORKFLOW_DIR = File.join(ROOT, ".github", "workflows")
+
+class ContractError < StandardError; end
+
+def fail_contract(message)
+  raise ContractError, message
+end
+
+def load_workflow(filename)
+  path = File.join(WORKFLOW_DIR, filename)
+  document = YAML.safe_load(File.read(path), aliases: false)
+  fail_contract("#{filename} is not a YAML mapping") unless document.is_a?(Hash)
+
+  document
+rescue Psych::Exception => e
+  fail_contract("#{filename} is not valid YAML: #{e.message}")
+end
+
+def trigger_config(document, filename)
+  # YAML 1.1 parsers treat the GitHub Actions `on` key as boolean true.
+  document["on"] || document[true] || fail_contract("#{filename} has no `on` trigger")
+end
+
+def trigger_names(config, filename)
+  names = case config
+  when Hash then config.keys.map(&:to_s)
+  when Array then config.map(&:to_s)
+  when String then [config]
+  else []
+  end
+  fail_contract("#{filename} has no recognized triggers") if names.empty?
+
+  names
+end
+
+def walk(value, &block)
+  yield value
+  case value
+  when Hash
+    value.each { |key, child| walk(key, &block); walk(child, &block) }
+  when Array
+    value.each { |child| walk(child, &block) }
+  end
+end
+
+def contains_secret_reference?(value)
+  found = false
+  walk(value) do |node|
+    found ||= node.is_a?(String) && node.match?(/\$\{\{\s*secrets\./)
+  end
+  found
+end
+
+def contains_environment_binding?(job)
+  found = false
+  walk(job) do |node|
+    found ||= node.is_a?(Hash) && node.key?("environment")
+  end
+  found
+end
+
+def contains_write_permission?(value)
+  found = false
+  walk(value) do |node|
+    next unless node.is_a?(Hash) && node.key?("permissions")
+
+    permissions = node["permissions"]
+    found ||= permissions == "write" || permissions == "admin"
+    if permissions.is_a?(Hash)
+      found ||= permissions.values.any? { |permission| %w[write admin].include?(permission.to_s) }
+    end
+  end
+  found
+end
+
+def jobs(document, filename)
+  value = document["jobs"]
+  fail_contract("#{filename} has no jobs mapping") unless value.is_a?(Hash)
+
+  value
+end
+
+def checkout_steps(job)
+  steps = []
+  walk(job) do |node|
+    next unless node.is_a?(Hash) && node["uses"].is_a?(String)
+    next unless node["uses"].start_with?("actions/checkout@")
+
+    steps << node
+  end
+  steps
+end
+
+def install_commands(job)
+  commands = []
+  walk(job) do |node|
+    next unless node.is_a?(Hash) && node["run"].is_a?(String)
+
+    commands << node["run"]
+  end
+  commands.grep(/\bbun\s+install\b/)
+end
+
+def assert_pull_request_workflow_is_untrusted(document, filename)
+  names = trigger_names(trigger_config(document, filename), filename)
+  fail_contract("#{filename} must only run for pull_request") unless names == ["pull_request"]
+
+  jobs(document, filename).each do |job_name, job|
+    fail_contract("#{filename}:#{job_name} contains a secret reference") if contains_secret_reference?(job)
+    fail_contract("#{filename}:#{job_name} binds an environment") if contains_environment_binding?(job)
+    fail_contract("#{filename}:#{job_name} grants write permission") if contains_write_permission?(job)
+
+    checkouts = checkout_steps(job)
+    fail_contract("#{filename}:#{job_name} has no checkout credential hardening") if checkouts.empty?
+    checkouts.each do |step|
+      persist = step.fetch("with", {})["persist-credentials"]
+      fail_contract("#{filename}:#{job_name} persists checkout credentials") unless persist == false
+    end
+
+    installs = install_commands(job)
+    fail_contract("#{filename}:#{job_name} has no dependency install") if installs.empty?
+    unless installs.all? { |command| command.include?("--ignore-scripts") }
+      fail_contract("#{filename}:#{job_name} runs dependency lifecycle scripts")
+    end
+  end
+end
+
+def assert_trusted_main_workflow(document, filename)
+  config = trigger_config(document, filename)
+  names = trigger_names(config, filename)
+  fail_contract("#{filename} must only run for push") unless names == ["push"]
+
+  push = config["push"]
+  branches = push.is_a?(Hash) ? push["branches"] : nil
+  fail_contract("#{filename} must be restricted to main") unless branches == ["main"]
+
+  secret_jobs = jobs(document, filename).select do |_job_name, job|
+    contains_secret_reference?(job) || contains_environment_binding?(job)
+  end
+  fail_contract("#{filename} has no secret-backed test job") if secret_jobs.empty?
+
+  jobs(document, filename).each do |job_name, job|
+    fail_contract("#{filename}:#{job_name} grants write permission") if contains_write_permission?(job)
+    checkout_steps(job).each do |step|
+      persist = step.fetch("with", {})["persist-credentials"]
+      fail_contract("#{filename}:#{job_name} persists checkout credentials") unless persist == false
+    end
+  end
+end
+
+def assert_checks_workflow_is_read_only(document, filename)
+  names = trigger_names(trigger_config(document, filename), filename)
+  expected = %w[push pull_request]
+  fail_contract("#{filename} trigger set changed: #{names.inspect}") unless names == expected
+  fail_contract("#{filename} contains a secret reference") if contains_secret_reference?(document)
+  fail_contract("#{filename} binds an environment") if contains_environment_binding?(document)
+  fail_contract("#{filename} grants write permission") if contains_write_permission?(document)
+end
+
+def assert_event_routing
+  cases = {
+    ["push", "refs/heads/main"] => true,
+    ["push", "refs/heads/feature"] => false,
+    ["pull_request", "refs/pull/42/merge"] => false,
+    ["workflow_dispatch", "refs/heads/main"] => false,
+  }
+
+  cases.each do |(event, ref), expected|
+    actual = event == "push" && ref == "refs/heads/main"
+    fail_contract("secret route mismatch for #{event} #{ref}") unless actual == expected
+  end
+end
+
+begin
+  pull_request = load_workflow("tests.yml")
+  trusted_main = load_workflow("tests-trusted.yml")
+  checks = load_workflow("checks.yml")
+
+  assert_pull_request_workflow_is_untrusted(pull_request, "tests.yml")
+  assert_trusted_main_workflow(trusted_main, "tests-trusted.yml")
+  assert_checks_workflow_is_read_only(checks, "checks.yml")
+  assert_event_routing
+
+  puts "PASS: workflow secret boundary (pull requests are read-only; main is secret-backed)"
+rescue ContractError => e
+  warn "FAIL: #{e.message}"
+  exit 1
+end


### PR DESCRIPTION
## Summary

- Move the secret-backed integration suite to `.github/workflows/tests-trusted.yml`, triggered only by pushes to `main`.
- Make `.github/workflows/tests.yml` pull-request-only, read-only, and lifecycle-script-free.
- Keep the `Run tests on ubuntu-24.04` status context stable for branch protection.
- Add a policy verifier that rejects secret or environment bindings in pull-request workflows.
- Run broad deterministic workspace tests in an isolated, allowlisted environment with no runner credentials.
- Document the trust boundary and prohibit `pull_request_target` checkout of contributor code in secret jobs.

This branch is stacked on https://github.com/manaflow-ai/manaflow/pull/1910 and addresses the remaining same-repository pull-request exposure. No CLA files are changed.

## Verification

- `ruby -c scripts/ci/verify-workflow-secret-boundary.rb`
- `ruby scripts/ci/verify-workflow-secret-boundary.rb`
- `actionlint -shellcheck /opt/homebrew/bin/shellcheck .github/workflows/*.yml`
- `shellcheck scripts/ci/run-untrusted-tests.sh`
- `git diff --check`
- Hosted pull-request suite: 288 tests passed and 23 skipped across client, Convex, shared, server, worker, www, and cmux (Ubuntu run 33580177852).
- Hosted `Checks` verifier passed (run 33580177833).
- `packages/cmux` environment-leak test passed locally.
- Vercel preview checks remain pending because this PR changes workflows and CI scripts only.

The Rust Clippy failures currently reported on PR1910 are pre-existing toolchain findings in cmux-proxy, global-proxy, native-core, and sandbox. Fresh `main` runs 33577447186, 33577448867, 33577450673, and 33577452850 reproduce the same failures. This PR does not change those sources.
