### PR TITLE
security: fail closed on privileged workflow refs

### DIFF
--- a/.github/scripts/verify-privileged-ref.sh
+++ b/.github/scripts/verify-privileged-ref.sh
@@ -183,6 +183,12 @@ if [[ "$TRUSTED_REF_KIND" == "tag" ]]; then
     die "unable to resolve protected main"
   main_sha="$(printf '%s\n' "$main_ref_output" | awk 'NF == 2 && $2 == "refs/heads/main" { print $1; exit }')"
   [[ "$main_sha" =~ $HEX_SHA_RE ]] || die "protected main did not resolve to a commit"
+  if ! git cat-file -e "$main_sha^{commit}" 2>/dev/null; then
+    GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$main_sha" >/dev/null 2>&1 || \
+      die "unable to fetch protected main commit"
+  fi
+  git cat-file -e "$main_sha^{commit}" 2>/dev/null || \
+    die "protected main commit is not available locally"
   git merge-base --is-ancestor "$event_sha" "$main_sha" || \
     die "tag revision is not reachable from protected main"
 fi
@@ -198,6 +204,12 @@ if [[ "$TRUSTED_REF_KIND" == "release-branch" ]]; then
     die "unable to resolve protected main"
   main_sha="$(printf '%s\n' "$main_ref_output" | awk 'NF == 2 && $2 == "refs/heads/main" { print $1; exit }')"
   [[ "$main_sha" =~ $HEX_SHA_RE ]] || die "protected main did not resolve to a commit"
+  if ! git cat-file -e "$main_sha^{commit}" 2>/dev/null; then
+    GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$main_sha" >/dev/null 2>&1 || \
+      die "unable to fetch protected main commit"
+  fi
+  git cat-file -e "$main_sha^{commit}" 2>/dev/null || \
+    die "protected main commit is not available locally"
   git merge-base --is-ancestor "$TRUSTED_BASE_SHA" "$main_sha" || \
     die "trusted release base is not reachable from the current protected main revision"
   release_parent="$(git rev-parse --verify "$event_sha^1" 2>/dev/null)" || \

