### PR TITLE
fix(rust): clear stable Clippy baseline warnings

### DIFF
--- a/apps/global-proxy/src/lib.rs
+++ b/apps/global-proxy/src/lib.rs
@@ -33,6 +33,7 @@ use chrono::Utc;
 use serde_json::{Value, json};
 
 type HttpClient = Client<hyper_rustls::HttpsConnector<HttpConnector>, Body>;
+type ProxyResponseError = Box<Response<Body>>;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const GIT_COMMIT: &str = match option_env!("GIT_COMMIT") {
@@ -626,7 +627,7 @@ async fn handle_websocket(
     let (backend_stream, backend_headers) =
         match connect_upstream_websocket(state.client.clone(), backend_request).await {
             Ok(result) => result,
-            Err(response) => return response,
+            Err(response) => return *response,
         };
 
     let client_upgrade = hyper::upgrade::on(req);
@@ -762,13 +763,13 @@ fn check_upgrade_request(req: &Request<Body>) -> UpgradeCheck {
 async fn connect_upstream_websocket(
     client: HttpClient,
     request: Request<Body>,
-) -> Result<(Upgraded, HeaderMap), Response<Body>> {
+) -> Result<(Upgraded, HeaderMap), ProxyResponseError> {
     let response = client.request(request).await.map_err(|err| {
         error!(%err, "upstream websocket request error");
-        text_response(
+        Box::new(text_response(
             StatusCode::BAD_GATEWAY,
             "Failed to connect to websocket backend",
-        )
+        ))
     })?;
 
     if response.status() != StatusCode::SWITCHING_PROTOCOLS {
@@ -776,10 +777,12 @@ async fn connect_upstream_websocket(
         let body_bytes = body::to_bytes(response.into_body())
             .await
             .unwrap_or_else(|_| Bytes::new());
-        return Err(Response::builder()
-            .status(status)
-            .body(Body::from(body_bytes))
-            .unwrap());
+        return Err(Box::new(
+            Response::builder()
+                .status(status)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        ));
     }
 
     let headers = response.headers().clone();
@@ -787,10 +790,10 @@ async fn connect_upstream_websocket(
         Ok(upgraded) => Ok((upgraded, headers)),
         Err(err) => {
             error!(%err, "upstream websocket upgrade failed");
-            Err(text_response(
+            Err(Box::new(text_response(
                 StatusCode::BAD_GATEWAY,
                 "Failed to upgrade websocket backend",
-            ))
+            )))
         }
     }
 }

--- a/apps/global-proxy/tests/proxy_tests.rs
+++ b/apps/global-proxy/tests/proxy_tests.rs
@@ -244,6 +244,11 @@ impl TestWsBackend {
         }
     }
 
+    // Tungstenite fixes the callback error type to its large HTTP response.
+    #[expect(
+        clippy::result_large_err,
+        reason = "the dependency fixes this callback error type"
+    )]
     async fn spawn_with_handshake(protocol: Option<&str>, extensions: Option<&str>) -> Self {
         let listener = tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .await
@@ -325,6 +330,11 @@ impl TestWsBackend {
         }
     }
 
+    // Tungstenite fixes the callback error type to its large HTTP response.
+    #[expect(
+        clippy::result_large_err,
+        reason = "the dependency fixes this callback error type"
+    )]
     async fn spawn_capture_workspace_header()
     -> (Self, tokio::sync::oneshot::Receiver<Option<String>>) {
         let listener = tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))

--- a/apps/server/native/core/src/diff/refs.rs
+++ b/apps/server/native/core/src/diff/refs.rs
@@ -761,38 +761,38 @@ pub fn diff_refs(opts: GitDiffOptions) -> Result<Vec<DiffEntry>> {
                         }
                     }
                     "R" | "R100" | "R099" | "R098" | "R097" | "R096" | "R095" | "R094" | "R093"
-                    | "R092" | "R091" | "R090" => {
-                        if parts.len() >= 3 {
-                            let oldp = parts[1].to_string();
-                            let newp = parts[2].to_string();
-                            let mut e = DiffEntry {
-                                filePath: newp.clone(),
-                                oldPath: Some(oldp.clone()),
-                                status: "renamed".into(),
-                                additions: 0,
-                                deletions: 0,
-                                isBinary: false,
-                                ..Default::default()
-                            };
-                            if include {
-                                let new_s = crate::util::run_git(
-                                    &cwd,
-                                    &["show", &format!("{}:{}", head_oid, newp)],
-                                )
-                                .unwrap_or_default();
-                                let new_sz = new_s.len();
-                                e.newSize = Some(new_sz as i32);
-                                e.oldSize = Some(new_sz as i32);
-                                if new_sz <= max_bytes {
-                                    e.oldContent = Some(new_s.clone());
-                                    e.newContent = Some(new_s);
-                                    e.contentOmitted = Some(false);
-                                } else {
-                                    e.contentOmitted = Some(true);
-                                }
+                    | "R092" | "R091" | "R090"
+                        if parts.len() >= 3 =>
+                    {
+                        let oldp = parts[1].to_string();
+                        let newp = parts[2].to_string();
+                        let mut e = DiffEntry {
+                            filePath: newp.clone(),
+                            oldPath: Some(oldp.clone()),
+                            status: "renamed".into(),
+                            additions: 0,
+                            deletions: 0,
+                            isBinary: false,
+                            ..Default::default()
+                        };
+                        if include {
+                            let new_s = crate::util::run_git(
+                                &cwd,
+                                &["show", &format!("{}:{}", head_oid, newp)],
+                            )
+                            .unwrap_or_default();
+                            let new_sz = new_s.len();
+                            e.newSize = Some(new_sz as i32);
+                            e.oldSize = Some(new_sz as i32);
+                            if new_sz <= max_bytes {
+                                e.oldContent = Some(new_s.clone());
+                                e.newContent = Some(new_s);
+                                e.contentOmitted = Some(false);
+                            } else {
+                                e.contentOmitted = Some(true);
                             }
-                            fallback.push(e);
                         }
+                        fallback.push(e);
                     }
                     _ => {}
                 }

--- a/apps/server/native/core/src/repo/cache.rs
+++ b/apps/server/native/core/src/repo/cache.rs
@@ -146,7 +146,7 @@ fn update_cache_index(root: &Path, repo_path: &Path) -> Result<()> {
         });
     }
     idx.entries
-        .sort_by(|a, b| b.last_access_ms.cmp(&a.last_access_ms));
+        .sort_by_key(|entry| std::cmp::Reverse(entry.last_access_ms));
     idx.entries.dedup_by(|a, b| a.slug == b.slug);
     save_index(root, &idx)?;
     Ok(())
@@ -186,7 +186,7 @@ fn update_cache_index_with(
         });
     }
     idx.entries
-        .sort_by(|a, b| b.last_access_ms.cmp(&a.last_access_ms));
+        .sort_by_key(|entry| std::cmp::Reverse(entry.last_access_ms));
     idx.entries.dedup_by(|a, b| a.slug == b.slug);
     save_index(root, &idx)?;
     Ok(())
@@ -265,7 +265,7 @@ fn enforce_cache_limit(root: &Path) -> Result<()> {
         return Ok(());
     }
     idx.entries