--- a/.github/scripts/verify-privileged-ref.sh
+++ b/.github/scripts/verify-privileged-ref.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+# Fail-closed guard for workflows that can publish artifacts, write repository
+# state, or read environment secrets. The workflow must still use a job-level
+# `if` with github.ref_protected so an untrusted ref never gets a runner.
+
+set -euo pipefail
+
+readonly HEX_SHA_RE='^[0-9a-fA-F]{40}$'
+readonly REF_NAME_RE='^refs/(heads/main|tags/v[0-9]+\.[0-9]+\.[0-9]+)$'
+
+die() {
+  echo "trusted-ref: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ -n "$value" ]] || die "$name is required"
+}
+
+require_sha_value() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" =~ $HEX_SHA_RE ]] || die "$name must be a 40-character commit SHA"
+}
+
+require_sha() {
+  local name="$1"
+  require_sha_value "$name" "${!name:-}"
+}
+
+require_safe_path() {
+  local path="$1"
+  [[ "$path" != /* && "$path" != *..* && "$path" != *$'\n'* ]] || die "unsafe workflow path"
+}
+
+require_value GITHUB_REPOSITORY
+require_value GITHUB_REF
+require_value GITHUB_REF_TYPE
+require_value GITHUB_SHA
+require_value GITHUB_WORKFLOW_REF
+require_value GITHUB_WORKFLOW_SHA
+require_value GITHUB_EVENT_NAME
+require_value GITHUB_REF_PROTECTED
+require_value TRUSTED_WORKFLOW_PATH
+require_value TRUSTED_REF_KIND
+require_value TRUSTED_BASE_SHA
+require_value TRUSTED_SOURCE_SHA
+
+[[ "$GITHUB_REPOSITORY" == "${TRUSTED_REPOSITORY:-manaflow-ai/manaflow}" ]] || \
+  die "unexpected repository: $GITHUB_REPOSITORY"
+[[ "$GITHUB_REF_PROTECTED" == "true" ]] || \
+  die "ref is not protected; refusing privileged workflow"
+[[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "schedule" || \
+  "$GITHUB_EVENT_NAME" == "workflow_call" ]] || \
+  die "event $GITHUB_EVENT_NAME is not allowed"
+
+require_safe_path "$TRUSTED_WORKFLOW_PATH"
+require_sha GITHUB_SHA
+require_sha GITHUB_WORKFLOW_SHA
+require_sha TRUSTED_BASE_SHA
+require_sha TRUSTED_SOURCE_SHA
+
+# A reusable workflow inherits the caller's github context. The caller's ref
+# and SHA are therefore separate from the release ref and SHA checked out by
+# the called workflow. Normal workflows leave these overrides unset.
+event_ref="${TRUSTED_EVENT_REF:-$GITHUB_REF}"
+event_ref_type="${TRUSTED_EVENT_REF_TYPE:-$GITHUB_REF_TYPE}"
+event_sha="${TRUSTED_EVENT_SHA:-$GITHUB_SHA}"
+caller_ref="${TRUSTED_CALLER_REF:-$GITHUB_REF}"
+workflow_ref="${TRUSTED_WORKFLOW_REF:-$GITHUB_WORKFLOW_REF}"
+workflow_sha="${TRUSTED_WORKFLOW_SHA:-$GITHUB_WORKFLOW_SHA}"
+ref_protected="${TRUSTED_REF_PROTECTED:-$GITHUB_REF_PROTECTED}"
+called_workflow_path="${TRUSTED_CALLED_WORKFLOW_PATH:-$TRUSTED_WORKFLOW_PATH}"
+
+[[ -n "$event_ref" && -n "$event_ref_type" && -n "$event_sha" &&
+  -n "$caller_ref" && -n "$workflow_ref" && -n "$workflow_sha" &&
+  -n "$ref_protected" ]] || die "trusted event context is incomplete"
+require_sha_value TRUSTED_EVENT_SHA "$event_sha"
+require_sha_value TRUSTED_WORKFLOW_SHA "$workflow_sha"
+[[ "$ref_protected" == "true" ]] || \
+  die "ref is not protected; refusing privileged workflow"
+[[ "$TRUSTED_SOURCE_SHA" == "$event_sha" ]] || \
+  die "trusted source SHA does not match the triggering revision"
+require_safe_path "$called_workflow_path"
+
+workflow_ref_prefix="${GITHUB_REPOSITORY}/${TRUSTED_WORKFLOW_PATH}@"
+[[ "$workflow_ref" == "$workflow_ref_prefix"* ]] || \
+  die "workflow ref does not identify the expected workflow"
+workflow_ref_suffix="${workflow_ref#"$workflow_ref_prefix"}"
+[[ "$workflow_ref_suffix" == "$caller_ref" ]] || \
+  die "workflow ref does not identify the caller ref"
+
+case "$TRUSTED_REF_KIND" in
+  main)
+    [[ "$event_ref" == "refs/heads/main" && "$event_ref_type" == "branch" ]] || \
+      die "main policy requires refs/heads/main"
+    [[ "$TRUSTED_BASE_SHA" == "$event_sha" ]] || \
+      die "main policy requires the source SHA as its base"
+    ;;
+  tag)
+    [[ "$event_ref_type" == "tag" && "$event_ref" =~ $REF_NAME_RE &&
+      "$event_ref" == refs/tags/* ]] || \
+      die "tag policy requires a protected vX.Y.Z tag"
+    [[ "$TRUSTED_BASE_SHA" == "$event_sha" ]] || \
+      die "tag policy requires the source SHA as its base"
+    ;;
+  release-branch)
+    [[ "$event_ref_type" == "branch" && "$event_ref" =~ ^refs/heads/release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+      die "release policy requires a release/vX.Y.Z branch"
+    [[ "$TRUSTED_WORKFLOW_PATH" == ".github/workflows/release-pr.yml" &&
+      "$caller_ref" == "refs/heads/main" ]] || \
+      die "release policy requires the protected release-pr caller"
+    ;;
+  *)
+    die "unknown ref policy: $TRUSTED_REF_KIND"
+    ;;
+esac
+
+# A checkout step must run before this script. It is deliberately checked
+# against the event SHA, rather than trusting the branch name or a mutable
+# checkout ref.
+checked_out_sha="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || \
+  die "the checkout is not a commit"
+[[ "$checked_out_sha" == "$event_sha" ]] || \
+  die "checked out $checked_out_sha, expected $event_sha"
+git cat-file -e "$TRUSTED_BASE_SHA^{commit}" 2>/dev/null || \
+  die "trusted base is not available locally"
+git merge-base --is-ancestor "$TRUSTED_BASE_SHA" "$event_sha" || \
+  die "checked out revision is not based on the trusted base SHA"
+
+git cat-file -e "$workflow_sha:$TRUSTED_WORKFLOW_PATH" 2>/dev/null || \
+  die "workflow file is missing from workflow SHA"
+git cat-file -e "HEAD:$TRUSTED_WORKFLOW_PATH" 2>/dev/null || \
+  die "workflow file is missing from checked-out revision"
+
+workflow_blob="$(git rev-parse "$workflow_sha:$TRUSTED_WORKFLOW_PATH")" || \
+  die "cannot resolve workflow blob at workflow SHA"
+head_blob="$(git rev-parse "HEAD:$TRUSTED_WORKFLOW_PATH")" || \
+  die "cannot resolve workflow blob at checked-out revision"
+[[ "$workflow_blob" == "$head_blob" ]] || \
+  die "workflow file changed after the trusted workflow revision"
+
+if [[ "$called_workflow_path" != "$TRUSTED_WORKFLOW_PATH" ]]; then
+  git cat-file -e "$workflow_sha:$called_workflow_path" 2>/dev/null || \
+    die "called workflow file is missing from workflow SHA"
+  git cat-file -e "HEAD:$called_workflow_path" 2>/dev/null || \
+    die "called workflow file is missing from checked-out revision"
+  called_workflow_blob="$(git rev-parse "$workflow_sha:$called_workflow_path")" || \
+    die "cannot resolve called workflow blob at workflow SHA"
+  head_called_workflow_blob="$(git rev-parse "HEAD:$called_workflow_path")" || \
+    die "cannot resolve called workflow blob at checked-out revision"
+  [[ "$called_workflow_blob" == "$head_called_workflow_blob" ]] || \
+    die "called workflow file changed after the trusted workflow revision"
+fi
+
+git merge-base --is-ancestor "$workflow_sha" "$event_sha" || \
+  die "workflow SHA is not an ancestor of the checked-out revision"
+
+# Confirm that the remote ref still resolves to this exact commit. This closes
+# the dispatch race where a mutable branch or tag moves after GitHub creates a
+# run but before the privileged job starts. For annotated tags, accept the
+# peeled commit object as well as the direct ref object.
+remote_ref_output="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin "$event_ref" "$event_ref^{}" 2>/dev/null)" || \
+  die "unable to resolve remote ref"
+remote_ref_lines="$(printf '%s\n' "$remote_ref_output" | awk 'NF == 2 { count += 1 } END { print count + 0 }')"
+(( remote_ref_lines > 0 && remote_ref_lines <= 2 )) || \
+  die "remote ref response is missing or unexpectedly large"
+if ! printf '%s\n' "$remote_ref_output" | awk -v expected="$event_sha" '
+  NF == 2 && $1 == expected { found = 1 }
+  END { exit(found ? 0 : 1) }
+'; then
+  die "remote ref does not resolve to $event_sha"
+fi
+
+if [[ "$TRUSTED_REF_KIND" == "tag" ]]; then
+  # A protected release tag must point at a commit already reachable from
+  # protected main. This rejects a newly-created tag carrying an unrelated
+  # history, even when the tag itself is covered by a ruleset.
+  main_ref_output="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin refs/heads/main 2>/dev/null)" || \
+    die "unable to resolve protected main"
+  main_sha="$(printf '%s\n' "$main_ref_output" | awk 'NF == 2 && $2 == "refs/heads/main" { print $1; exit }')"
+  [[ "$main_sha" =~ $HEX_SHA_RE ]] || die "protected main did not resolve to a commit"
+  git merge-base --is-ancestor "$event_sha" "$main_sha" || \
+    die "tag revision is not reachable from protected main"
+fi
+
+if [[ "$TRUSTED_REF_KIND" == "release-branch" ]]; then
+  # Generated release branches must carry the base SHA captured by the
+  # trusted release-pr workflow. The value is passed only through the
+  # reusable-workflow call, so a user cannot select an old branch. Main may
+  # advance while a long build runs, but it must retain the captured base.
+  git cat-file -e "$TRUSTED_BASE_SHA^{commit}" 2>/dev/null || \
+    die "trusted release base is not available locally"
+  main_ref_output="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin refs/heads/main 2>/dev/null)" || \
+    die "unable to resolve protected main"
+  main_sha="$(printf '%s\n' "$main_ref_output" | awk 'NF == 2 && $2 == "refs/heads/main" { print $1; exit }')"
+  [[ "$main_sha" =~ $HEX_SHA_RE ]] || die "protected main did not resolve to a commit"
+  git merge-base --is-ancestor "$TRUSTED_BASE_SHA" "$main_sha" || \
+    die "trusted release base is not reachable from the current protected main revision"
+  release_parent="$(git rev-parse --verify "$event_sha^1" 2>/dev/null)" || \
+    die "release branch tip has no parent"
+  [[ "$release_parent" == "$TRUSTED_BASE_SHA" ]] || \
+    die "release branch tip does not match the trusted base SHA"
+  parent_count="$(git rev-list --parents -n 1 "$event_sha" | awk '{ print NF - 1 }')"
+  [[ "$parent_count" == "1" ]] || \
+    die "release branch tip must be a single-parent commit"
+
+  release_version="${event_ref#refs/heads/release/v}"
+  release_subject="$(git log -1 --format=%s "$event_sha")"
+  [[ "$release_subject" == "chore: release v$release_version" ]] || \
+    die "release branch commit has an unexpected subject"
+  [[ "$(git log -1 --format=%an "$event_sha")" == "github-actions[bot]" ]] || \
+    die "release branch commit author is not the Actions bot"
+  [[ "$(git log -1 --format=%ae "$event_sha")" == "github-actions[bot]@users.noreply.github.com" ]] || \
+    die "release branch commit author email is not the Actions bot"
+  [[ "$(git log -1 --format=%cn "$event_sha")" == "github-actions[bot]" ]] || \
+    die "release branch commit committer is not the Actions bot"
+  [[ "$(git log -1 --format=%ce "$event_sha")" == "github-actions[bot]@users.noreply.github.com" ]] || \
+    die "release branch commit committer email is not the Actions bot"
+
+  changed_files="$(git diff-tree --no-commit-id --name-only -r "$event_sha")"
+  [[ "$changed_files" == "apps/client/package.json" ]] || \
+    die "release branch commit changes files outside the version manifest"
+fi
+
+echo "trusted-ref: verified $GITHUB_REPOSITORY $event_ref at $event_sha"

--- a/.github/scripts/verify-privileged-ref.sh
+++ b/.github/scripts/verify-privileged-ref.sh
@@ -126,11 +126,21 @@ checked_out_sha="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || \
   die "the checkout is not a commit"
 [[ "$checked_out_sha" == "$event_sha" ]] || \
   die "checked out $checked_out_sha, expected $event_sha"
+if ! git cat-file -e "$TRUSTED_BASE_SHA^{commit}" 2>/dev/null; then
+  GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$TRUSTED_BASE_SHA" >/dev/null 2>&1 || \
+    die "unable to fetch trusted base commit"
+fi
 git cat-file -e "$TRUSTED_BASE_SHA^{commit}" 2>/dev/null || \
   die "trusted base is not available locally"
 git merge-base --is-ancestor "$TRUSTED_BASE_SHA" "$event_sha" || \
   die "checked out revision is not based on the trusted base SHA"
 
+if ! git cat-file -e "$workflow_sha^{commit}" 2>/dev/null; then
+  GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$workflow_sha" >/dev/null 2>&1 || \
+    die "unable to fetch trusted workflow commit"
+fi
+git cat-file -e "$workflow_sha^{commit}" 2>/dev/null || \
+  die "trusted workflow commit is not available locally"
 git cat-file -e "$workflow_sha:$TRUSTED_WORKFLOW_PATH" 2>/dev/null || \
   die "workflow file is missing from workflow SHA"
 git cat-file -e "HEAD:$TRUSTED_WORKFLOW_PATH" 2>/dev/null || \
@@ -156,8 +166,13 @@ if [[ "$called_workflow_path" != "$TRUSTED_WORKFLOW_PATH" ]]; then
     die "called workflow file changed after the trusted workflow revision"
 fi
 
-git merge-base --is-ancestor "$workflow_sha" "$event_sha" || \
-  die "workflow SHA is not an ancestor of the checked-out revision"
+if [[ "$TRUSTED_REF_KIND" == "release-branch" ]]; then
+  git merge-base --is-ancestor "$TRUSTED_BASE_SHA" "$workflow_sha" || \
+    die "workflow SHA is not based on the trusted release base"
+else
+  git merge-base --is-ancestor "$workflow_sha" "$event_sha" || \
+    die "workflow SHA is not an ancestor of the checked-out revision"
+fi
 
 # Confirm that the remote ref still resolves to this exact commit. This closes
 # the dispatch race where a mutable branch or tag moves after GitHub creates a
@@ -189,6 +204,8 @@ if [[ "$TRUSTED_REF_KIND" == "tag" ]]; then
   fi
   git cat-file -e "$main_sha^{commit}" 2>/dev/null || \
     die "protected main commit is not available locally"
+  git merge-base --is-ancestor "$workflow_sha" "$main_sha" || \
+    die "trusted workflow SHA is not reachable from protected main"
   git merge-base --is-ancestor "$event_sha" "$main_sha" || \
     die "tag revision is not reachable from protected main"
 fi
@@ -210,6 +227,8 @@ if [[ "$TRUSTED_REF_KIND" == "release-branch" ]]; then
   fi
   git cat-file -e "$main_sha^{commit}" 2>/dev/null || \
     die "protected main commit is not available locally"
+  git merge-base --is-ancestor "$workflow_sha" "$main_sha" || \
+    die "trusted workflow SHA is not reachable from protected main"
   git merge-base --is-ancestor "$TRUSTED_BASE_SHA" "$main_sha" || \
     die "trusted release base is not reachable from the current protected main revision"
   release_parent="$(git rev-parse --verify "$event_sha^1" 2>/dev/null)" || \

--- a/.github/scripts/verify-privileged-ref.sh
+++ b/.github/scripts/verify-privileged-ref.sh
@@ -183,11 +183,26 @@ remote_ref_output="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin "$event_ref" "$e
 remote_ref_lines="$(printf '%s\n' "$remote_ref_output" | awk 'NF == 2 { count += 1 } END { print count + 0 }')"
 (( remote_ref_lines > 0 && remote_ref_lines <= 2 )) || \
   die "remote ref response is missing or unexpectedly large"
-if ! printf '%s\n' "$remote_ref_output" | awk -v expected="$event_sha" '
-  NF == 2 && $1 == expected { found = 1 }
-  END { exit(found ? 0 : 1) }
-'; then
-  die "remote ref does not resolve to $event_sha"
+remote_ref_sha="$(printf '%s\n' "$remote_ref_output" | awk -v ref="$event_ref" '
+  NF == 2 && $2 == ref { print $1; exit }
+')"
+[[ "$remote_ref_sha" =~ $HEX_SHA_RE ]] || die "remote ref did not resolve to a commit"
+if [[ "$TRUSTED_REF_KIND" == "main" ]]; then
+  if ! git cat-file -e "$remote_ref_sha^{commit}" 2>/dev/null; then
+    GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$remote_ref_sha" >/dev/null 2>&1 || \
+      die "unable to fetch current protected main commit"
+  fi
+  git cat-file -e "$remote_ref_sha^{commit}" 2>/dev/null || \
+    die "current protected main commit is not available locally"
+  git merge-base --is-ancestor "$event_sha" "$remote_ref_sha" || \
+    die "triggering main revision is not reachable from protected main"
+else
+  if ! printf '%s\n' "$remote_ref_output" | awk -v expected="$event_sha" '
+    NF == 2 && $1 == expected { found = 1 }
+    END { exit(found ? 0 : 1) }
+  '; then
+    die "remote ref does not resolve to $event_sha"
+  fi
 fi
 
 if [[ "$TRUSTED_REF_KIND" == "tag" ]]; then
@@ -204,6 +219,8 @@ if [[ "$TRUSTED_REF_KIND" == "tag" ]]; then
   fi
   git cat-file -e "$main_sha^{commit}" 2>/dev/null || \
     die "protected main commit is not available locally"
+  [[ "$workflow_sha" == "$main_sha" ]] || \
+    die "tag workflow is not the current protected workflow revision"
   git merge-base --is-ancestor "$workflow_sha" "$main_sha" || \
     die "trusted workflow SHA is not reachable from protected main"
   git merge-base --is-ancestor "$event_sha" "$main_sha" || \
@@ -255,6 +272,16 @@ if [[ "$TRUSTED_REF_KIND" == "release-branch" ]]; then
   changed_files="$(git diff-tree --no-commit-id --name-only -r "$event_sha")"
   [[ "$changed_files" == "apps/client/package.json" ]] || \
     die "release branch commit changes files outside the version manifest"
+
+  release_tag_ref="refs/tags/v$release_version"
+  release_tag_output="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin "$release_tag_ref" "$release_tag_ref^{}" 2>/dev/null)" || \
+    die "unable to resolve immutable release tag"
+  if ! printf '%s\n' "$release_tag_output" | awk -v expected="$event_sha" '
+    NF == 2 && $1 == expected { found = 1 }
+    END { exit(found ? 0 : 1) }
+  '; then
+    die "release branch is not bound to its immutable release tag"
+  fi
 fi
 
 echo "trusted-ref: verified $GITHUB_REPOSITORY $event_ref at $event_sha"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,10 @@ on:
       - crates/**
       # Shell scripts
       - prompt-wrapper.sh
-  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -41,11 +44,9 @@ env:
 jobs:
   docker-build:
     name: Build Docker image (${{ matrix.platform }})
-    # The build pushes to Docker Hub with repository credentials. A manual
-    # dispatch must use the protected main ref, never arbitrary branch code.
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # The build pushes to Docker Hub with repository credentials. It runs only
+    # from a protected main push, never from a user-selected ref.
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -59,6 +60,23 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify trusted publication ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/docker.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
+
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -69,12 +87,6 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
-
-      - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.6.0
@@ -129,14 +141,29 @@ jobs:
 
   docker-merge:
     name: Create multi-arch manifest
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: ubuntu-24.04
     needs: docker-build
     permissions:
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify trusted publication ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/docker.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
+
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/host-screenshot-collector.yml
+++ b/.github/workflows/host-screenshot-collector.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - packages/host-screenshot-collector/**
       - .github/workflows/host-screenshot-collector.yml
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,9 +20,9 @@ env:
 jobs:
   build-and-sync:
     name: Build and Sync to Convex
-    # This job publishes to Convex with the electron environment secret. A
-    # manual run must use the protected main revision, never branch code.
-    if: github.ref == 'refs/heads/main'
+    # This job publishes to Convex with the electron environment secret. It
+    # runs only from a protected main push, never from a user-selected ref.
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: ubuntu-latest
     environment: electron
     steps:
@@ -31,7 +30,18 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify trusted publication ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/host-screenshot-collector.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/morph-snapshot.yml
+++ b/.github/workflows/morph-snapshot.yml
@@ -3,7 +3,6 @@ name: Daily Morph Snapshot
 on:
   schedule:
     - cron: "0 18 * * *" # 10am PST / 11am PDT
-  workflow_dispatch:
 
 concurrency:
   group: morph-snapshot
@@ -21,8 +20,8 @@ jobs:
   morph-snapshot:
     name: Build Morph Snapshot
     # This job has write permissions and a Morph API credential. Always run
-    # the checked-in main revision, including for a manual dispatch.
-    if: github.ref == 'refs/heads/main'
+    # the checked-in main revision.
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: ubuntu-latest
     environment: dev
     permissions:
@@ -33,7 +32,18 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify trusted publication ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/morph-snapshot.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/privileged-workflow-contract.yml
+++ b/.github/workflows/privileged-workflow-contract.yml
@@ -1,0 +1,52 @@
+name: Privileged Workflow Contract
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/verify-privileged-ref.sh
+      - .github/workflows/docker.yml
+      - .github/workflows/sandbox.yml
+      - .github/workflows/morph-snapshot.yml
+      - .github/workflows/host-screenshot-collector.yml
+      - .github/workflows/release-pr.yml
+      - .github/workflows/release-updates.yml
+      - scripts/ci/test-verify-privileged-ref.sh
+      - scripts/ci/test-privileged-workflow-gates.rb
+      - .github/workflows/privileged-workflow-contract.yml
+      - docs/release-workflow.md
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/verify-privileged-ref.sh
+      - .github/workflows/docker.yml
+      - .github/workflows/sandbox.yml
+      - .github/workflows/morph-snapshot.yml
+      - .github/workflows/host-screenshot-collector.yml
+      - .github/workflows/release-pr.yml
+      - .github/workflows/release-updates.yml
+      - scripts/ci/test-verify-privileged-ref.sh
+      - scripts/ci/test-privileged-workflow-gates.rb
+      - .github/workflows/privileged-workflow-contract.yml
+      - docs/release-workflow.md
+
+concurrency:
+  group: privileged-workflow-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify privileged workflow gates
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
+      - name: Verify workflow contracts
+        run: |
+          set -euo pipefail
+          ruby scripts/ci/test-privileged-workflow-gates.rb
+          scripts/ci/test-verify-privileged-ref.sh

--- a/.github/workflows/privileged-workflow-contract.yml
+++ b/.github/workflows/privileged-workflow-contract.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/release-updates.yml
       - scripts/ci/test-verify-privileged-ref.sh
       - scripts/ci/test-privileged-workflow-gates.rb
+      - scripts/release-pr.ts
       - .github/workflows/privileged-workflow-contract.yml
       - docs/release-workflow.md
   push:
@@ -26,6 +27,7 @@ on:
       - .github/workflows/release-updates.yml
       - scripts/ci/test-verify-privileged-ref.sh
       - scripts/ci/test-privileged-workflow-gates.rb
+      - scripts/release-pr.ts
       - .github/workflows/privileged-workflow-contract.yml
       - docs/release-workflow.md
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -129,12 +129,6 @@ jobs:
         if: steps.release_changes.outputs.proceed == 'true'
         run: bun install --frozen-lockfile
 
-      - name: Configure git user
-        if: steps.release_changes.outputs.proceed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Create draft release PR
         id: create_release_pr
         if: steps.release_changes.outputs.proceed == 'true'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "30 12 * * *" # 4:30 AM PT
     - cron: "0 3 * * *" # 7:00 PM PT
-  workflow_dispatch:
 
 concurrency:
   group: release-pr
@@ -20,15 +19,18 @@ env:
 jobs:
   open-release-pr:
     name: Open draft release PR
-    # The job creates a branch and dispatches a publishing workflow. Restrict
-    # manual runs to the protected main revision so a caller cannot execute a
-    # modified branch with write-capable credentials.
-    if: github.ref == 'refs/heads/main'
+    # The scheduled job creates a branch and calls the publishing workflow.
+    # There is no user-selectable secret-bearing dispatch path.
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: ubuntu-latest
     permissions:
       contents: write # Create the generated release branch.
       pull-requests: write # Create the draft release pull request.
-      actions: write # Dispatch the signed electron build workflow.
+    outputs:
+      release_pr_state: ${{ steps.create_release_pr.outputs.release_pr_state }}
+      release_branch: ${{ steps.create_release_pr.outputs.release_branch }}
+      release_sha: ${{ steps.release_revision.outputs.release_sha }}
+      release_base_sha: ${{ steps.release_revision.outputs.base_sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
@@ -39,6 +41,16 @@ jobs:
           fetch-tags: true
           # release-pr.ts supplies a transient auth header for git pushes.
           persist-credentials: false
+
+      - name: Verify trusted release ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/release-pr.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
 
       - name: Verify main revision
         env:
@@ -55,7 +67,10 @@ jobs:
       - name: Check for changes since last release
         id: release_changes
         run: |
-          last_tag=$(git describe --tags --match "v[0-9]*" --abbrev=0 2>/dev/null || echo "")
+          # Tags point at the immutable generated release commit. That commit
+          # may not be reachable from main when the PR is squash-merged, so
+          # do not use git describe's ancestry-only lookup here.
+          last_tag=$(git tag --list "v[0-9]*" --sort=-version:refname | head -n1)
 
           if [ -z "$last_tag" ]; then
             echo "No release tags found. Proceeding with release." >> "$GITHUB_STEP_SUMMARY"
@@ -101,28 +116,47 @@ jobs:
           RELEASE_BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: bun ./scripts/release-pr.ts
 
-      - name: Trigger electron build workflow
+      - name: Capture release revision
+        id: release_revision
         if: steps.release_changes.outputs.proceed == 'true' && steps.create_release_pr.outputs.release_pr_state == 'created'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         env:
+          BASE_SHA: ${{ github.sha }}
           RELEASE_BRANCH: ${{ steps.create_release_pr.outputs.release_branch }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const branch = process.env.RELEASE_BRANCH;
-            if (!branch) {
-              core.setFailed('Release branch output missing; cannot dispatch electron build workflow.');
-              return;
-            }
-            const workflowId = 'release-updates.yml';
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: workflowId,
-              ref: branch,
-            });
-            core.info(`Triggered ${workflowId} on ${branch}`);
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "Unexpected release branch: $RELEASE_BRANCH" >&2
+            exit 1
+          }
+          git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH" || {
+            echo "Generated release branch is not present in the checkout" >&2
+            exit 1
+          }
+          release_sha="$(git rev-parse --verify "refs/heads/$RELEASE_BRANCH^{commit}")"
+          base_sha="$BASE_SHA"
+          git cat-file -e "$base_sha^{commit}"
+          parent_sha="$(git rev-parse --verify "$release_sha^1")"
+          [[ "$parent_sha" == "$base_sha" ]] || {
+            echo "Release branch is not based on the checked-out main revision" >&2
+            exit 1
+          }
+          printf 'release_sha=%s\n' "$release_sha" >> "$GITHUB_OUTPUT"
+          printf 'base_sha=%s\n' "$base_sha" >> "$GITHUB_OUTPUT"
 
       - name: Skip release (no changes)
         if: steps.release_changes.outputs.proceed == 'false'
         run: echo "Skipping release because no changes were detected since the last tag."
+
+  build-release:
+    name: Build generated release
+    needs: open-release-pr
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true && needs.open-release-pr.outputs.release_pr_state == 'created'
+    permissions:
+      contents: write # Let the called workflow create and update the release.
+    uses: ./.github/workflows/release-updates.yml
+    with:
+      release_ref: ${{ needs.open-release-pr.outputs.release_branch }}
+      release_sha: ${{ needs.open-release-pr.outputs.release_sha }}
+      release_base_sha: ${{ needs.open-release-pr.outputs.release_base_sha }}
+      caller_sha: ${{ github.sha }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -28,6 +28,7 @@ jobs:
       pull-requests: write # Create the draft release pull request.
     outputs:
       release_pr_state: ${{ steps.create_release_pr.outputs.release_pr_state }}
+      release_pr_draft: ${{ steps.create_release_pr.outputs.release_pr_draft }}
       release_branch: ${{ steps.create_release_pr.outputs.release_branch }}
       release_sha: ${{ steps.release_revision.outputs.release_sha }}
       release_base_sha: ${{ steps.release_revision.outputs.base_sha }}
@@ -122,7 +123,11 @@ jobs:
 
       - name: Capture release revision
         id: release_revision
-        if: steps.release_changes.outputs.proceed == 'true' && steps.create_release_pr.outputs.release_pr_state == 'created'
+        if: >-
+          steps.release_changes.outputs.proceed == 'true' &&
+          (steps.create_release_pr.outputs.release_pr_state == 'created' ||
+          (steps.create_release_pr.outputs.release_pr_state == 'existing' &&
+          steps.create_release_pr.outputs.release_pr_draft == 'true'))
         env:
           BASE_SHA: ${{ github.sha }}
           RELEASE_BRANCH: ${{ steps.create_release_pr.outputs.release_branch }}
@@ -138,15 +143,14 @@ jobs:
             exit 1
           }
           release_sha="$(git rev-parse --verify "refs/heads/$RELEASE_BRANCH^{commit}")"
-          base_sha="$BASE_SHA"
-          git cat-file -e "$base_sha^{commit}"
           parent_sha="$(git rev-parse --verify "$release_sha^1")"
-          [[ "$parent_sha" == "$base_sha" ]] || {
-            echo "Release branch is not based on the checked-out main revision" >&2
+          git cat-file -e "$BASE_SHA^{commit}"
+          git merge-base --is-ancestor "$parent_sha" "$BASE_SHA" || {
+            echo "Release branch base is not reachable from the checked-out main revision" >&2
             exit 1
           }
           printf 'release_sha=%s\n' "$release_sha" >> "$GITHUB_OUTPUT"
-          printf 'base_sha=%s\n' "$base_sha" >> "$GITHUB_OUTPUT"
+          printf 'base_sha=%s\n' "$parent_sha" >> "$GITHUB_OUTPUT"
 
       - name: Skip release (no changes)
         if: steps.release_changes.outputs.proceed == 'false'
@@ -155,7 +159,11 @@ jobs:
   build-release:
     name: Build generated release
     needs: open-release-pr
-    if: github.ref == 'refs/heads/main' && github.ref_protected == true && needs.open-release-pr.outputs.release_pr_state == 'created'
+    if: >-
+      github.ref == 'refs/heads/main' && github.ref_protected == true &&
+      (needs.open-release-pr.outputs.release_pr_state == 'created' ||
+      (needs.open-release-pr.outputs.release_pr_state == 'existing' &&
+      needs.open-release-pr.outputs.release_pr_draft == 'true'))
     permissions:
       contents: write # Let the called workflow create and update the release.
     uses: ./.github/workflows/release-updates.yml

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,7 +37,9 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           # Keep a local branch because release-pr.ts creates a child branch.
-          ref: refs/heads/main
+          # Pin the generated branch to the scheduled revision. The trust gate
+          # separately permits a protected-main fast-forward while this runs.
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
           # release-pr.ts supplies a transient auth header for git pushes.
@@ -60,10 +62,30 @@ jobs:
           set -euo pipefail
           actual_sha="$(git rev-parse HEAD)"
           if [[ "$actual_sha" != "$EXPECTED_SHA" ]]; then
-            echo "main advanced while the workflow was starting" >&2
+            echo "checked out revision does not match the scheduled source" >&2
             echo "expected $EXPECTED_SHA, checked out $actual_sha" >&2
             exit 1
           fi
+          main_sha="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin refs/heads/main | awk '
+            NF == 2 && $2 == "refs/heads/main" { print $1; exit }
+          ')"
+          if [[ ! "$main_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "protected main did not resolve to a commit" >&2
+            exit 1
+          fi
+          if ! git cat-file -e "$main_sha^{commit}" 2>/dev/null; then
+            GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$main_sha" >/dev/null 2>&1 || {
+              echo "unable to fetch the current protected main commit" >&2
+              exit 1
+            }
+          fi
+          git merge-base --is-ancestor "$EXPECTED_SHA" "$main_sha" || {
+            echo "scheduled source is not reachable from the current protected main" >&2
+            exit 1
+          }
+
+      - name: Create local release base branch
+        run: git switch --create "release-run-${GITHUB_RUN_ID}"
 
       - name: Fetch version tags
         shell: bash
@@ -151,6 +173,74 @@ jobs:
           }
           printf 'release_sha=%s\n' "$release_sha" >> "$GITHUB_OUTPUT"
           printf 'base_sha=%s\n' "$parent_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Bind immutable release tag
+        id: release_tag
+        if: >-
+          steps.release_changes.outputs.proceed == 'true' &&
+          (steps.create_release_pr.outputs.release_pr_state == 'created' ||
+          (steps.create_release_pr.outputs.release_pr_state == 'existing' &&
+          steps.create_release_pr.outputs.release_pr_draft == 'true'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PR_STATE: ${{ steps.create_release_pr.outputs.release_pr_state }}
+          RELEASE_BRANCH: ${{ steps.create_release_pr.outputs.release_branch }}
+          RELEASE_SHA: ${{ steps.release_revision.outputs.release_sha }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "Unexpected release branch: $RELEASE_BRANCH" >&2
+            exit 1
+          }
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "Unexpected release SHA" >&2
+            exit 1
+          }
+
+          release_tag="v${RELEASE_BRANCH#release/v}"
+          branch_sha="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin \
+            "refs/heads/$RELEASE_BRANCH" | awk -v ref="refs/heads/$RELEASE_BRANCH" '
+              NF == 2 && $2 == ref { print $1; exit }
+            ')"
+          [[ "$branch_sha" == "$RELEASE_SHA" ]] || {
+            echo "Release branch moved before immutable tag binding" >&2
+            echo "expected $RELEASE_SHA, found ${branch_sha:-<missing>}" >&2
+            exit 1
+          }
+
+          tag_refs="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin \
+            "refs/tags/$release_tag" "refs/tags/$release_tag^{}")"
+          if [[ -z "$tag_refs" ]]; then
+            if [[ "$RELEASE_PR_STATE" != "created" ]]; then
+              target_commitish="$(gh release view "$release_tag" --repo "$REPO" \
+                --json targetCommitish --jq '.targetCommitish // empty' 2>/dev/null || true)"
+              echo "Existing draft release targetCommitish: ${target_commitish:-<unavailable>}" >&2
+              echo "Existing draft release has no immutable tag; refusing an automatic retry" >&2
+              exit 1
+            fi
+
+            echo "Creating immutable tag $release_tag at $RELEASE_SHA"
+            if ! gh api --method POST "repos/$REPO/git/refs" \
+              -f "ref=refs/tags/$release_tag" \
+              -f "sha=$RELEASE_SHA" >/dev/null; then
+              echo "Tag creation raced; validating the existing tag" >&2
+            fi
+            tag_refs="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin \
+              "refs/tags/$release_tag" "refs/tags/$release_tag^{}")"
+          fi
+
+          printf '%s\n' "$tag_refs" | awk -v expected="$RELEASE_SHA" '
+            NF == 2 && $1 == expected { found = 1 }
+            END {
+              if (!found) {
+                print "Immutable release tag does not point at the generated release commit" > "/dev/stderr"
+                exit 1
+              }
+            }
+          '
+          printf 'tag=%s\n' "$release_tag" >> "$GITHUB_OUTPUT"
 
       - name: Skip release (no changes)
         if: steps.release_changes.outputs.proceed == 'false'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,6 +64,10 @@ jobs:
             exit 1
           fi
 
+      - name: Fetch version tags
+        shell: bash
+        run: git fetch --force --tags origin
+
       - name: Check for changes since last release
         id: release_changes
         run: |

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -43,8 +43,7 @@ jobs:
       startsWith(inputs.release_ref, 'release/v') &&
       inputs.release_sha != '' &&
       inputs.release_base_sha != '' &&
-      inputs.caller_sha == github.sha &&
-      inputs.release_base_sha == inputs.caller_sha
+      inputs.caller_sha == github.sha
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.resolve.outputs.tag }}
@@ -78,6 +77,12 @@ jobs:
             echo "Caller SHA does not match the protected workflow SHA" >&2
             exit 1
           }
+          if ! git cat-file -e "$TRUSTED_WORKFLOW_SHA^{commit}" 2>/dev/null; then
+            GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$TRUSTED_WORKFLOW_SHA" >/dev/null 2>&1 || {
+              echo "Unable to fetch the protected caller commit" >&2
+              exit 1
+            }
+          fi
           trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
           git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
           chmod 700 "$trusted_gate"
@@ -289,8 +294,7 @@ jobs:
       startsWith(inputs.release_ref, 'release/v') &&
       inputs.release_sha != '' &&
       inputs.release_base_sha != '' &&
-      inputs.caller_sha == github.sha &&
-      inputs.release_base_sha == inputs.caller_sha
+      inputs.caller_sha == github.sha
     environment: electron
     permissions:
       # Required to upload signed artifacts to the GitHub release.
@@ -326,6 +330,12 @@ jobs:
             echo "Caller SHA does not match the protected workflow SHA" >&2
             exit 1
           }
+          if ! git cat-file -e "$TRUSTED_WORKFLOW_SHA^{commit}" 2>/dev/null; then
+            GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$TRUSTED_WORKFLOW_SHA" >/dev/null 2>&1 || {
+              echo "Unable to fetch the protected caller commit" >&2
+              exit 1
+            }
+          fi
           trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
           git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
           chmod 700 "$trusted_gate"
@@ -462,8 +472,7 @@ jobs:
       startsWith(inputs.release_ref, 'release/v') &&
       inputs.release_sha != '' &&
       inputs.release_base_sha != '' &&
-      inputs.caller_sha == github.sha &&
-      inputs.release_base_sha == inputs.caller_sha
+      inputs.caller_sha == github.sha
     environment: electron
     permissions:
       # Required to upload signed artifacts to the GitHub release.
@@ -500,6 +509,12 @@ jobs:
             echo "Caller SHA does not match the protected workflow SHA" >&2
             exit 1
           }
+          if ! git cat-file -e "$TRUSTED_WORKFLOW_SHA^{commit}" 2>/dev/null; then
+            GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$TRUSTED_WORKFLOW_SHA" >/dev/null 2>&1 || {
+              echo "Unable to fetch the protected caller commit" >&2
+              exit 1
+            }
+          fi
           trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
           git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
           chmod 700 "$trusted_gate"
@@ -781,8 +796,7 @@ jobs:
       startsWith(inputs.release_ref, 'release/v') &&
       inputs.release_sha != '' &&
       inputs.release_base_sha != '' &&
-      inputs.caller_sha == github.sha &&
-      inputs.release_base_sha == inputs.caller_sha
+      inputs.caller_sha == github.sha
     environment: electron
     permissions:
       # Required to publish the Windows artifact to the GitHub release.
@@ -818,6 +832,12 @@ jobs:
             echo "Caller SHA does not match the protected workflow SHA" >&2
             exit 1
           }
+          if ! git cat-file -e "$TRUSTED_WORKFLOW_SHA^{commit}" 2>/dev/null; then
+            GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$TRUSTED_WORKFLOW_SHA" >/dev/null 2>&1 || {
+              echo "Unable to fetch the protected caller commit" >&2
+              exit 1
+            }
+          fi
           trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
           git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
           chmod 700 "$trusted_gate"
@@ -885,8 +905,7 @@ jobs:
       startsWith(inputs.release_ref, 'release/v') &&
       inputs.release_sha != '' &&
       inputs.release_base_sha != '' &&
-      inputs.caller_sha == github.sha &&
-      inputs.release_base_sha == inputs.caller_sha
+      inputs.caller_sha == github.sha
     environment: electron
     permissions:
       # Required to publish the Linux artifact to the GitHub release.
@@ -919,6 +938,12 @@ jobs:
             echo "Caller SHA does not match the protected workflow SHA" >&2
             exit 1
           }
+          if ! git cat-file -e "$TRUSTED_WORKFLOW_SHA^{commit}" 2>/dev/null; then
+            GIT_TERMINAL_PROMPT=0 git fetch --no-tags origin "$TRUSTED_WORKFLOW_SHA" >/dev/null 2>&1 || {
+              echo "Unable to fetch the protected caller commit" >&2
+              exit 1
+            }
+          fi
           trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
           git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
           chmod 700 "$trusted_gate"

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -140,11 +140,18 @@ jobs:
           tag_refs="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin \
             "refs/tags/$resolved_tag" "refs/tags/$resolved_tag^{}")"
           if [[ -z "$tag_refs" ]]; then
-            if [[ "$release_exists" == true && \
-              ( "$release_is_draft" != true || "$release_target" != "$SOURCE_SHA" ) ]]; then
-              echo "Draft release $resolved_tag has no tag at the verified source SHA" >&2
-              exit 1
+            if [[ "$release_exists" == true ]]; then
+              echo "Release $resolved_tag has no immutable tag" >&2
+              if [[ "$release_is_draft" == true && "$release_target" == "$SOURCE_SHA" ]]; then
+                echo "Its draft targetCommitish matches the source, but an existing draft retry still requires a pre-bound tag" >&2
+              else
+                echo "Draft targetCommitish is not the verified source SHA" >&2
+              fi
+            else
+              echo "Release $resolved_tag is missing its immutable tag" >&2
             fi
+            echo "Refusing to publish without a tag bound before this workflow call" >&2
+            exit 1
           elif ! printf '%s\n' "$tag_refs" | awk -v expected="$SOURCE_SHA" '
             NF == 2 && $1 == expected { found = 1 }
             END { exit(found ? 0 : 1) }
@@ -157,7 +164,7 @@ jobs:
             echo "Creating draft release $resolved_tag"
             gh release create "$resolved_tag" \
               --repo "$repo" \
-              --target "$SOURCE_SHA" \
+              --verify-tag \
               --draft \
               --title "$resolved_tag" \
               --notes ""

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -2,13 +2,24 @@
 name: Build & Publish Electron Updates (GitHub Releases)
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - package.json
-      - apps/client/package.json
+  workflow_call:
+    inputs:
+      release_ref:
+        description: Exact generated release branch to build
+        required: true
+        type: string
+      release_sha:
+        description: Exact generated release-branch commit to build
+        required: true
+        type: string
+      release_base_sha:
+        description: Protected main commit used to create the release branch
+        required: true
+        type: string
+      caller_sha:
+        description: Protected main commit containing the caller and called workflows
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -23,77 +34,125 @@ env:
 jobs:
   prepare-release:
     name: Prepare Release
-    # Publishing uses repository write access and signing credentials. Permit
-    # only main, generated release branches, and version tags.
+    # Publishing uses repository write access and signing credentials. The
+    # protected release-pr workflow is the only permitted caller.
     if: >-
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/heads/release/v') ||
-      startsWith(github.ref, 'refs/tags/v')
+      github.ref_protected == true &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main' &&
+      startsWith(inputs.release_ref, 'release/v') &&
+      inputs.release_sha != '' &&
+      inputs.release_base_sha != '' &&
+      inputs.caller_sha == github.sha &&
+      inputs.release_base_sha == inputs.caller_sha
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.resolve.outputs.tag }}
     permissions:
       # Required to create the draft release record.
-      contents: write
+      contents: write # Create the draft release record for the verified commit.
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
           persist-credentials: false
+      - name: Verify trusted release ref
+        env:
+          TRUSTED_BASE_SHA: ${{ inputs.release_base_sha }}
+          TRUSTED_CALLED_WORKFLOW_PATH: .github/workflows/release-updates.yml
+          TRUSTED_CALLER_REF: ${{ github.ref }}
+          TRUSTED_EVENT_REF: ${{ format('refs/heads/{0}', inputs.release_ref) }}
+          TRUSTED_EVENT_REF_TYPE: branch
+          TRUSTED_EVENT_SHA: ${{ inputs.release_sha }}
+          TRUSTED_REF_KIND: release-branch
+          TRUSTED_REF_PROTECTED: ${{ github.ref_protected }}
+          TRUSTED_SOURCE_SHA: ${{ inputs.release_sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ inputs.caller_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/release-pr.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TRUSTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ && \
+            "$TRUSTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || {
+            echo "Caller SHA does not match the protected workflow SHA" >&2
+            exit 1
+          }
+          trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
+          git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
+          chmod 700 "$trusted_gate"
+          "$trusted_gate"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Resolve release tag
         id: resolve
         env:
-          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          RELEASE_REF: ${{ inputs.release_ref }}
+          SOURCE_SHA: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
 
-          release_tag="${EVENT_RELEASE_TAG:-}"
           repo="${GITHUB_REPOSITORY}"
 
           version="$(node -p "require('./apps/client/package.json').version")"
-          if [[ -z "$version" ]]; then
-            echo "Unable to determine app version from apps/client/package.json" >&2
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "App version is not an exact semantic version: $version" >&2
+            exit 1
+          fi
+          if [[ -n "$RELEASE_REF" && "$RELEASE_REF" != "release/v$version" ]]; then
+            echo "Release branch does not match app version: $RELEASE_REF" >&2
             exit 1
           fi
 
-          declare -a candidates
-          candidates=()
-
-          if [[ -n "$release_tag" ]]; then
-            candidates+=("$release_tag")
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            candidates+=("$GITHUB_REF_NAME")
+          resolved_tag="v$version"
+          release_json=""
+          if ! release_json="$(gh release view "$resolved_tag" --repo "$repo" \
+            --json isDraft,targetCommitish,tagName 2>&1)"; then
+            release_error="$release_json"
+            [[ "$release_error" == *"release not found"* ]] || {
+              echo "Unable to inspect release $resolved_tag: $release_error" >&2
+              exit 1
+            }
+            release_json=""
+          fi
+          release_exists=false
+          release_is_draft=false
+          release_target=""
+          if [[ -n "$release_json" ]]; then
+            release_exists=true
+            release_is_draft="$(jq -r '.isDraft // false' <<<"$release_json")"
+            release_target="$(jq -r '.targetCommitish // empty' <<<"$release_json")"
+            release_tag_name="$(jq -r '.tagName // empty' <<<"$release_json")"
+            [[ "$release_tag_name" == "$resolved_tag" ]] || {
+              echo "Release lookup returned an unexpected tag: $release_tag_name" >&2
+              exit 1
+            }
           fi
 
-          candidates+=("v$version" "$version")
-
-          resolved_tag=""
-          for tag in "${candidates[@]}"; do
-            if [[ -z "$tag" ]]; then
-              continue
-            fi
-            if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
-              resolved_tag="$tag"
-              break
-            fi
-          done
-
-          if [[ -z "$resolved_tag" ]]; then
-            resolved_tag="${candidates[0]}"
-            if [[ -z "$resolved_tag" ]]; then
-              echo "Unable to resolve a release tag candidate" >&2
+          tag_refs="$(GIT_TERMINAL_PROMPT=0 git ls-remote origin \
+            "refs/tags/$resolved_tag" "refs/tags/$resolved_tag^{}")"
+          if [[ -z "$tag_refs" ]]; then
+            if [[ "$release_exists" == true && \
+              ( "$release_is_draft" != true || "$release_target" != "$SOURCE_SHA" ) ]]; then
+              echo "Draft release $resolved_tag has no tag at the verified source SHA" >&2
               exit 1
             fi
+          elif ! printf '%s\n' "$tag_refs" | awk -v expected="$SOURCE_SHA" '
+            NF == 2 && $1 == expected { found = 1 }
+            END { exit(found ? 0 : 1) }
+          '; then
+            echo "Release tag $resolved_tag does not point at $SOURCE_SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$release_exists" == false ]]; then
             echo "Creating draft release $resolved_tag"
             gh release create "$resolved_tag" \
               --repo "$repo" \
+              --target "$SOURCE_SHA" \
               --draft \
               --title "$resolved_tag" \
               --notes ""
@@ -224,13 +283,18 @@ jobs:
     name: macOS arm64
     needs: prepare-release
     if: >-
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/heads/release/v') ||
-      startsWith(github.ref, 'refs/tags/v')
+      github.ref_protected == true &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main' &&
+      startsWith(inputs.release_ref, 'release/v') &&
+      inputs.release_sha != '' &&
+      inputs.release_base_sha != '' &&
+      inputs.caller_sha == github.sha &&
+      inputs.release_base_sha == inputs.caller_sha
     environment: electron
     permissions:
       # Required to upload signed artifacts to the GitHub release.
-      contents: write
+      contents: write # Upload signed macOS arm64 artifacts to the verified release.
     runs-on: self-hosted
     defaults:
       run:
@@ -238,8 +302,34 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
           persist-credentials: false
+      - name: Verify trusted release ref
+        env:
+          TRUSTED_BASE_SHA: ${{ inputs.release_base_sha }}
+          TRUSTED_CALLED_WORKFLOW_PATH: .github/workflows/release-updates.yml
+          TRUSTED_CALLER_REF: ${{ github.ref }}
+          TRUSTED_EVENT_REF: ${{ format('refs/heads/{0}', inputs.release_ref) }}
+          TRUSTED_EVENT_REF_TYPE: branch
+          TRUSTED_EVENT_SHA: ${{ inputs.release_sha }}
+          TRUSTED_REF_KIND: release-branch
+          TRUSTED_REF_PROTECTED: ${{ github.ref_protected }}
+          TRUSTED_SOURCE_SHA: ${{ inputs.release_sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ inputs.caller_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/release-pr.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TRUSTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ && \
+            "$TRUSTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || {
+            echo "Caller SHA does not match the protected workflow SHA" >&2
+            exit 1
+          }
+          trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
+          git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
+          chmod 700 "$trusted_gate"
+          "$trusted_gate"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -366,13 +456,18 @@ jobs:
     name: macOS universal
     needs: prepare-release
     if: >-
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/heads/release/v') ||
-      startsWith(github.ref, 'refs/tags/v')
+      github.ref_protected == true &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main' &&
+      startsWith(inputs.release_ref, 'release/v') &&
+      inputs.release_sha != '' &&
+      inputs.release_base_sha != '' &&
+      inputs.caller_sha == github.sha &&
+      inputs.release_base_sha == inputs.caller_sha
     environment: electron
     permissions:
       # Required to upload signed artifacts to the GitHub release.
-      contents: write
+      contents: write # Upload signed macOS universal artifacts to the verified release.
     runs-on: self-hosted
     defaults:
       run:
@@ -380,8 +475,35 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify trusted release ref
+        env:
+          TRUSTED_BASE_SHA: ${{ inputs.release_base_sha }}
+          TRUSTED_CALLED_WORKFLOW_PATH: .github/workflows/release-updates.yml
+          TRUSTED_CALLER_REF: ${{ github.ref }}
+          TRUSTED_EVENT_REF: ${{ format('refs/heads/{0}', inputs.release_ref) }}
+          TRUSTED_EVENT_REF_TYPE: branch
+          TRUSTED_EVENT_SHA: ${{ inputs.release_sha }}
+          TRUSTED_REF_KIND: release-branch
+          TRUSTED_REF_PROTECTED: ${{ github.ref_protected }}
+          TRUSTED_SOURCE_SHA: ${{ inputs.release_sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ inputs.caller_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/release-pr.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TRUSTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ && \
+            "$TRUSTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || {
+            echo "Caller SHA does not match the protected workflow SHA" >&2
+            exit 1
+          }
+          trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
+          git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
+          chmod 700 "$trusted_gate"
+          "$trusted_gate"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -653,13 +775,18 @@ jobs:
     name: Windows x64
     needs: prepare-release
     if: >-
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/heads/release/v') ||
-      startsWith(github.ref, 'refs/tags/v')
+      github.ref_protected == true &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main' &&
+      startsWith(inputs.release_ref, 'release/v') &&
+      inputs.release_sha != '' &&
+      inputs.release_base_sha != '' &&
+      inputs.caller_sha == github.sha &&
+      inputs.release_base_sha == inputs.caller_sha
     environment: electron
     permissions:
       # Required to publish the Windows artifact to the GitHub release.
-      contents: write
+      contents: write # Upload the signed Windows artifact to the verified release.
     runs-on: windows-latest
     defaults:
       run:
@@ -667,8 +794,34 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
           persist-credentials: false
+      - name: Verify trusted release ref
+        env:
+          TRUSTED_BASE_SHA: ${{ inputs.release_base_sha }}
+          TRUSTED_CALLED_WORKFLOW_PATH: .github/workflows/release-updates.yml
+          TRUSTED_CALLER_REF: ${{ github.ref }}
+          TRUSTED_EVENT_REF: ${{ format('refs/heads/{0}', inputs.release_ref) }}
+          TRUSTED_EVENT_REF_TYPE: branch
+          TRUSTED_EVENT_SHA: ${{ inputs.release_sha }}
+          TRUSTED_REF_KIND: release-branch
+          TRUSTED_REF_PROTECTED: ${{ github.ref_protected }}
+          TRUSTED_SOURCE_SHA: ${{ inputs.release_sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ inputs.caller_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/release-pr.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TRUSTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ && \
+            "$TRUSTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || {
+            echo "Caller SHA does not match the protected workflow SHA" >&2
+            exit 1
+          }
+          trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
+          git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
+          chmod 700 "$trusted_gate"
+          "$trusted_gate"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -726,19 +879,50 @@ jobs:
     name: Linux x64
     needs: prepare-release
     if: >-
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/heads/release/v') ||
-      startsWith(github.ref, 'refs/tags/v')
+      github.ref_protected == true &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main' &&
+      startsWith(inputs.release_ref, 'release/v') &&
+      inputs.release_sha != '' &&
+      inputs.release_base_sha != '' &&
+      inputs.caller_sha == github.sha &&
+      inputs.release_base_sha == inputs.caller_sha
     environment: electron
     permissions:
       # Required to publish the Linux artifact to the GitHub release.
-      contents: write
+      contents: write # Upload the signed Linux artifact to the verified release.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
           persist-credentials: false
+      - name: Verify trusted release ref
+        env:
+          TRUSTED_BASE_SHA: ${{ inputs.release_base_sha }}
+          TRUSTED_CALLED_WORKFLOW_PATH: .github/workflows/release-updates.yml
+          TRUSTED_CALLER_REF: ${{ github.ref }}
+          TRUSTED_EVENT_REF: ${{ format('refs/heads/{0}', inputs.release_ref) }}
+          TRUSTED_EVENT_REF_TYPE: branch
+          TRUSTED_EVENT_SHA: ${{ inputs.release_sha }}
+          TRUSTED_REF_KIND: release-branch
+          TRUSTED_REF_PROTECTED: ${{ github.ref_protected }}
+          TRUSTED_SOURCE_SHA: ${{ inputs.release_sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ inputs.caller_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/release-pr.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TRUSTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ && \
+            "$TRUSTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || {
+            echo "Caller SHA does not match the protected workflow SHA" >&2
+            exit 1
+          }
+          trusted_gate="${RUNNER_TEMP:?}/verify-privileged-ref-${GITHUB_JOB}.sh"
+          git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh" > "$trusted_gate"
+          chmod 700 "$trusted_gate"
+          "$trusted_gate"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -10,7 +10,10 @@ on:
     paths:
       - packages/sandbox/**
       - .github/workflows/sandbox.yml
-  workflow_dispatch:
+
+concurrency:
+  group: sandbox-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -57,9 +60,7 @@ jobs:
     name: Build Docker image (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: rust-checks
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     permissions:
       contents: read
       packages: write # Publish the image to GHCR from protected main only.
@@ -77,7 +78,18 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify trusted publication ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/sandbox.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.6.0
@@ -160,13 +172,28 @@ jobs:
     name: Create multi-arch manifest
     runs-on: ubuntu-24.04
     needs: docker-build
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     permissions:
       contents: read
       packages: write # Publish the manifest to GHCR from protected main only.
     steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify trusted publication ref
+        env:
+          TRUSTED_BASE_SHA: ${{ github.sha }}
+          TRUSTED_REF_KIND: main
+          TRUSTED_SOURCE_SHA: ${{ github.sha }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          TRUSTED_WORKFLOW_PATH: .github/workflows/sandbox.yml
+        shell: bash
+        run: .github/scripts/verify-privileged-ref.sh
+
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,29 @@
+# Release workflow
+
+The release workflow runs from the protected `main` branch on its schedule.
+It creates a single-file `release/vX.Y.Z` branch, then calls
+`.github/workflows/release-updates.yml` as a reusable workflow. The call carries
+the exact release commit, its `main` parent, and the protected caller commit.
+The publishing workflow has no `push` or `workflow_dispatch` entrypoint, so the
+pre-merge release call is the single source of the tag and its artifacts.
+
+This removes the manual and post-merge paths that could otherwise select
+arbitrary branch code or publish the same version twice. Outside the schedule,
+wait for the next scheduled run or rerun a failed release job after confirming
+that its captured base commit is still reachable from protected `main`.
+The eventual merge commit does not start another publication or move the tag.
+Retries can reuse a draft release without a tag only when its target commit
+matches the captured release SHA.
+Change detection reads the highest version tag directly, so merge-commit,
+squash, and rebase strategies do not change the release source.
+Keep the generated release branch and draft PR unchanged until all artifact
+jobs finish. If either was merged, deleted, or force-pushed, start a new release
+instead of rerunning the old one.
+
+The trust gate rejects stale or moved refs, workflow changes, non-bot release
+commits, and release commits that change files other than
+`apps/client/package.json`. Keep `main` protected and configure non-empty
+required reviewers for the `electron` environment before relying on publication.
+Build jobs read signing and build values from that environment in the called
+workflow. The caller does not use `secrets: inherit`, so unrelated repository
+secrets do not cross the workflow boundary.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -4,7 +4,9 @@ The release workflow runs from the protected `main` branch on its schedule.
 It creates a single-file `release/vX.Y.Z` branch, then calls
 `.github/workflows/release-updates.yml` as a reusable workflow. The call carries
 the exact release commit, its `main` parent, and the protected caller commit.
-The publishing workflow has no `push` or `workflow_dispatch` entrypoint, so the
+The caller binds an immutable `vX.Y.Z` tag to that exact generated commit
+before the publishing call. The publishing workflow has no `push` or
+`workflow_dispatch` entrypoint, and only verifies that pre-bound tag, so the
 pre-merge release call is the single source of the tag and its artifacts.
 
 This removes the manual and post-merge paths that could otherwise select
@@ -12,8 +14,10 @@ arbitrary branch code or publish the same version twice. Outside the schedule,
 wait for the next scheduled run or rerun a failed release job after confirming
 that its captured base commit is still reachable from protected `main`.
 The eventual merge commit does not start another publication or move the tag.
-Retries can reuse a draft release without a tag only when its target commit
-matches the captured release SHA.
+Retries can reuse an existing draft only when its immutable tag already exists
+and points at the validated release commit. A missing tag fails closed, even
+when the draft `targetCommitish` value appears to match, so start a fresh
+scheduled release for that case.
 Change detection reads the highest version tag directly, so merge-commit,
 squash, and rebase strategies do not change the release source.
 Keep the generated release branch and draft PR unchanged until all artifact
@@ -22,8 +26,10 @@ instead of rerunning the old one.
 
 The trust gate rejects stale or moved refs, workflow changes, non-bot release
 commits, and release commits that change files other than
-`apps/client/package.json`. Keep `main` protected and configure non-empty
-required reviewers for the `electron` environment before relying on publication.
+`apps/client/package.json`. Protect `release/v*` branches from force-pushes and
+protect `v*` tags from updates, with the Actions integration as the only
+automation bypass. Keep `main` protected and configure non-empty required
+reviewers for the `electron` environment before relying on publication.
 Build jobs read signing and build values from that environment in the called
 workflow. The caller does not use `secrets: inherit`, so unrelated repository
 secrets do not cross the workflow boundary.

--- a/scripts/ci/test-privileged-workflow-gates.rb
+++ b/scripts/ci/test-privileged-workflow-gates.rb
@@ -199,6 +199,13 @@ end
 unless release_script.include?("refs/heads/${branchName}:refs/heads/${branchName}")
   errors << "scripts/release-pr.ts must fetch an existing release branch before retry"
 end
+unless release_script.include?("function commitAsActionsBot") &&
+       release_script.include?("GIT_AUTHOR_NAME: actionsBotName") &&
+       release_script.include?("GIT_AUTHOR_EMAIL: actionsBotEmail") &&
+       release_script.include?("GIT_COMMITTER_NAME: actionsBotName") &&
+       release_script.include?("GIT_COMMITTER_EMAIL: actionsBotEmail")
+  errors << "scripts/release-pr.ts must set the trusted Actions identity for generated commits"
+end
 
 %w[mac-arm64 mac-universal windows-x64 linux-x64].each do |job_id|
   environment = release_updates.fetch("jobs").fetch(job_id).fetch("environment", nil)

--- a/scripts/ci/test-privileged-workflow-gates.rb
+++ b/scripts/ci/test-privileged-workflow-gates.rb
@@ -174,6 +174,21 @@ end
 unless stringify(release_pr.fetch("jobs").fetch("open-release-pr")).include?("git fetch --force --tags origin")
   errors << "release-pr.yml must fetch version tags before change detection"
 end
+open_release_text = stringify(release_pr.fetch("jobs").fetch("open-release-pr"))
+release_checkout = release_pr.fetch("jobs").fetch("open-release-pr").fetch("steps").find do |step|
+  step.is_a?(Hash) && step.fetch("uses", "").to_s.start_with?("actions/checkout@")
+end
+unless release_checkout&.fetch("with", {})&.fetch("ref", nil) == "${{ github.sha }}"
+  errors << "release-pr.yml must checkout the immutable scheduled SHA"
+end
+unless open_release_text.include?("gh api --method POST") &&
+       open_release_text.include?("refs/tags/$release_tag") &&
+       open_release_text.include?("RELEASE_PR_STATE\" != \"created\"")
+  errors << "release-pr.yml must bind a new immutable tag and fail closed for missing retry tags"
+end
+unless open_release_text.include?("git merge-base --is-ancestor \"$EXPECTED_SHA\" \"$main_sha\"")
+  errors << "release-pr.yml must allow delayed runs only on protected-main ancestry"
+end
 release_script = File.read("scripts/release-pr.ts")
 unless release_script.include?("verifyGeneratedReleaseCommit")
   errors << "scripts/release-pr.ts must validate the generated commit before pushing"
@@ -198,11 +213,24 @@ prepare_release_text = stringify(release_updates.fetch("jobs").fetch("prepare-re
 if prepare_release_text.include?("inputs.release_base_sha == inputs.caller_sha")
   errors << "release-updates.yml must allow a validated release base ancestor"
 end
-unless prepare_release_text.include?('--target "$SOURCE_SHA"')
-  errors << "release-updates.yml does not bind a new release tag to the verified source SHA"
+unless prepare_release_text.include?("--verify-tag")
+  errors << "release-updates.yml must only create releases from an existing immutable tag"
 end
-unless prepare_release_text.include?("Release tag $resolved_tag does not point at $SOURCE_SHA")
+unless prepare_release_text.include?("Release tag $resolved_tag does not point at $SOURCE_SHA") &&
+       prepare_release_text.include?("Refusing to publish without a tag bound before this workflow call")
   errors << "release-updates.yml does not reject an existing tag at another source SHA"
+end
+
+gate_script = File.read(".github/scripts/verify-privileged-ref.sh")
+unless gate_script.include?("git merge-base --is-ancestor \"$event_sha\" \"$remote_ref_sha\"")
+  errors << "verify-privileged-ref.sh must accept only protected-main ancestry for delayed jobs"
+end
+unless gate_script.include?("release branch is not bound to its immutable release tag")
+  errors << "verify-privileged-ref.sh must bind release branches to immutable tags"
+end
+unless gate_script.include?("tag workflow is not the current protected workflow revision") &&
+       gate_script.include?("[[ \"$workflow_sha\" == \"$main_sha\" ]]")
+  errors << "verify-privileged-ref.sh must bind credentialed tag workflows to current protected main"
 end
 
 if errors.empty?

--- a/scripts/ci/test-privileged-workflow-gates.rb
+++ b/scripts/ci/test-privileged-workflow-gates.rb
@@ -1,0 +1,198 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+
+WORKFLOWS = %w[
+  .github/workflows/docker.yml
+  .github/workflows/sandbox.yml
+  .github/workflows/morph-snapshot.yml
+  .github/workflows/host-screenshot-collector.yml
+  .github/workflows/release-pr.yml
+  .github/workflows/release-updates.yml
+].freeze
+
+PINNED_ACTION = %r{@[0-9a-f]{40}(?:\s+#.*)?\z}i
+PRIVILEGED_TEXT = /(secrets\.|contents:\s*write|packages:\s*write|pull-requests:\s*write|actions:\s*write|git push|gh release|gh pr)/
+
+errors = []
+
+def stringify(value)
+  case value
+  when Hash
+    value.map { |key, child| "#{key}:#{stringify(child)}" }.join(" ")
+  when Array
+    value.map { |child| stringify(child) }.join(" ")
+  else
+    value.to_s
+  end
+end
+
+WORKFLOWS.each do |path|
+  data = YAML.safe_load(File.read(path), aliases: false)
+  events = data.fetch(true, data.fetch("on", {}))
+  if events.key?("workflow_dispatch")
+    errors << "#{path} exposes a manual workflow_dispatch trigger"
+  end
+  if path == ".github/workflows/release-updates.yml" && events.key?("push")
+    errors << "release-updates.yml exposes a post-merge push trigger"
+  end
+  jobs = data.fetch("jobs")
+  jobs.each do |job_id, job|
+    job_text = stringify(job)
+    privileged = job_text.match?(PRIVILEGED_TEXT)
+    condition = job.fetch("if", "").to_s
+    if privileged
+      unless condition.include?("github.ref_protected == true")
+        errors << "#{path} job #{job_id} lacks a protected-ref condition"
+      end
+      unless condition.include?("github.ref == 'refs/heads/main'") ||
+             condition.include?("github.workflow_ref == 'manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main'")
+        errors << "#{path} job #{job_id} lacks a protected main or trusted release caller condition"
+      end
+      if job_text.match?(/actions:\s*write/) || job_text.match?(/secrets:\s*inherit/)
+        errors << "#{path} job #{job_id} requests an unsafe workflow permission or secret inheritance"
+      end
+
+      # A reusable-workflow caller has no steps of its own. The called
+      # workflow owns checkout, trust verification, and secret use.
+      if job.key?("uses")
+        unless job["uses"] == "./.github/workflows/release-updates.yml"
+          errors << "#{path} job #{job_id} calls an unexpected workflow: #{job["uses"]}"
+        end
+        next
+      end
+
+      steps = job.fetch("steps", [])
+      checkout_index = steps.index do |step|
+        step.is_a?(Hash) && step.fetch("uses", "").to_s.start_with?("actions/checkout@")
+      end
+      if checkout_index.nil?
+        errors << "#{path} job #{job_id} has privileged operations but no checkout"
+        next
+      end
+
+      checkout = steps.fetch(checkout_index)
+      checkout_with = checkout.fetch("with", {})
+      unless checkout_with["persist-credentials"] == false
+        errors << "#{path} job #{job_id} checkout must set persist-credentials: false"
+      end
+
+      gate_index = steps.index do |step|
+        next false unless step.is_a?(Hash)
+
+        gate_run = step.fetch("run", "").to_s
+        if path == ".github/workflows/release-updates.yml"
+          gate_run.include?('git show "$TRUSTED_WORKFLOW_SHA:.github/scripts/verify-privileged-ref.sh"')
+        else
+          gate_run.strip == ".github/scripts/verify-privileged-ref.sh"
+        end
+      end
+      if gate_index.nil? || gate_index != checkout_index + 1
+        errors << "#{path} job #{job_id} must run the trust gate immediately after checkout"
+      else
+        gate_env = steps.fetch(gate_index).fetch("env", {})
+        %w[TRUSTED_BASE_SHA TRUSTED_SOURCE_SHA TRUSTED_REF_KIND TRUSTED_WORKFLOW_PATH TRUSTED_WORKFLOW_SHA].each do |key|
+          errors << "#{path} job #{job_id} gate lacks #{key}" unless gate_env.key?(key)
+        end
+        if path == ".github/workflows/release-updates.yml"
+          %w[
+            TRUSTED_CALLED_WORKFLOW_PATH
+            TRUSTED_CALLER_REF
+            TRUSTED_EVENT_REF
+            TRUSTED_EVENT_REF_TYPE
+            TRUSTED_EVENT_SHA
+            TRUSTED_REF_PROTECTED
+          ].each do |key|
+            errors << "#{path} job #{job_id} gate lacks #{key}" unless gate_env.key?(key)
+          end
+          gate_run = steps.fetch(gate_index).fetch("run").to_s
+          unless gate_run.include?('"$TRUSTED_WORKFLOW_SHA" == "$GITHUB_SHA"') &&
+                 gate_run.include?('chmod 700 "$trusted_gate"')
+            errors << "#{path} job #{job_id} must bootstrap the gate from the protected caller SHA"
+          end
+        end
+        gate_shell = steps.fetch(gate_index).fetch("shell", "").to_s
+        errors << "#{path} job #{job_id} gate must use bash" unless gate_shell == "bash"
+        steps[0...gate_index].each_with_index do |step, index|
+          if stringify(step).match?(%r{secrets\.})
+            errors << "#{path} job #{job_id} exposes a secret before the trust gate (step #{index})"
+          end
+        end
+      end
+    end
+
+    # Every checkout in these workflows is pinned and must not leave a token
+    # in the local repository configuration.
+    Array(job.fetch("steps", [])).each_with_index do |step, index|
+      next unless step.is_a?(Hash)
+
+      uses = step.fetch("uses", "").to_s
+      if uses.start_with?("actions/") || uses.include?("/")
+        unless uses.match?(PINNED_ACTION)
+          errors << "#{path} job #{job_id} step #{index} uses an unpinned action: #{uses}"
+        end
+      end
+    end
+  end
+
+  top_permissions = data.fetch("permissions", {})
+  if top_permissions.is_a?(Hash) && top_permissions.values.any? { |value| value.to_s == "write" }
+    errors << "#{path} grants write permission at workflow scope"
+  end
+end
+
+release_updates = YAML.safe_load(File.read(".github/workflows/release-updates.yml"), aliases: false)
+workflow_call = release_updates.fetch(true).fetch("workflow_call")
+inputs = workflow_call.fetch("inputs")
+%w[release_ref release_sha release_base_sha caller_sha].each do |key|
+  errors << "release-updates.yml lacks workflow_call input #{key}" unless inputs.key?(key)
+end
+
+release_pr = YAML.safe_load(File.read(".github/workflows/release-pr.yml"), aliases: false)
+build_release = release_pr.fetch("jobs").fetch("build-release")
+trigger_text = stringify(build_release)
+%w[release_ref release_sha release_base_sha caller_sha].each do |key|
+  errors << "release-pr.yml does not forward #{key}" unless trigger_text.include?(key)
+end
+if build_release["secrets"] == "inherit" || trigger_text.match?(/secrets:\s*inherit/)
+  errors << "release-pr.yml must not inherit caller secrets"
+end
+capture_step = release_pr.fetch("jobs").fetch("open-release-pr").fetch("steps").find { |step| step["id"] == "release_revision" }
+capture_text = stringify(capture_step || {})
+unless capture_text.include?("git show-ref --verify --quiet")
+  errors << "release-pr.yml must assert the generated release branch exists locally"
+end
+change_step = release_pr.fetch("jobs").fetch("open-release-pr").fetch("steps").find { |step| step["id"] == "release_changes" }
+change_text = stringify(change_step || {})
+unless change_text.include?("git tag --list") && change_text.include?("--sort=-version:refname")
+  errors << "release-pr.yml must find the latest version tag without ancestry-only lookup"
+end
+release_script = File.read("scripts/release-pr.ts")
+unless release_script.include?("verifyGeneratedReleaseCommit")
+  errors << "scripts/release-pr.ts must validate the generated commit before pushing"
+end
+
+%w[mac-arm64 mac-universal windows-x64 linux-x64].each do |job_id|
+  environment = release_updates.fetch("jobs").fetch(job_id).fetch("environment", nil)
+  unless environment == "electron"
+    errors << "release-updates.yml job #{job_id} must resolve secrets through the electron environment"
+  end
+end
+unless stringify(release_updates.fetch("jobs").fetch("prepare-release")).include?("inputs.caller_sha == github.sha")
+  errors << "release-updates.yml does not bind caller_sha to github.sha"
+end
+prepare_release_text = stringify(release_updates.fetch("jobs").fetch("prepare-release"))
+unless prepare_release_text.include?('--target "$SOURCE_SHA"')
+  errors << "release-updates.yml does not bind a new release tag to the verified source SHA"
+end
+unless prepare_release_text.include?("Release tag $resolved_tag does not point at $SOURCE_SHA")
+  errors << "release-updates.yml does not reject an existing tag at another source SHA"
+end
+
+if errors.empty?
+  puts "privileged workflow gate static tests passed (release secrets stay environment-scoped)"
+  exit 0
+end
+
+warn errors.join("\n")
+exit 1

--- a/scripts/ci/test-privileged-workflow-gates.rb
+++ b/scripts/ci/test-privileged-workflow-gates.rb
@@ -167,6 +167,9 @@ change_text = stringify(change_step || {})
 unless change_text.include?("git tag --list") && change_text.include?("--sort=-version:refname")
   errors << "release-pr.yml must find the latest version tag without ancestry-only lookup"
 end
+unless stringify(release_pr.fetch("jobs").fetch("open-release-pr")).include?("git fetch --force --tags origin")
+  errors << "release-pr.yml must fetch version tags before change detection"
+end
 release_script = File.read("scripts/release-pr.ts")
 unless release_script.include?("verifyGeneratedReleaseCommit")
   errors << "scripts/release-pr.ts must validate the generated commit before pushing"

--- a/scripts/ci/test-privileged-workflow-gates.rb
+++ b/scripts/ci/test-privileged-workflow-gates.rb
@@ -154,6 +154,10 @@ trigger_text = stringify(build_release)
 %w[release_ref release_sha release_base_sha caller_sha].each do |key|
   errors << "release-pr.yml does not forward #{key}" unless trigger_text.include?(key)
 end
+unless trigger_text.include?("release_pr_state == 'existing'") &&
+       trigger_text.include?("release_pr_draft == 'true'")
+  errors << "release-pr.yml must permit retries only for existing draft releases"
+end
 if build_release["secrets"] == "inherit" || trigger_text.match?(/secrets:\s*inherit/)
   errors << "release-pr.yml must not inherit caller secrets"
 end
@@ -174,6 +178,12 @@ release_script = File.read("scripts/release-pr.ts")
 unless release_script.include?("verifyGeneratedReleaseCommit")
   errors << "scripts/release-pr.ts must validate the generated commit before pushing"
 end
+unless release_script.include?("writeGithubOutput(\"release_pr_draft\", String(existing.draft))")
+  errors << "scripts/release-pr.ts must expose existing draft state"
+end
+unless release_script.include?("refs/heads/${branchName}:refs/heads/${branchName}")
+  errors << "scripts/release-pr.ts must fetch an existing release branch before retry"
+end
 
 %w[mac-arm64 mac-universal windows-x64 linux-x64].each do |job_id|
   environment = release_updates.fetch("jobs").fetch(job_id).fetch("environment", nil)
@@ -185,6 +195,9 @@ unless stringify(release_updates.fetch("jobs").fetch("prepare-release")).include
   errors << "release-updates.yml does not bind caller_sha to github.sha"
 end
 prepare_release_text = stringify(release_updates.fetch("jobs").fetch("prepare-release"))
+if prepare_release_text.include?("inputs.release_base_sha == inputs.caller_sha")
+  errors << "release-updates.yml must allow a validated release base ancestor"
+end
 unless prepare_release_text.include?('--target "$SOURCE_SHA"')
   errors << "release-updates.yml does not bind a new release tag to the verified source SHA"
 end

--- a/scripts/ci/test-verify-privileged-ref.sh
+++ b/scripts/ci/test-verify-privileged-ref.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+GATE_SCRIPT="$SCRIPT_DIR/../../.github/scripts/verify-privileged-ref.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+repo_dir="$tmp_dir/repo"
+remote_dir="$tmp_dir/origin.git"
+mkdir -p "$repo_dir/.github/workflows"
+mkdir -p "$repo_dir/apps/client"
+git -C "$repo_dir" init --quiet --initial-branch=main
+git -C "$repo_dir" config user.name "CI test"
+git -C "$repo_dir" config user.email "ci-test@example.invalid"
+printf '%s\n' 'name: test' > "$repo_dir/.github/workflows/test.yml"
+printf '%s\n' 'name: release-pr' > "$repo_dir/.github/workflows/release-pr.yml"
+printf '%s\n' '{"version":"1.2.2"}' > "$repo_dir/apps/client/package.json"
+git -C "$repo_dir" add .
+git -C "$repo_dir" commit --quiet -m "test: add workflow"
+workflow_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+printf '%s\n' 'trusted source' > "$repo_dir/source.txt"
+git -C "$repo_dir" add source.txt
+git -C "$repo_dir" commit --quiet -m "test: add source"
+source_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" clone --quiet --bare . "$remote_dir"
+git -C "$repo_dir" remote add origin "$remote_dir"
+git -C "$repo_dir" push --quiet origin main
+git -C "$repo_dir" -c tag.gpgSign=false tag v1.2.3
+git -C "$repo_dir" push --quiet origin refs/tags/v1.2.3
+
+run_gate() {
+  local kind="$1"
+  local ref="$2"
+  local ref_type="$3"
+  local sha="$4"
+  local protected="$5"
+  local base_sha="$6"
+  local workflow_sha_value="$7"
+  local trusted_source_sha="${8:-$sha}"
+  local workflow_path=".github/workflows/test.yml"
+
+  (
+    cd "$repo_dir"
+    git checkout --quiet --detach "$sha"
+    GITHUB_REPOSITORY=manaflow-ai/manaflow \
+    GITHUB_REF="$ref" \
+    GITHUB_REF_TYPE="$ref_type" \
+    GITHUB_SHA="$sha" \
+    GITHUB_WORKFLOW_REF="manaflow-ai/manaflow/$workflow_path@$ref" \
+    GITHUB_WORKFLOW_SHA="$workflow_sha_value" \
+    GITHUB_EVENT_NAME=push \
+    GITHUB_REF_PROTECTED="$protected" \
+    TRUSTED_BASE_SHA="$base_sha" \
+    TRUSTED_SOURCE_SHA="$trusted_source_sha" \
+    TRUSTED_WORKFLOW_PATH="$workflow_path" \
+    TRUSTED_REF_KIND="$kind" \
+    "$GATE_SCRIPT"
+  )
+}
+
+expect_success() {
+  local description="$1"
+  shift
+  if ! run_gate "$@" >/dev/null; then
+    echo "FAIL: expected success: $description" >&2
+    exit 1
+  fi
+}
+
+expect_failure() {
+  local description="$1"
+  shift
+  if run_gate "$@" >/dev/null 2>&1; then
+    echo "FAIL: expected failure: $description" >&2
+    exit 1
+  fi
+}
+
+expect_success "protected main" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha"
+expect_success "protected tag" tag refs/tags/v1.2.3 tag "$source_sha" true "$source_sha" "$workflow_sha"
+
+git -C "$repo_dir" checkout --quiet -b release/v1.2.3
+git -C "$repo_dir" config user.name "github-actions[bot]"
+git -C "$repo_dir" config user.email "github-actions[bot]@users.noreply.github.com"
+mkdir -p "$repo_dir/apps/client"
+printf '%s\n' '{"version":"1.2.3"}' > "$repo_dir/apps/client/package.json"
+git -C "$repo_dir" add apps/client/package.json
+git -C "$repo_dir" commit --quiet -m "chore: release v1.2.3"
+release_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin release/v1.2.3
+# The publishing workflow creates the version tag at the generated release
+# commit, before the release branch is merged into main.
+git -C "$repo_dir" -c tag.gpgSign=false tag -f v1.2.3 "$release_sha" >/dev/null
+git -C "$repo_dir" push --quiet --force origin refs/tags/v1.2.3
+
+run_called_gate() {
+  local event_name="${1:-workflow_call}"
+  local event_ref="${2:-refs/heads/release/v1.2.3}"
+  local event_sha="${3:-$release_sha}"
+  local base_sha="${4:-$source_sha}"
+  local caller_ref="${5:-refs/heads/main}"
+  local workflow_ref="${6:-manaflow-ai/manaflow/.github/workflows/release-pr.yml@$caller_ref}"
+  local protected="${7:-true}"
+  (
+    cd "$repo_dir"
+    git checkout --quiet --detach "$event_sha"
+    GITHUB_REPOSITORY=manaflow-ai/manaflow \
+    GITHUB_REF="$caller_ref" \
+    GITHUB_REF_TYPE=branch \
+    GITHUB_SHA="$source_sha" \
+    GITHUB_WORKFLOW_REF="$workflow_ref" \
+    GITHUB_WORKFLOW_SHA="$workflow_sha" \
+    GITHUB_EVENT_NAME="$event_name" \
+    GITHUB_REF_PROTECTED="$protected" \
+    TRUSTED_BASE_SHA="$base_sha" \
+    TRUSTED_CALLED_WORKFLOW_PATH=.github/workflows/test.yml \
+    TRUSTED_CALLER_REF="$caller_ref" \
+    TRUSTED_EVENT_REF="$event_ref" \
+    TRUSTED_EVENT_REF_TYPE=branch \
+    TRUSTED_EVENT_SHA="$event_sha" \
+    TRUSTED_REF_KIND=release-branch \
+    TRUSTED_REF_PROTECTED="$protected" \
+    TRUSTED_SOURCE_SHA="$event_sha" \
+    TRUSTED_WORKFLOW_SHA="$workflow_sha" \
+    TRUSTED_WORKFLOW_PATH=.github/workflows/release-pr.yml \
+    "$GATE_SCRIPT"
+  )
+}
+
+expect_called_failure() {
+  local description="$1"
+  shift
+  if run_called_gate "$@" >/dev/null 2>&1; then
+    echo "FAIL: expected called workflow failure: $description" >&2
+    exit 1
+  fi
+}
+
+if ! run_called_gate >/dev/null; then
+  echo "FAIL: expected reusable release workflow call to pass" >&2
+  exit 1
+fi
+if ! run_called_gate schedule >/dev/null; then
+  echo "FAIL: expected reusable release workflow scheduled caller to pass" >&2
+  exit 1
+fi
+
+# Main can advance while a long release build runs. The captured base remains
+# trusted when it is still an ancestor of the protected main tip.
+git -C "$repo_dir" checkout --quiet main
+printf '%s\n' 'main advanced during release build' > "$repo_dir/main-advance.txt"
+git -C "$repo_dir" add main-advance.txt
+git -C "$repo_dir" commit --quiet -m "test: advance main during release"
+git -C "$repo_dir" push --quiet origin main
+if ! run_called_gate >/dev/null; then
+  echo "FAIL: release call should allow a protected main fast-forward" >&2
+  exit 1
+fi
+
+expect_called_failure "manual event" workflow_dispatch
+expect_called_failure \
+  "feature-branch caller" \
+  workflow_call \
+  refs/heads/release/v1.2.3 \
+  "$release_sha" \
+  "$source_sha" \
+  refs/heads/feature
+expect_called_failure \
+  "unexpected caller workflow" \
+  workflow_call \
+  refs/heads/release/v1.2.3 \
+  "$release_sha" \
+  "$source_sha" \
+  refs/heads/main \
+  manaflow-ai/manaflow/.github/workflows/test.yml@refs/heads/main
+expect_called_failure \
+  "unprotected caller" \
+  workflow_call \
+  refs/heads/release/v1.2.3 \
+  "$release_sha" \
+  "$source_sha" \
+  refs/heads/main \
+  manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main \
+  false
+expect_failure "unprotected main" main refs/heads/main branch "$source_sha" false "$source_sha" "$workflow_sha"
+expect_failure "feature branch" main refs/heads/feature branch "$source_sha" true "$source_sha" "$workflow_sha"
+expect_failure "unprotected tag" tag refs/tags/v1.2.3 tag "$source_sha" false "$source_sha" "$workflow_sha"
+expect_failure "non-semver tag" tag refs/tags/v1 tag "$source_sha" true "$source_sha" "$workflow_sha"
+expect_failure "source SHA mismatch" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha" "0000000000000000000000000000000000000000"
+
+git -C "$repo_dir" checkout --quiet --detach "$workflow_sha"
+printf '%s\n' 'divergent workflow revision' > "$repo_dir/.github/workflows/test.yml"
+git -C "$repo_dir" add .github/workflows/test.yml
+git -C "$repo_dir" commit --quiet -m "test: divergent workflow"
+divergent_workflow_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" checkout --quiet --detach "$source_sha"
+expect_failure "workflow SHA is not an ancestor" main refs/heads/main branch "$source_sha" true "$source_sha" "$divergent_workflow_sha"
+expect_called_failure \
+  "release base is not an ancestor of current main" \
+  workflow_call \
+  refs/heads/release/v1.2.3 \
+  "$release_sha" \
+  "$divergent_workflow_sha"
+
+git -C "$repo_dir" checkout --quiet -b release/v1.2.4 "$source_sha"
+git -C "$repo_dir" config user.name "CI test"
+git -C "$repo_dir" config user.email "ci-test@example.invalid"
+printf '%s\n' '{"version":"1.2.4"}' > "$repo_dir/apps/client/package.json"
+git -C "$repo_dir" add apps/client/package.json
+git -C "$repo_dir" commit --quiet -m "chore: release v1.2.4"
+wrong_author_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin release/v1.2.4
+expect_called_failure \
+  "release commit has an untrusted author" \
+  workflow_call \
+  refs/heads/release/v1.2.4 \
+  "$wrong_author_sha"
+
+git -C "$repo_dir" checkout --quiet -b release/v1.2.5 "$source_sha"
+git -C "$repo_dir" config user.name "github-actions[bot]"
+git -C "$repo_dir" config user.email "github-actions[bot]@users.noreply.github.com"
+printf '%s\n' '{"version":"1.2.5"}' > "$repo_dir/apps/client/package.json"
+printf '%s\n' 'unexpected' > "$repo_dir/unexpected.txt"
+git -C "$repo_dir" add apps/client/package.json unexpected.txt
+git -C "$repo_dir" commit --quiet -m "chore: release v1.2.5"
+extra_file_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin release/v1.2.5
+expect_called_failure \
+  "release commit changes an extra file" \
+  workflow_call \
+  refs/heads/release/v1.2.5 \
+  "$extra_file_sha"
+
+git -C "$repo_dir" checkout --quiet -b release/v1.2.7 "$source_sha"
+printf '%s\n' '{"version":"1.2.7"}' > "$repo_dir/apps/client/package.json"
+mkdir -p "$repo_dir/.github/scripts"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$repo_dir/.github/scripts/verify-privileged-ref.sh"
+git -C "$repo_dir" add apps/client/package.json .github/scripts/verify-privileged-ref.sh
+git -C "$repo_dir" commit --quiet -m "chore: release v1.2.7"
+replaced_gate_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin release/v1.2.7
+expect_called_failure \
+  "release revision replaces its verifier" \
+  workflow_call \
+  refs/heads/release/v1.2.7 \
+  "$replaced_gate_sha"
+
+git -C "$repo_dir" checkout --quiet -b release/v1.2.6 "$source_sha"
+printf '%s\n' '{"version":"1.2.6"}' > "$repo_dir/apps/client/package.json"
+git -C "$repo_dir" add apps/client/package.json
+git -C "$repo_dir" commit --quiet -m "chore: release v1.2.6"
+unpublished_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+expect_called_failure \
+  "release revision is not published at its claimed ref" \
+  workflow_call \
+  refs/heads/release/v1.2.6 \
+  "$unpublished_sha"
+
+git -C "$repo_dir" checkout --quiet main
+git -C "$repo_dir" config user.name "CI test"
+git -C "$repo_dir" config user.email "ci-test@example.invalid"
+git -C "$repo_dir" merge --quiet --no-ff release/v1.2.3 -m "Merge release v1.2.3"
+post_merge_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin main
+tag_sha="$(git -C "$repo_dir" ls-remote origin \
+  refs/tags/v1.2.3 'refs/tags/v1.2.3^{}' | awk 'NF == 2 { print $1; exit }')"
+if [[ "$tag_sha" != "$release_sha" ]]; then
+  echo "FAIL: post-merge main changed the release tag source" >&2
+  exit 1
+fi
+expect_called_failure \
+  "post-merge main SHA cannot replace the pre-merge release source" \
+  workflow_call \
+  refs/heads/main \
+  "$post_merge_sha" \
+  "$source_sha"
+expect_failure "main moved after the run started" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha"
+
+echo "verify-privileged-ref behavior tests passed"

--- a/scripts/ci/test-verify-privileged-ref.sh
+++ b/scripts/ci/test-verify-privileged-ref.sh
@@ -95,7 +95,9 @@ git -C "$repo_dir" push --quiet origin release/v1.2.3
 git -C "$repo_dir" -c tag.gpgSign=false tag -f v1.2.3 "$release_sha" >/dev/null
 git -C "$repo_dir" push --quiet --force origin refs/tags/v1.2.3
 
-run_called_gate() {
+run_called_gate_in() {
+  local gate_repo="$1"
+  shift
   local event_name="${1:-workflow_call}"
   local event_ref="${2:-refs/heads/release/v1.2.3}"
   local event_sha="${3:-$release_sha}"
@@ -104,7 +106,7 @@ run_called_gate() {
   local workflow_ref="${6:-manaflow-ai/manaflow/.github/workflows/release-pr.yml@$caller_ref}"
   local protected="${7:-true}"
   (
-    cd "$repo_dir"
+    cd "$gate_repo"
     git checkout --quiet --detach "$event_sha"
     GITHUB_REPOSITORY=manaflow-ai/manaflow \
     GITHUB_REF="$caller_ref" \
@@ -127,6 +129,10 @@ run_called_gate() {
     TRUSTED_WORKFLOW_PATH=.github/workflows/release-pr.yml \
     "$GATE_SCRIPT"
   )
+}
+
+run_called_gate() {
+  run_called_gate_in "$repo_dir" "$@"
 }
 
 expect_called_failure() {
@@ -156,6 +162,15 @@ git -C "$repo_dir" commit --quiet -m "test: advance main during release"
 git -C "$repo_dir" push --quiet origin main
 if ! run_called_gate >/dev/null; then
   echo "FAIL: release call should allow a protected main fast-forward" >&2
+  exit 1
+fi
+
+# A runner may only have the release tip and its base locally when main moves.
+# The gate must fetch the current protected-main commit before checking ancestry.
+shallow_dir="$tmp_dir/shallow"
+git clone --quiet --no-local --depth=3 --branch release/v1.2.3 "$remote_dir" "$shallow_dir"
+if ! run_called_gate_in "$shallow_dir" >/dev/null; then
+  echo "FAIL: release call should fetch an advanced protected main commit" >&2
   exit 1
 fi
 

--- a/scripts/ci/test-verify-privileged-ref.sh
+++ b/scripts/ci/test-verify-privileged-ref.sh
@@ -79,7 +79,10 @@ expect_failure() {
 }
 
 expect_success "protected main" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha"
-expect_success "protected tag" tag refs/tags/v1.2.3 tag "$source_sha" true "$source_sha" "$workflow_sha"
+expect_success "protected tag" tag refs/tags/v1.2.3 tag "$source_sha" true "$source_sha" "$source_sha"
+expect_failure \
+  "tag workflow must be the current protected-main revision" \
+  tag refs/tags/v1.2.3 tag "$source_sha" true "$source_sha" "$workflow_sha"
 
 git -C "$repo_dir" checkout --quiet -b release/v1.2.3
 git -C "$repo_dir" config user.name "github-actions[bot]"
@@ -270,11 +273,26 @@ printf '%s\n' '{"version":"1.2.6"}' > "$repo_dir/apps/client/package.json"
 git -C "$repo_dir" add apps/client/package.json
 git -C "$repo_dir" commit --quiet -m "chore: release v1.2.6"
 unpublished_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin release/v1.2.6
 expect_called_failure \
-  "release revision is not published at its claimed ref" \
+  "release revision has no immutable release tag" \
   workflow_call \
   refs/heads/release/v1.2.6 \
   "$unpublished_sha"
+
+git -C "$repo_dir" checkout --quiet -b release/v1.2.8 "$source_sha"
+printf '%s\n' '{"version":"1.2.8"}' > "$repo_dir/apps/client/package.json"
+git -C "$repo_dir" add apps/client/package.json
+git -C "$repo_dir" commit --quiet -m "chore: release v1.2.8"
+mismatched_tag_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet origin release/v1.2.8
+git -C "$repo_dir" -c tag.gpgSign=false tag v1.2.8 "$source_sha"
+git -C "$repo_dir" push --quiet origin refs/tags/v1.2.8
+expect_called_failure \
+  "release tag points at a different commit" \
+  workflow_call \
+  refs/heads/release/v1.2.8 \
+  "$mismatched_tag_sha"
 
 git -C "$repo_dir" checkout --quiet main
 git -C "$repo_dir" config user.name "CI test"
@@ -291,9 +309,23 @@ fi
 expect_called_failure \
   "post-merge main SHA cannot replace the pre-merge release source" \
   workflow_call \
-  refs/heads/main \
+  refs/heads/release/v1.2.3 \
   "$post_merge_sha" \
   "$source_sha"
-expect_failure "main moved after the run started" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha"
+expect_success "main advanced after the run started" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha"
+
+# A protected-main ref that diverges from the triggering revision must still
+# fail. Ancestry tolerates a fast-forward only; it does not trust an unrelated
+# history merely because the ref is named main.
+git -C "$repo_dir" checkout --quiet --orphan divergent-main
+git -C "$repo_dir" rm --quiet -r --cached .
+printf '%s\n' 'unrelated main history' > "$repo_dir/divergent.txt"
+git -C "$repo_dir" add divergent.txt
+git -C "$repo_dir" commit --quiet -m "test: divergent protected main"
+divergent_main_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" push --quiet --force origin "$divergent_main_sha:refs/heads/main"
+git -C "$repo_dir" clean --quiet -fd
+git -C "$repo_dir" checkout --quiet --detach "$source_sha"
+expect_failure "divergent protected main history" main refs/heads/main branch "$source_sha" true "$source_sha" "$workflow_sha"
 
 echo "verify-privileged-ref behavior tests passed"

--- a/scripts/ci/test-verify-privileged-ref.sh
+++ b/scripts/ci/test-verify-privileged-ref.sh
@@ -105,15 +105,17 @@ run_called_gate_in() {
   local caller_ref="${5:-refs/heads/main}"
   local workflow_ref="${6:-manaflow-ai/manaflow/.github/workflows/release-pr.yml@$caller_ref}"
   local protected="${7:-true}"
+  local caller_sha="${8:-$source_sha}"
+  local workflow_sha_value="${9:-$caller_sha}"
   (
     cd "$gate_repo"
     git checkout --quiet --detach "$event_sha"
     GITHUB_REPOSITORY=manaflow-ai/manaflow \
     GITHUB_REF="$caller_ref" \
     GITHUB_REF_TYPE=branch \
-    GITHUB_SHA="$source_sha" \
+    GITHUB_SHA="$caller_sha" \
     GITHUB_WORKFLOW_REF="$workflow_ref" \
-    GITHUB_WORKFLOW_SHA="$workflow_sha" \
+    GITHUB_WORKFLOW_SHA="$workflow_sha_value" \
     GITHUB_EVENT_NAME="$event_name" \
     GITHUB_REF_PROTECTED="$protected" \
     TRUSTED_BASE_SHA="$base_sha" \
@@ -125,7 +127,7 @@ run_called_gate_in() {
     TRUSTED_REF_KIND=release-branch \
     TRUSTED_REF_PROTECTED="$protected" \
     TRUSTED_SOURCE_SHA="$event_sha" \
-    TRUSTED_WORKFLOW_SHA="$workflow_sha" \
+    TRUSTED_WORKFLOW_SHA="$workflow_sha_value" \
     TRUSTED_WORKFLOW_PATH=.github/workflows/release-pr.yml \
     "$GATE_SCRIPT"
   )
@@ -169,7 +171,8 @@ fi
 # The gate must fetch the current protected-main commit before checking ancestry.
 shallow_dir="$tmp_dir/shallow"
 git clone --quiet --no-local --depth=3 --branch release/v1.2.3 "$remote_dir" "$shallow_dir"
-if ! run_called_gate_in "$shallow_dir" >/dev/null; then
+main_advance_sha="$(git -C "$repo_dir" rev-parse main)"
+if ! run_called_gate_in "$shallow_dir" workflow_call refs/heads/release/v1.2.3 "$release_sha" "$source_sha" refs/heads/main "manaflow-ai/manaflow/.github/workflows/release-pr.yml@refs/heads/main" true "$main_advance_sha" "$main_advance_sha" >/dev/null; then
   echo "FAIL: release call should fetch an advanced protected main commit" >&2
   exit 1
 fi

--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -43,6 +43,14 @@ type Repository = {
 type PullRequest = {
   html_url: string;
   number: number;
+  draft: boolean;
+  user?: { login?: string };
+  head?: {
+    ref?: string;
+    sha?: string;
+    repo?: { full_name?: string } | null;
+  };
+  base?: { ref?: string };
 };
 
 function writeGithubOutput(key: string, value: string): void {
@@ -337,6 +345,34 @@ async function findExistingPullRequest(
   return pulls[0] ?? null;
 }
 
+function verifyExistingReleasePullRequest(
+  pullRequest: PullRequest,
+  branchName: string,
+  baseBranch: string,
+  releaseSha: string,
+  repo: Repository,
+): void {
+  const expectedRepository = `${repo.owner}/${repo.name}`;
+  if (!pullRequest.draft) {
+    throw new Error(
+      "Existing release PR is not a draft; refusing an automatic retry.",
+    );
+  }
+  if (pullRequest.user?.login !== actionsBotName) {
+    throw new Error("Existing release PR was not created by the Actions bot.");
+  }
+  if (
+    pullRequest.head?.ref !== branchName ||
+    pullRequest.head.repo?.full_name !== expectedRepository ||
+    pullRequest.head.sha !== releaseSha ||
+    pullRequest.base?.ref !== baseBranch
+  ) {
+    throw new Error(
+      "Existing release PR provenance does not match the generated release branch.",
+    );
+  }
+}
+
 async function createPullRequest(
   repo: Repository,
   token: string,
@@ -462,6 +498,8 @@ async function main(): Promise<void> {
     );
   }
 
+  const baseBranch = getBaseBranch();
+
   const localTagCheck = run(
     "git",
     ["rev-parse", "-q", "--verify", `refs/tags/v${newVersion}`],
@@ -494,12 +532,33 @@ async function main(): Promise<void> {
     const token = ensureToken();
     const existing = await findExistingPullRequest(branchName, repo, token);
     if (existing) {
+      runGit(
+        [
+          "fetch",
+          firstRemote,
+          `refs/heads/${branchName}:refs/heads/${branchName}`,
+        ],
+        { stdio: "inherit" },
+      );
+      const releaseSha = run("git", [
+        "rev-parse",
+        "--verify",
+        `refs/heads/${branchName}^{commit}`,
+      ]).stdout.trim();
+      verifyExistingReleasePullRequest(
+        existing,
+        branchName,
+        baseBranch,
+        releaseSha,
+        repo,
+      );
       console.log(
         `Release branch ${branchName} already has open PR #${existing.number}: ${existing.html_url}`,
       );
       writeGithubOutput("release_branch", branchName);
       writeGithubOutput("release_version", newVersion);
       writeGithubOutput("release_pr_state", "existing");
+      writeGithubOutput("release_pr_draft", String(existing.draft));
       writeGithubOutput("release_pr_number", existing.number.toString());
       writeGithubOutput("release_pr_url", existing.html_url);
       writeGithubOutput("release_branch_created", "false");
@@ -528,11 +587,11 @@ async function main(): Promise<void> {
 
   writeGithubOutput("release_branch", branchName);
   writeGithubOutput("release_version", newVersion);
+  writeGithubOutput("release_pr_draft", "true");
   writeGithubOutput("release_branch_created", "true");
 
   const repo = resolveRepository();
   const token = ensureToken();
-  const baseBranch = getBaseBranch();
 
   const pullRequest = await createPullRequest(
     repo,

--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -50,7 +50,7 @@ type PullRequest = {
     sha?: string;
     repo?: { full_name?: string } | null;
   };
-  base?: { ref?: string };
+  base?: { ref?: string; sha?: string };
 };
 
 function writeGithubOutput(key: string, value: string): void {
@@ -373,6 +373,89 @@ function verifyExistingReleasePullRequest(
   }
 }
 
+async function resumeExistingRelease(
+  version: string,
+  firstRemote: string,
+  baseBranch: string,
+  repo: Repository,
+  token: string,
+): Promise<boolean> {
+  const branchName = buildReleaseBranch(version);
+  const branchCheck = runGit(
+    ["ls-remote", "--heads", firstRemote, branchName],
+    { allowNonZeroExit: true },
+  );
+  if (!branchCheck.stdout.trim()) {
+    return false;
+  }
+
+  const existing = await findExistingPullRequest(branchName, repo, token);
+  if (!existing) {
+    throw new Error(
+      `Release branch ${branchName} has no open draft PR; refusing to replace it automatically.`,
+    );
+  }
+
+  runGit(
+    ["fetch", firstRemote, `refs/heads/${branchName}:refs/heads/${branchName}`],
+    { stdio: "inherit" },
+  );
+  const releaseSha = run("git", [
+    "rev-parse",
+    "--verify",
+    `refs/heads/${branchName}^{commit}`,
+  ]).stdout.trim();
+  verifyExistingReleasePullRequest(
+    existing,
+    branchName,
+    baseBranch,
+    releaseSha,
+    repo,
+  );
+
+  const protectedBaseSha = existing.base?.sha;
+  if (!protectedBaseSha || !/^[0-9a-f]{40}$/i.test(protectedBaseSha)) {
+    throw new Error(
+      "Existing release PR does not expose an immutable base revision.",
+    );
+  }
+  const releaseBaseSha = run("git", [
+    "rev-parse",
+    "--verify",
+    `${releaseSha}^1`,
+  ]).stdout.trim();
+  const baseCheck = runGit(["cat-file", "-e", `${protectedBaseSha}^{commit}`], {
+    allowNonZeroExit: true,
+  });
+  if (baseCheck.status !== 0) {
+    runGit(["fetch", "--no-tags", firstRemote, protectedBaseSha], {
+      stdio: "inherit",
+    });
+  }
+  verifyGeneratedReleaseCommit(releaseSha, releaseBaseSha, version);
+  const ancestryCheck = runGit(
+    ["merge-base", "--is-ancestor", releaseBaseSha, protectedBaseSha],
+    { allowNonZeroExit: true },
+  );
+  if (ancestryCheck.status !== 0) {
+    throw new Error(
+      "Existing release branch is not based on the protected base revision.",
+    );
+  }
+
+  console.log(
+    `Release branch ${branchName} already has open PR #${existing.number}: ${existing.html_url}`,
+  );
+  writeGithubOutput("release_branch", branchName);
+  writeGithubOutput("release_version", version);
+  writeGithubOutput("release_pr_state", "existing");
+  writeGithubOutput("release_pr_draft", String(existing.draft));
+  writeGithubOutput("release_pr_number", existing.number.toString());
+  writeGithubOutput("release_pr_url", existing.html_url);
+  writeGithubOutput("release_branch_created", "false");
+  return true;
+}
+
 async function createPullRequest(
   repo: Repository,
   token: string,
@@ -462,31 +545,59 @@ async function main(): Promise<void> {
   runGit(["fetch", "--tags", firstRemote], { stdio: "inherit" });
 
   const packageVersion = loadCurrentVersion();
-  const highestTagVersion = determineHighestTagVersion();
-
-  let baseVersion = packageVersion;
-  if (highestTagVersion && compareSemver(highestTagVersion, baseVersion) > 0) {
-    baseVersion = highestTagVersion;
-  }
-
   const bumpTarget = args[0] ?? "";
 
-  let newVersion: string;
-
+  let bumpMode: IncrementMode | undefined;
+  let manualTarget: string | undefined;
   if (!bumpTarget) {
-    newVersion = incrementVersion("patch", baseVersion);
+    bumpMode = "patch";
   } else if (
     bumpTarget === "major" ||
     bumpTarget === "minor" ||
     bumpTarget === "patch"
   ) {
-    newVersion = incrementVersion(bumpTarget, baseVersion);
+    bumpMode = bumpTarget;
   } else {
-    const manualTarget = bumpTarget.startsWith("v")
+    manualTarget = bumpTarget.startsWith("v")
       ? bumpTarget.slice(1)
       : bumpTarget;
-    newVersion = manualTarget;
   }
+  const incrementMode = bumpMode ?? "patch";
+
+  const baseBranch = getBaseBranch();
+  const repo = resolveRepository();
+  const token = ensureToken();
+
+  // A pre-merge immutable tag can be present while the base package version
+  // still lags behind it. Resume that exact draft before calculating a newer
+  // version from the tag list.
+  const packageCandidate =
+    manualTarget ?? incrementVersion(incrementMode, packageVersion);
+  if (!isSemver(packageCandidate)) {
+    throw new Error(
+      `Version "${packageCandidate}" is not a valid semver (x.y.z).`,
+    );
+  }
+  if (
+    await resumeExistingRelease(
+      packageCandidate,
+      firstRemote,
+      baseBranch,
+      repo,
+      token,
+    )
+  ) {
+    return;
+  }
+
+  const highestTagVersion = determineHighestTagVersion();
+  let baseVersion = packageVersion;
+  if (highestTagVersion && compareSemver(highestTagVersion, baseVersion) > 0) {
+    baseVersion = highestTagVersion;
+  }
+
+  const newVersion =
+    manualTarget ?? incrementVersion(incrementMode, baseVersion);
 
   if (!isSemver(newVersion)) {
     throw new Error(`Version "${newVersion}" is not a valid semver (x.y.z).`);
@@ -497,8 +608,6 @@ async function main(): Promise<void> {
       `New version ${newVersion} must be greater than existing version ${baseVersion}.`,
     );
   }
-
-  const baseBranch = getBaseBranch();
 
   const localTagCheck = run(
     "git",
@@ -522,51 +631,26 @@ async function main(): Promise<void> {
   }
 
   const branchName = buildReleaseBranch(newVersion);
+  if (
+    await resumeExistingRelease(
+      newVersion,
+      firstRemote,
+      baseBranch,
+      repo,
+      token,
+    )
+  ) {
+    return;
+  }
 
   const branchCheck = runGit(
     ["ls-remote", "--heads", firstRemote, branchName],
     { allowNonZeroExit: true },
   );
   if (branchCheck.stdout.trim()) {
-    const repo = resolveRepository();
-    const token = ensureToken();
-    const existing = await findExistingPullRequest(branchName, repo, token);
-    if (existing) {
-      runGit(
-        [
-          "fetch",
-          firstRemote,
-          `refs/heads/${branchName}:refs/heads/${branchName}`,
-        ],
-        { stdio: "inherit" },
-      );
-      const releaseSha = run("git", [
-        "rev-parse",
-        "--verify",
-        `refs/heads/${branchName}^{commit}`,
-      ]).stdout.trim();
-      verifyExistingReleasePullRequest(
-        existing,
-        branchName,
-        baseBranch,
-        releaseSha,
-        repo,
-      );
-      console.log(
-        `Release branch ${branchName} already has open PR #${existing.number}: ${existing.html_url}`,
-      );
-      writeGithubOutput("release_branch", branchName);
-      writeGithubOutput("release_version", newVersion);
-      writeGithubOutput("release_pr_state", "existing");
-      writeGithubOutput("release_pr_draft", String(existing.draft));
-      writeGithubOutput("release_pr_number", existing.number.toString());
-      writeGithubOutput("release_pr_url", existing.html_url);
-      writeGithubOutput("release_branch_created", "false");
-      return;
-    }
-    // Branch exists but no open PR - delete the stale branch and continue
-    console.log(`Deleting stale branch ${branchName} (no open PR found)`);
-    runGit(["push", firstRemote, "--delete", branchName], { stdio: "inherit" });
+    throw new Error(
+      `Release branch ${branchName} exists but could not be resumed safely.`,
+    );
   }
 
   const baseSha = run("git", ["rev-parse", "HEAD"]).stdout.trim();
@@ -589,9 +673,6 @@ async function main(): Promise<void> {
   writeGithubOutput("release_version", newVersion);
   writeGithubOutput("release_pr_draft", "true");
   writeGithubOutput("release_branch_created", "true");
-
-  const repo = resolveRepository();
-  const token = ensureToken();
 
   const pullRequest = await createPullRequest(
     repo,

--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -17,6 +17,9 @@ const semverPattern = /^\d+\.\d+\.\d+$/;
 const defaultBaseBranch = "main";
 
 const releaseBranchPrefix = "release/";
+const releaseManifestPath = "apps/client/package.json";
+const actionsBotName = "github-actions[bot]";
+const actionsBotEmail = "github-actions[bot]@users.noreply.github.com";
 
 type IncrementMode = "major" | "minor" | "patch";
 
@@ -102,10 +105,7 @@ function runGit(args: string[], options: RunOptions = {}): RunResult {
     return run("git", args, options);
   }
 
-  const configuredCount = Number.parseInt(
-    baseEnv.GIT_CONFIG_COUNT ?? "0",
-    10,
-  );
+  const configuredCount = Number.parseInt(baseEnv.GIT_CONFIG_COUNT ?? "0", 10);
   const configIndex =
     Number.isSafeInteger(configuredCount) && configuredCount >= 0
       ? configuredCount
@@ -180,7 +180,7 @@ function loadCurrentVersion(): string {
     version?: string;
   }
 
-  const packagePath = resolve("apps", "client", "package.json");
+  const packagePath = resolve(releaseManifestPath);
   const raw = readFileSync(packagePath, "utf8");
   const parsed: PackageJson = JSON.parse(raw);
 
@@ -221,12 +221,65 @@ function determineHighestTagVersion(): string {
 }
 
 function updateVersionFile(version: string): void {
-  const packagePath = resolve("apps", "client", "package.json");
+  const packagePath = resolve(releaseManifestPath);
   const raw = readFileSync(packagePath, "utf8");
   const parsed = JSON.parse(raw) as Record<string, unknown>;
   parsed.version = version;
   writeFileSync(packagePath, `${JSON.stringify(parsed, null, 2)}\n`);
   run("git", ["add", packagePath]);
+}
+
+function verifyGeneratedReleaseCommit(
+  releaseSha: string,
+  baseSha: string,
+  version: string,
+): void {
+  const parentSha = run("git", [
+    "rev-parse",
+    "--verify",
+    `${releaseSha}^1`,
+  ]).stdout.trim();
+  if (parentSha !== baseSha) {
+    throw new Error(
+      `Release commit ${releaseSha} is not based on the checked-out main revision.`,
+    );
+  }
+
+  const changedFiles = run("git", [
+    "diff-tree",
+    "--no-commit-id",
+    "--name-only",
+    "-r",
+    releaseSha,
+  ])
+    .stdout.trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+  if (changedFiles.length !== 1 || changedFiles[0] !== releaseManifestPath) {
+    throw new Error(`Release commit must change only ${releaseManifestPath}.`);
+  }
+
+  const metadata = run("git", [
+    "show",
+    "-s",
+    "--format=%an%n%ae%n%cn%n%ce%n%s",
+    releaseSha,
+  ])
+    .stdout.trim()
+    .split(/\r?\n/);
+  const [authorName, authorEmail, committerName, committerEmail, subject] =
+    metadata;
+  if (
+    authorName !== actionsBotName ||
+    authorEmail !== actionsBotEmail ||
+    committerName !== actionsBotName ||
+    committerEmail !== actionsBotEmail ||
+    subject !== `chore: release v${version}`
+  ) {
+    throw new Error(
+      "Release commit metadata does not match the trusted Actions bot format.",
+    );
+  }
 }
 
 function resolveRepository(): Repository {
@@ -457,6 +510,7 @@ async function main(): Promise<void> {
     runGit(["push", firstRemote, "--delete", branchName], { stdio: "inherit" });
   }
 
+  const baseSha = run("git", ["rev-parse", "HEAD"]).stdout.trim();
   updateVersionFile(newVersion);
 
   console.log(`Preparing release ${newVersion} (base was ${baseVersion})`);
@@ -466,6 +520,9 @@ async function main(): Promise<void> {
   run("git", ["commit", "-m", `chore: release v${newVersion}`], {
     stdio: "inherit",
   });
+
+  const releaseSha = run("git", ["rev-parse", "HEAD"]).stdout.trim();
+  verifyGeneratedReleaseCommit(releaseSha, baseSha, newVersion);
 
   runGit(["push", "-u", firstRemote, branchName], { stdio: "inherit" });
 

--- a/scripts/release-pr.ts
+++ b/scripts/release-pr.ts
@@ -237,6 +237,21 @@ function updateVersionFile(version: string): void {
   run("git", ["add", packagePath]);
 }
 
+function commitAsActionsBot(version: string): void {
+  // Set both identities in the child environment. Runner-global git config and
+  // inherited GIT_* variables are not trusted inputs to the release contract.
+  run("git", ["commit", "-m", `chore: release v${version}`], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: actionsBotName,
+      GIT_AUTHOR_EMAIL: actionsBotEmail,
+      GIT_COMMITTER_NAME: actionsBotName,
+      GIT_COMMITTER_EMAIL: actionsBotEmail,
+    },
+  });
+}
+
 function verifyGeneratedReleaseCommit(
   releaseSha: string,
   baseSha: string,
@@ -660,9 +675,7 @@ async function main(): Promise<void> {
 
   run("git", ["checkout", "-b", branchName], { stdio: "inherit" });
 
-  run("git", ["commit", "-m", `chore: release v${newVersion}`], {
-    stdio: "inherit",
-  });
+  commitAsActionsBot(newVersion);
 
   const releaseSha = run("git", ["rev-parse", "HEAD"]).stdout.trim();
   verifyGeneratedReleaseCommit(releaseSha, baseSha, newVersion);


### PR DESCRIPTION
## Summary

- Remove manual dispatch from secret-bearing Docker, sandbox, Morph, screenshot, and release workflows.
- Add a fail-closed gate for protected main and trusted generated release commits. It verifies checkout SHA, workflow blob, remote ref, ancestry, and generated release commit metadata.
- Replace release dispatch with a local reusable workflow call carrying the exact release and protected-main SHAs. Bind newly created release tags to the verified source SHA and reject existing tags at another SHA.
- Set least-privilege job permissions, pin all actions, disable checkout credential persistence, and add static and behavior contract tests.

## Testing

- `scripts/ci/test-verify-privileged-ref.sh`
- `ruby scripts/ci/test-privileged-workflow-gates.rb`
- `actionlint .github/workflows/*.yml`
- `bash -n .github/scripts/verify-privileged-ref.sh scripts/ci/test-verify-privileged-ref.sh`
- `shellcheck .github/scripts/verify-privileged-ref.sh scripts/ci/test-verify-privileged-ref.sh`
- `git diff --check`
- `zizmor --pedantic`: 0 low, medium, or high findings; five informational Rust setup notices remain.

## Stack and rollout

Stacked on [PR 1910](https://github.com/manaflow-ai/manaflow/pull/1910). Configure protected `main` and non-empty required reviewers for the `electron` environment before merging this stack. No merge was performed by this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790906400&installation_model_id=21920&pr_number=1912&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1912&signature=db3196a2acc067ad844f87fc5e9eca8d0ac90994a481e2b790295298f13099dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `workflow_dispatch` from secret-bearing workflows and replaces branch-based trust with fail-closed checks for protected refs, workflow revisions, and release metadata. Privileged jobs now run only from protected `main` pushes, scheduled `main` runs, or the trusted reusable release call; manual arbitrary-ref runs and post-merge release publishing no longer work.

- Adds a shared verification gate that checks exact SHAs, workflow files, ancestry, remote refs, and release commit identity; release commits must be single-file Actions-bot commits on the exact base.
- Runs release publishing from `release-pr.yml` with exact release, base, and caller SHAs; new tags bind to the verified source, moved tags are rejected, and retries are limited to untouched bot-created draft releases.
- Finds the latest release tag by fetching tags and sorting by semver, since release tags point at generated commits not reachable from `main` after a squash merge.
- Tightens permissions, pins actions, disables checkout credentials, and adds static and behavior contract tests covering the workflows and release script.

**Migration**

- Protect `main`, `release/v*` branches, and `v*` tags; configure non-empty required reviewers for the `electron` environment.
- Outside the schedule, rerun a recent scheduled release only after confirming its captured `main` commit remains reachable.

<sup>Written for commit 94387dbb58c81c51735b13668df0a91b98b718dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