-        .sort_by(|a, b| b.last_access_ms.cmp(&a.last_access_ms));
+        .sort_by_key(|entry| std::cmp::Reverse(entry.last_access_ms));
     let survivors = idx.entries[..MAX_CACHE_REPOS].to_vec();
     let victims = idx.entries[MAX_CACHE_REPOS..].to_vec();
     for v in &victims {

--- a/crates/cmux-proxy/src/lib.rs
+++ b/crates/cmux-proxy/src/lib.rs
@@ -31,6 +31,9 @@ use http::header::{CONNECTION, HOST, UPGRADE};
 type BoxBody =
     http_body_util::combinators::BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
+type ProxyResponse = Response<BoxBody>;
+type ProxyResponseError = Box<ProxyResponse>;
+type ProxyResult<T> = Result<T, ProxyResponseError>;
 const HTTP2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 const HOST_OVERRIDE_HEADER: &str = "X-Cmux-Host-Override";
 const HTTP2_KEEP_ALIVE_INTERVAL_SECS: u64 = 30;
@@ -512,12 +515,11 @@ async fn sniff_http2_preface(stream: TcpStream) -> io::Result<(BufferedStream, b
     Ok((BufferedStream::new(stream, buffer), is_http2))
 }
 
-#[allow(clippy::result_large_err)]
-fn get_port_from_header(headers: &HeaderMap) -> Result<u16, Response<BoxBody>> {
+fn get_port_from_header(headers: &HeaderMap) -> ProxyResult<u16> {
     const HDR: &str = "X-Cmux-Port-Internal";
     if let Some(val) = headers.get(HDR) {
         let s = val.to_str().map_err(|_| {
-            response_with(
+            response_error(
                 StatusCode::BAD_REQUEST,
                 "invalid header value (not UTF-8)".to_string(),
             )
@@ -525,14 +527,14 @@ fn get_port_from_header(headers: &HeaderMap) -> Result<u16, Response<BoxBody>> {
 
         let s = s.trim();
         if s.is_empty() {
-            return Err(response_with(
+            return Err(response_error(
                 StatusCode::BAD_REQUEST,
                 "header value cannot be empty".to_string(),
             ));
         }
 
         let port: u16 = s.parse().map_err(|_| {
-            response_with(
+            response_error(
                 StatusCode::BAD_REQUEST,
                 "invalid port in X-Cmux-Port-Internal".to_string(),
             )
@@ -545,7 +547,7 @@ fn get_port_from_header(headers: &HeaderMap) -> Result<u16, Response<BoxBody>> {
         return Ok(port);
     }
 
-    Err(response_with(
+    Err(response_error(
         StatusCode::BAD_REQUEST,
         format!("missing required header: {}", HDR),
     ))
@@ -585,29 +587,28 @@ pub fn workspace_ip_from_name(name: &str) -> Option<std::net::Ipv4Addr> {
     Some(Ipv4Addr::new(127, 18, b2, b3))
 }
 
-#[allow(clippy::result_large_err)]
 fn upstream_host_from_headers(
     headers: &HeaderMap,
     default_host: &str,
     allow_default_without_workspace: bool,
-) -> Result<String, Response<BoxBody>> {
+) -> ProxyResult<String> {
     const HDR_WS: &str = "X-Cmux-Workspace-Internal";
     if let Some(val) = headers.get(HDR_WS) {
         let v = val.to_str().map_err(|_| {
-            response_with(
+            response_error(
                 StatusCode::BAD_REQUEST,
                 format!("invalid header value (not UTF-8): {}", HDR_WS),
             )
         })?;
         let ws = v.trim();
         if ws.is_empty() {
-            return Err(response_with(
+            return Err(response_error(
                 StatusCode::BAD_REQUEST,
                 format!("{} cannot be empty", HDR_WS),
             ));
         }
         let ip = workspace_ip_from_name(ws).ok_or_else(|| {
-            response_with(
+            response_error(
                 StatusCode::BAD_REQUEST,
                 format!("invalid workspace name: {}", ws),
             )
@@ -624,7 +625,7 @@ fn upstream_host_from_headers(
         if let Some(ip) = workspace_ip_from_name(&ws) {
             return Ok(ip.to_string());
         } else {
-            return Err(response_with(
+            return Err(response_error(
                 StatusCode::BAD_REQUEST,
                 format!("invalid workspace name: {}", ws),
             ));
@@ -684,16 +685,11 @@ fn strip_hop_by_hop_headers(h: &mut HeaderMap) {
     }
 }
 
-#[allow(clippy::result_large_err)]
-fn build_upstream_uri(
-    upstream_host: &str,
-    port: u16,
-    orig: &Uri,
-) -> Result<Uri, Response<BoxBody>> {
+fn build_upstream_uri(upstream_host: &str, port: u16, orig: &Uri) -> ProxyResult<Uri> {
     let path_and_query = orig.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
     let uri_str = format!("http://{}:{}{}", upstream_host, port, path_and_query);
     Uri::from_str(&uri_str)
-        .map_err(|_| response_with(StatusCode::BAD_GATEWAY, "invalid upstream uri".into()))
+        .map_err(|_| response_error(StatusCode::BAD_GATEWAY, "invalid upstream uri".into()))
 }
 
 // Attempt to parse a pattern like: <workspace>-<port>.localhost[:...]
@@ -733,18 +729,14 @@ fn parse_workspace_port_from_host(headers: &HeaderMap) -> Option<(String, u16)> 
     Some((ws_part.to_string(), port))
 }
 
-#[allow(clippy::result_large_err)]
-fn enforce_local_host_header(
-    headers: &HeaderMap,
-    host_override: Option<&str>,
-) -> Result<(), Response<BoxBody>> {
+fn enforce_local_host_header(headers: &HeaderMap, host_override: Option<&str>) -> ProxyResult<()> {
     if host_override.is_some() {
         return Ok(());
     }
 
     if let Some(value) = headers.get(HOST) {
         value.to_str().map_err(|_| {
-            response_with(
+            response_error(
                 StatusCode::BAD_REQUEST,
                 "invalid Host header (not UTF-8)".to_string(),
             )
@@ -762,6 +754,10 @@ fn response_with(status: StatusCode, msg: String) -> Response<BoxBody> {
         .unwrap()
 }
 
+fn response_error(status: StatusCode, msg: String) -> ProxyResponseError {
+    Box::new(response_with(status, msg))
+}
+
 async fn handle(
     client: Client<HttpConnector, BoxBody>,
     cfg: ProxyConfig,
@@ -774,18 +770,18 @@ async fn handle(
     match method {
         Method::CONNECT => match handle_connect(req, &cfg, remote_addr).await {
             Ok(resp) => Ok(resp),
-            Err(resp) => Ok(resp),
+            Err(resp) => Ok(*resp),
         },
         _ => {
             if is_upgrade {
                 match handle_upgrade(client, cfg, remote_addr, req).await {
                     Ok(resp) => Ok(resp),
-                    Err(resp) => Ok(resp),
+                    Err(resp) => Ok(*resp),
                 }
             } else {
                 match handle_http(client, &cfg, remote_addr, req).await {
                     Ok(resp) => Ok(resp),
-                    Err(resp) => Ok(resp),
+                    Err(resp) => Ok(*resp),
                 }
             }
         }
@@ -797,7 +793,7 @@ async fn handle_http(
     cfg: &ProxyConfig,
     remote_addr: SocketAddr,
     req: Request<Incoming>,
-) -> Result<Response<BoxBody>, Response<BoxBody>> {
+) -> ProxyResult<ProxyResponse> {
     let (mut parts, incoming) = req.into_parts();
 
     let port = get_port_from_header(&parts.headers)?;
@@ -844,7 +840,7 @@ async fn handle_http(
     );
 
     let upstream_resp = client.request(new_req).await.map_err(|e| {
-        response_with(
+        response_error(
             StatusCode::BAD_GATEWAY,
             format!("upstream request error: {}", e),
         )
@@ -863,7 +859,7 @@ async fn handle_http(
 
     let body = incoming_to_box(upstream_resp.into_body());
     let resp = client_resp_builder.body(body).map_err(|_| {
-        response_with(
+        response_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to build response".into(),
         )
@@ -876,7 +872,7 @@ async fn handle_upgrade(
     cfg: ProxyConfig,
     remote_addr: SocketAddr,
     req: Request<Incoming>,
-) -> Result<Response<BoxBody>, Response<BoxBody>> {
+) -> ProxyResult<ProxyResponse> {
     // Treat as reverse-proxied upgrade (e.g., WebSocket). We forward the request to upstream,
     // then mirror the 101 response headers to the client and tunnel bytes between both upgrades.
 
@@ -916,7 +912,7 @@ async fn handle_upgrade(
     let (parts, incoming) = req.into_parts();
     let proxied_body: BoxBody = incoming_to_box(incoming);
     let mut proxied_req = proxied_req_builder.body(proxied_body).map_err(|_| {
-        response_with(
+        response_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to build upgrade request".into(),
         )
@@ -938,7 +934,7 @@ async fn handle_upgrade(
 
     // Send to upstream and get its response (should be 101)
     let upstream_resp = client.request(proxied_req).await.map_err(|e| {
-        response_with(
+        response_error(
             StatusCode::BAD_GATEWAY,
             format!("upstream upgrade error: {}", e),
         )
@@ -954,7 +950,7 @@ async fn handle_upgrade(
         }
         let body = incoming_to_box(upstream_resp.into_body());
         return builder.body(body).map_err(|_| {
-            response_with(
+            response_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "failed to build response".into(),
             )
@@ -974,7 +970,7 @@ async fn handle_upgrade(
 
     // Prepare response to client (empty body; the connection upgrades)
     let client_resp = client_resp_builder.body(empty_body()).map_err(|_| {
-        response_with(
+        response_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to build upgrade response".into(),
         )
@@ -1014,7 +1010,7 @@ async fn handle_connect(
     req: Request<Incoming>,
     cfg: &ProxyConfig,
     remote_addr: SocketAddr,
-) -> Result<Response<BoxBody>, Response<BoxBody>> {
+) -> ProxyResult<ProxyResponse> {
     let port = get_port_from_header(req.headers())?;
     let upstream_host = upstream_host_from_headers(
         req.headers(),
@@ -1033,7 +1029,7 @@ async fn handle_connect(
         .header(CONNECTION, HeaderValue::from_static("upgrade"))
         .body(empty_body())
         .map_err(|_| {
-            response_with(
+            response_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "failed to build CONNECT response".into(),
             )

--- a/packages/sandbox/src/acp_client/markdown.rs
+++ b/packages/sandbox/src/acp_client/markdown.rs
@@ -118,10 +118,8 @@ pub(crate) fn markdown_to_lines(source: &str) -> Vec<Line<'static>> {
             MdEvent::Start(Tag::Item) => {
                 current_spans.push(Span::raw("• ".to_owned()));
             }
-            MdEvent::End(TagEnd::Item) => {
-                if !current_spans.is_empty() {
-                    lines.push(Line::from(std::mem::take(&mut current_spans)));
-                }
+            MdEvent::End(TagEnd::Item) if !current_spans.is_empty() => {
+                lines.push(Line::from(std::mem::take(&mut current_spans)));
             }
             _ => {}
         }

--- a/packages/sandbox/src/bin/cli.rs
+++ b/packages/sandbox/src/bin/cli.rs
@@ -1563,7 +1563,7 @@ async fn handle_prune(client: &Client, base_url: &str, args: PruneArgs) -> anyho
         .collect();
 
     // Sort by age (oldest first)
-    to_prune.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    to_prune.sort_by_key(|sandbox| sandbox.created_at);
 
     if to_prune.is_empty() {
         let filter_desc = if args.all {

--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -570,7 +570,7 @@ impl BubblewrapService {
         // 3. Try searching by prefix
         let guard = self.sandboxes.lock().await;
         let mut matched = None;
-        for (uuid, _) in guard.iter() {
+        for uuid in guard.keys() {
             let simple = uuid.simple().to_string();
             if simple.starts_with(id_str) {
                 if matched.is_some() {
@@ -2463,7 +2463,7 @@ impl SandboxService for BubblewrapService {
                             // Forward signal to all PTY child processes
                             let sessions = sessions.lock().await;
                             let mut sent_count = 0;
-                            for (_session_id, handle) in sessions.iter() {
+                            for handle in sessions.values() {
                                 if let Some(pid) = handle.child_pid {
                                     // Use libc to send the signal
                                     let result = unsafe { libc::kill(pid as i32, signum) };

--- a/packages/sandbox/src/mux/runner.rs
+++ b/packages/sandbox/src/mux/runner.rs
@@ -897,10 +897,8 @@ fn handle_input(
                                     tab.navigate(crate::mux::layout::NavDirection::Right);
                                 }
                             }
-                            KeyCode::Tab => {
-                                if app.sidebar.visible {
-                                    app.focus = FocusArea::Sidebar;
-                                }
+                            KeyCode::Tab if app.sidebar.visible => {
+                                app.focus = FocusArea::Sidebar;
                             }
                             _ => {}
                         }

--- a/packages/sandbox/src/mux/terminal.rs
+++ b/packages/sandbox/src/mux/terminal.rs
@@ -2227,7 +2227,7 @@ impl Perform for VirtualTerminal {
                     // 29 = ANSI text locator
                     self.pending_responses
                         .push(b"\x1b[?64;1;2;6;9;15;16;17;18;21;22;28;29c".to_vec());
-                } else if intermediates == [b'>'] && is_query {
+                } else if intermediates == *b">" && is_query {
                     // Secondary Device Attributes (DA2): CSI > c or CSI > 0 c
                     // Respond as xterm version 314+:
                     // 41 = xterm terminal type
@@ -2313,13 +2313,13 @@ impl Perform for VirtualTerminal {
                 self.insert_chars(n);
             }
             // Soft Terminal Reset (DECSTR) - CSI ! p
-            'p' if intermediates == [b'!'] => {
+            'p' if intermediates == *b"!" => {
                 self.soft_reset();
             }
             // Private modes (DECSET/DECRST) and standard modes (SM/RM)
             'h' | 'l' => {
                 let enable = action == 'h';
-                if intermediates == [b'?'] {
+                if intermediates == *b"?" {
                     // Private (DEC) modes
                     for &param in &params_vec {
                         match param {
@@ -2524,7 +2524,7 @@ impl Perform for VirtualTerminal {
             }
             // DECRQCRA - Request Checksum of Rectangular Area
             // CSI Pid ; Pp ; Pt ; Pl ; Pb ; Pr * y
-            'y' if intermediates == [b'*'] => {
+            'y' if intermediates == *b"*" => {
                 let pid = params_vec.first().copied().unwrap_or(0);
                 let _page = params_vec.get(1).copied().unwrap_or(1); // page number, ignored
                 let top = params_vec.get(2).copied().unwrap_or(1).max(1) as usize;
@@ -2695,7 +2695,7 @@ impl Perform for VirtualTerminal {
                 self.pending_responses.push(response.into_bytes());
             }
             // DECFRA - Fill Rectangular Area: CSI Pc ; Pt ; Pl ; Pb ; Pr $ x
-            'x' if intermediates == [b'$'] => {
+            'x' if intermediates == *b"$" => {
                 let char_code = params_vec.first().copied().unwrap_or(32) as u8; // Default: space
                 let ch = if (32..127).contains(&char_code) {
                     char_code as char
@@ -2751,7 +2751,7 @@ impl Perform for VirtualTerminal {
                 }
             }
             // DECERA - Erase Rectangular Area: CSI Pt ; Pl ; Pb ; Pr $ z
-            'z' if intermediates == [b'$'] => {
+            'z' if intermediates == *b"$" => {
                 // Get rectangle bounds (1-based, convert to 0-based)
                 let top = params_vec.first().copied().unwrap_or(1).max(1) as usize - 1;
                 let left = params_vec.get(1).copied().unwrap_or(1).max(1) as usize - 1;
@@ -2806,7 +2806,7 @@ impl Perform for VirtualTerminal {
             // Ps=1: blinking block, Ps=2: steady block
             // Ps=3: blinking underline, Ps=4: steady underline
             // Ps=5: blinking bar, Ps=6: steady bar
-            'q' if intermediates == [b' '] => {
+            'q' if intermediates == *b" " => {
                 let style = params_vec.first().copied().unwrap_or(0);
                 self.cursor_style = style as u8;
                 // Odd values are blinking, even values (including 0) are steady


### PR DESCRIPTION
## Summary

- Clear the stable Rust 1.98 Clippy failures in cmux-proxy, global-proxy, native-core, and sandbox.
- Box HTTP response errors in private proxy helpers to satisfy `result_large_err` without changing behavior.
- Apply equivalent mechanical fixes for guarded matches, map iteration, byte strings, and cache sorting.
- Keep `-D warnings` unchanged. This PR does not modify workflows or CI policy.

## Verification

- `rustup run 1.98.0 cargo fmt --all -- --check` passes in all four crates.
- `rustup run 1.98.0 cargo clippy --all-targets --all-features -- -D warnings` passes in all four crates.
- `rustup run 1.98.0 cargo test --all-features --locked` passes in all four crates.

The failures were reproduced on fresh `main` at `9ab841fc0a8aae5f69f0e4328af36ed0f70c5e39`; the CI hardening PR remains separate at https://github.com/manaflow-ai/manaflow/pull/1910.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/manaflow/pr/1914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790917065&installation_model_id=21920&pr_number=1914&repository=manaflow-ai%2Fmanaflow&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fmanaflow%2Fpull%2F1914&signature=1db71582371850b737f24653eba55c667a9e9255190a32439df7e8dbab36efc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stable Rust 1.98 Clippy warnings in `cmux-proxy`, `global-proxy`, `native-core`, and `sandbox` without changing behavior.

- Boxes HTTP response errors in private proxy helpers to satisfy `result_large_err`.
- Applies mechanical fixes for guarded matches, map iteration, byte strings, and cache sorting.
- Keeps `-D warnings` unchanged; CI policy is untouched.

<sup>Written for commit 02c838ebd831503c058ec2a7105b1273f96b841a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/manaflow/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved proxy error handling for more consistent response processing.
  - Simplified rename detection and cache sorting logic without changing results.
  - Streamlined sandbox navigation, pruning, signal forwarding, and terminal protocol handling while preserving existing behavior.
  - Simplified list rendering conditions with no visible output changes.

- **Tests**
  - Updated test handling for expected connection errors; runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->